### PR TITLE
docs: fix tracking issue link (#1 → #2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Instructions for Claude Code working in the SlopWeaver public repo.
 
 ## What is SlopWeaver
 
-Open-source local-first MCP server that gives Claude Code (and any MCP client) the GitHub + Slack context behind any PR. Pre-alpha; v1.0.0 in development. See [README.md](README.md) and the [v1.0.0 roadmap tracking issue](https://github.com/slopweaver/slopweaver/issues/1).
+Open-source local-first MCP server that helps Claude Code answer "what should I work on next?" by searching across your work tools. Pre-alpha; v1.0.0 in development. See [README.md](README.md) and the [v1.0.0 roadmap tracking issue](https://github.com/slopweaver/slopweaver/issues/2).
 
 ## Repo state (pre-alpha)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![GitHub Stars](https://img.shields.io/github/stars/slopweaver/slopweaver?style=social)](https://github.com/slopweaver/slopweaver/stargazers)
 
-**Status**: pre-alpha. v1.0.0 ships in the coming weeks. Built solo by [@lachiejames](https://github.com/lachiejames). Roadmap: [tracking issue #1](https://github.com/slopweaver/slopweaver/issues/1).
+**Status**: pre-alpha. v1.0.0 ships in the coming weeks. Built solo by [@lachiejames](https://github.com/lachiejames). Roadmap: [tracking issue #2](https://github.com/slopweaver/slopweaver/issues/2).
 
 ---
 


### PR DESCRIPTION
PR #1 consumed the #1 number; the actual tracking issue is #2. Also tightened CLAUDE.md's one-line description to match the start_session hook in README.