### PR TITLE
docs: add CLAUDE.md, SECURITY.md, expand README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+Instructions for Claude Code working in the SlopWeaver public repo.
+
+## What is SlopWeaver
+
+Open-source local-first MCP server that gives Claude Code (and any MCP client) the GitHub + Slack context behind any PR. Pre-alpha; v1.0.0 in development. See [README.md](README.md) and the [v1.0.0 roadmap tracking issue](https://github.com/slopweaver/slopweaver/issues/1).
+
+## Repo state (pre-alpha)
+
+This repo is in active scaffolding. Most packages and apps don't exist yet. Don't assume code is here unless you've verified.
+
+Current files: `LICENSE`, `README.md`, `CLAUDE.md`, `SECURITY.md`, `.github/`, `.gitignore`. Everything else is upcoming.
+
+## Stack (target shape for v1.0.0)
+
+- **Node 22, pnpm 10, Turborepo** — monorepo with `apps/` + `packages/`
+- **TypeScript strict mode** — no `any` in production code; named object params for any function with 1+ args
+- **Drizzle ORM** with SQLite (better-sqlite3) for the local binary
+- **MCP SDK** (`@modelcontextprotocol/sdk`) for the server
+- **Vitest** for tests; Polly for HTTP recording in integration tests
+
+## Where things live
+
+- `apps/mcp-local/` — the local binary (npm install -g slopweaver). The v1 product.
+- `packages/mcp-server/` — framework-agnostic MCP server, including composite tools in `src/tools/composite/`
+- `packages/integrations/` — single package with subdirectories per platform (`github/`, `slack/`, etc.)
+- `packages/db/`, `packages/auth/`, `packages/memory/`, `packages/contracts/` — shared core packages
+- `packages/web-ui/` — React components for the local UI on `localhost:60701`
+
+(See ARCHITECTURE.md when it exists for the full layout.)
+
+## Development principles
+
+- **Direct imports between packages.** No dependency-inversion abstractions until there's a real second implementation.
+- **Composite MCP tools live in `packages/mcp-server/src/tools/composite/`.** Single-platform tools live in their integration package's `mcp-tools/` subdir.
+- **Apps wire packages together. Packages don't import from apps.** Enforced by `eslint-plugin-boundaries`.
+- **No `@nestjs/*` imports in `packages/*`.** NestJS belongs only to `apps/cloud/` (when that lands in v2). Enforced by `no-restricted-imports`.
+- **Small, focused PRs with clear descriptions.** Each PR should be reviewable in one sitting and have a real "what + why + test plan."
+
+## Security and privacy
+
+- This repo is public. Never commit user data, API keys, OAuth secrets, or test fixtures containing real customer/employer information.
+- The `.gitignore` excludes `.env` files, `*.har`, and other common secret carriers — but verify any test fixture you add doesn't contain real tokens.
+- Vulnerabilities should be reported privately to admin@slopweaver.ai (see [SECURITY.md](SECURITY.md)).
+
+## Strategy and design decisions
+
+The full strategy / decision trail is internal and lives in a private repo. This public repo is the implementation. If you need design context that isn't in code or in this README, ask [@lachiejames](https://github.com/lachiejames) rather than inventing it.
+
+## Issue and PR conventions
+
+- File issues using the templates in `.github/ISSUE_TEMPLATE/` (when those land).
+- PRs: use the template in `.github/pull_request_template.md` (when that lands).
+- Squash-merge only. Auto-delete branch on merge.
+
+## License
+
+MIT. By contributing, you agree your contributions are licensed under MIT.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,73 @@
 # SlopWeaver
 
-> Give Claude Code the GitHub + Slack context behind any PR.
+> Help Claude Code answer "what should I work on next?" by searching across your work tools.
 >
 > Open-source local-first MCP server. BYOK.
 
-**Status**: pre-alpha. v1 ships in the coming weeks. Watch this repo for releases.
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![GitHub Stars](https://img.shields.io/github/stars/slopweaver/slopweaver?style=social)](https://github.com/slopweaver/slopweaver/stargazers)
 
-The strategy and design docs live in [`docs/strategy/`](docs/strategy/) (landing soon).
+**Status**: pre-alpha. v1.0.0 ships in the coming weeks. Built solo by [@lachiejames](https://github.com/lachiejames). Roadmap: [tracking issue #1](https://github.com/slopweaver/slopweaver/issues/1).
 
-The npm package `slopweaver` will be the local binary; `@slopweaver/*` packages will be importable libraries.
+---
 
-## Coming soon
+## What it does
 
-- `npx -y slopweaver@latest init` — install + first-run setup
-- `slopweaver connect github` — connect your GitHub
-- `slopweaver doctor` — diagnose any issues
-- Add MCP token to `~/.claude.json` and ask Claude Code: "What's the context behind PR #1234?"
+You sit down to work. You ask Claude Code:
+
+> "What should I work on next?"
+
+SlopWeaver searches everything — your open PRs, Slack mentions, Linear tickets, threads waiting on your reply, recent activity in repos you care about. Claude synthesizes a priority order and tells you what's worth doing now, what can wait, and what isn't worth your time at all.
+
+You get oriented in 60 seconds instead of 20 minutes of tab-flipping.
+
+**Pull-based. Never acts without you. Cognitive partner, not automation tool.**
+
+(Demo video lands with v1.0.0.)
+
+---
+
+## Install (coming with v1.0.0)
+
+```bash
+npx -y slopweaver@latest init
+slopweaver connect github
+slopweaver token create
+```
+
+Then add the printed MCP token to `~/.claude.json` and ask Claude Code about your work.
+
+If anything fails, run `slopweaver doctor`.
+
+---
+
+## Why local-first
+
+- **Your work data stays on your machine.** No SaaS, no cloud round-trip, no signup.
+- **BYOK.** Bring your own Anthropic / OpenAI key (only needed for AI features; deterministic context tools work without).
+- **One binary. SQLite.** No Docker, no Postgres, no setup theatre.
+
+---
+
+## Cloud tier (year 2 — coming)
+
+Some things require a server: real-time webhooks instead of polling, mobile push notifications, cross-device sync, always-on observation. The optional [SlopWeaver Cloud](https://slopweaver.ai) (launching year 2) adds these. Same code; hosted deployment.
+
+---
+
+## Integrations
+
+**v1.0**: GitHub, Slack (preview).
+
+**v1.1+ (planned)**: Linear, Gmail, Google Calendar.
+
+[Request an integration](https://github.com/slopweaver/slopweaver/issues/new) once issue templates land.
+
+---
 
 ## License
 
 [MIT](LICENSE).
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for vulnerability disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,90 @@
+# Security Policy
+
+SlopWeaver uses **coordinated disclosure** to protect users. If a security vulnerability is announced publicly before a fix exists, every installed user is exposed to attackers reading the announcement. Reporting privately first means a patch can ship before attackers learn about the bug. Standard practice across OSS — not an attempt to bury anything.
+
+I'm one person ([@lachiejames](https://github.com/lachiejames)) maintaining this. The timelines below are best-effort, not contractual SLAs.
+
+---
+
+## How to report a vulnerability
+
+**Preferred**: use GitHub's private vulnerability reporting.
+
+> Go to <https://github.com/slopweaver/slopweaver/security/advisories/new> and click "Report a vulnerability." This opens a private discussion between you and me, generates a CVE if confirmed, and gives you visible credit.
+
+**Alternative**: email **admin@slopweaver.ai** if you can't or don't want to use GitHub's tool.
+
+Either way, please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, or a proof-of-concept
+- Your name / handle (if you'd like credit) and any disclosure preferences
+
+I aim to acknowledge receipt within **5 business days**.
+
+---
+
+## Supported versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | ✅ (when released) |
+| 0.x.y   | ❌ (pre-release)   |
+
+Pre-1.0 versions are alpha builds and may contain known issues; do not run them in production.
+
+---
+
+## Disclosure timeline
+
+Targets, in good faith:
+
+- **5 business days** to acknowledge receipt
+- **30 days** to confirm or deny the vulnerability
+- **90 days** from confirmation to ship a fix
+- Public disclosure timing is **coordinated with the reporter** — no unilateral disclosure
+
+If you don't hear back within 5 business days, please re-send to admin@slopweaver.ai or open a GitHub Discussion saying you've sent a security report (without disclosing the vulnerability itself).
+
+---
+
+## Public disclosure of fixed vulnerabilities
+
+Once a fix ships, SlopWeaver publishes a **GitHub Security Advisory** on this repo with:
+
+- A description of the vulnerability and affected versions
+- The fix and upgrade instructions
+- A CVE identifier (where applicable)
+- Credit to the reporter (with their permission)
+
+Fixed vulnerabilities are made visible — that's how the security community learns what to look for in similar projects. The privacy is only during the patch window, not forever.
+
+---
+
+## Bug bounty
+
+There's no paid bug bounty program. Security researchers are credited (with permission) in:
+
+- Release notes
+- The relevant GitHub Security Advisory
+- A `THANKS.md` file (when it exists)
+
+---
+
+## Scope
+
+**In scope**:
+
+- The `slopweaver` npm package (the local binary)
+- All `@slopweaver/*` packages
+- The MCP server transport, auth, and audit log
+- Code in this repository
+
+**Out of scope**:
+
+- Third-party MCP clients that consume SlopWeaver (Claude Code, Cursor, Cline, etc. — please report to the relevant vendor)
+- Vulnerabilities in upstream dependencies (please report to the dependency maintainer; SlopWeaver will update once they patch)
+- Issues requiring physical access to the user's machine
+- Self-XSS or social-engineering scenarios
+
+If you're not sure whether something is in scope, report it anyway via GitHub's private reporting and I'll triage.


### PR DESCRIPTION
First content PR after the bootstrap commit. Three small governance docs:

**README.md** — replaces the placeholder with a real first-impression page. New hook ("Help Claude Code answer 'what should I work on next?'"), session-start scenario as the demo, why-local-first, integrations list, link to roadmap tracking issue.

**CLAUDE.md** — new (~60 lines). Repo state, target stack, where things will live, dev principles (direct imports, package boundaries, no NestJS in packages, small focused PRs), security/privacy reminders, note that strategy docs live in a private repo.

**SECURITY.md** — new (~90 lines). Coordinated disclosure with the WHY up front. Primary channel is GitHub's private vulnerability reporting (already enabled). Alternative: admin@slopweaver.ai. 5/30/90 day timelines as best-effort. Public Security Advisories published once fixes ship.

Voice convention across all three: first-person ("I") for personal commitments; "SlopWeaver" for project-level policies; no "we" / "our" / "us" — solo founder.