### PR TITLE
docs: add CONTRIBUTING, CODE_OF_CONDUCT, issue + PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something isn't working as expected
+labels: [bug, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. SlopWeaver is pre-alpha; expect rough edges, but specific reports help a lot.
+
+        Before filing: please confirm the issue isn't already in the [v1.0.0 roadmap](https://github.com/slopweaver/slopweaver/issues/2) as a known TODO.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the bug.
+      placeholder: e.g. `slopweaver connect github` exits with code 1 immediately
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Steps to reproduce
+      description: Exact commands, in order. The smaller the reproducer, the faster the fix.
+      placeholder: |
+        1. `npx -y slopweaver@latest init`
+        2. `slopweaver connect github`
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: SlopWeaver version
+      description: Output of `slopweaver --version` (or `npm view slopweaver version` if you can't run the CLI).
+      placeholder: e.g. 0.1.0-alpha.3
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, MCP client (Claude Code / Cursor / Cline / other).
+      placeholder: e.g. macOS 15.3 (arm64), Node 22.12.0, Claude Code 2.0.5
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Output from `~/.slopweaver/logs/` or terminal output. Please redact any tokens or secrets.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/slopweaver/slopweaver/discussions
+    about: For questions or general discussion, please use Discussions instead of Issues.
+  - name: Security vulnerability
+    url: https://github.com/slopweaver/slopweaver/security/advisories/new
+    about: Please report security vulnerabilities privately, not as public Issues. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: [enhancement, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Before filing, please check if this is already on the [v1.0.0 roadmap](https://github.com/slopweaver/slopweaver/issues/2).
+
+        SlopWeaver is intentionally narrow in scope — see the README for the v1 hook ("help Claude Code answer 'what should I work on next?'") and CLAUDE.md for development principles. Suggestions outside that scope may be politely declined or moved to v2+.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The user problem you're hitting. Be concrete.
+      placeholder: e.g. I want to ask Claude about a Linear ticket but SlopWeaver only knows about GitHub + Slack.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: What you'd like SlopWeaver to do.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you've thought about.
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Are you willing to contribute this?
+      options:
+        - "I'd be happy to send a PR"
+        - "I could help review or test"
+        - "I'm just suggesting; not able to contribute the code"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -1,0 +1,47 @@
+name: Integration request
+description: Request support for a new platform (Linear, Gmail, Notion, etc.)
+labels: [integration-request, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the request. Integrations roll out incrementally — see [v1.0.0 roadmap](https://github.com/slopweaver/slopweaver/issues/2) for what's planned.
+
+        v1.0 ships with GitHub + Slack only. Linear, Gmail, and Calendar are planned for v1.1+. Other platforms get prioritized by demand + how well they fit the "context for AI agents" use case.
+
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: Which platform? Include the URL.
+      placeholder: e.g. Notion (https://www.notion.so)
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Why you need it
+      description: How does this platform fit into your work? What would you ask Claude Code about it?
+      placeholder: e.g. I keep all my engineering specs in Notion. When I review a PR, I want Claude to find the linked spec.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tools
+    attributes:
+      label: What MCP tools would you want from it?
+      description: e.g. "search docs", "fetch a page", "list pages I've recently edited"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Are you willing to contribute this integration?
+      options:
+        - "I'd build the package and send a PR"
+        - "I could help test against my workspace"
+        - "I'm just requesting; not able to contribute the code"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What this PR does
+
+<!-- 1-2 sentences. What changes; what's the user-visible effect. -->
+
+## Why
+
+<!-- Motivation. Link to issue if applicable: closes #123, refs #456. -->
+
+## Test plan
+
+<!-- How you verified this works. Bullet list of manual steps + automated tests added. -->
+
+- [ ] Tests added / updated
+- [ ] Manually verified
+- [ ] CI green
+
+## Breaking changes
+
+<!-- None / list them. If yes, mark "BREAKING CHANGE:" in commit body too. -->
+
+None.
+
+## Notes for the reviewer
+
+<!-- Anything that helps review: tradeoffs, things to call out, alternative approaches considered. Optional. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+This project adopts the **Contributor Covenant 2.1** as its Code of Conduct.
+
+The full text is at: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+By participating in this community (filing issues, opening PRs, posting in Discussions, commenting on commits), you agree to abide by it.
+
+## Reporting
+
+To report a violation of this Code of Conduct, email **admin@slopweaver.ai**. Reports are handled privately and confidentially.
+
+I'm one person ([@lachiejames](https://github.com/lachiejames)) maintaining this. I'll respond within 7 days, take any reported behavior seriously, and follow the enforcement guidelines from the Contributor Covenant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to SlopWeaver
+
+Thanks for your interest. SlopWeaver is **pre-alpha** and built by one person — I appreciate contributions, but please read this before sending a PR so I can review it efficiently.
+
+## Status check first
+
+- v1.0.0 is in active scaffolding. Most packages and apps **don't exist yet** — see the [v1.0.0 roadmap](https://github.com/slopweaver/slopweaver/issues/2) for what's coming and in what order.
+- The architecture is documented in [CLAUDE.md](CLAUDE.md). Skim it before contributing — it explains the package boundaries, dev principles, and what's intentionally NOT in scope for v1.
+
+## How to engage
+
+- **Questions, ideas, use-case discussion** → [GitHub Discussions](https://github.com/slopweaver/slopweaver/discussions). Not Issues.
+- **Bug reports** → [Issues](https://github.com/slopweaver/slopweaver/issues/new/choose) using the bug-report template.
+- **Feature requests** → [Issues](https://github.com/slopweaver/slopweaver/issues/new/choose) using the feature-request template. **Open the issue before writing code** so we can confirm scope/approach before you invest time.
+- **Integration requests** → [Issues](https://github.com/slopweaver/slopweaver/issues/new/choose) using the integration-request template.
+- **Security vulnerabilities** → privately, see [SECURITY.md](SECURITY.md).
+- **Pull requests** → see below.
+
+## Before sending a PR
+
+For anything beyond a typo or doc fix:
+
+1. Open an Issue or Discussion first to confirm the change is wanted.
+2. Wait for a thumbs-up from a maintainer before writing code. Saves you wasted effort if scope is wrong.
+3. Keep PRs **small and focused**. One concern per PR. Reviewable in one sitting (~500 lines max excluding generated/migration files).
+4. Use the PR template — fill in "What this PR does", "Why", "Test plan".
+
+## Code style
+
+When code lands (early in the v1.0.0 roadmap):
+
+- TypeScript strict mode. No `any` in production code; use `unknown` + type guards.
+- Named object parameters for any function with 1+ args (per the project convention; explicit return types on exported functions).
+- Tests for new features. Vitest for unit/component, Playwright for e2e (when the local UI exists).
+- No NestJS imports inside `packages/*` — see [CLAUDE.md](CLAUDE.md).
+- Direct imports between packages. No dependency-inversion abstractions until there's a real second implementation.
+
+## PR review timeline
+
+Best-effort, since I'm one person:
+
+- New PR: I aim to acknowledge within 7 days
+- First review feedback: within 14 days
+- Substantial PRs (>500 lines, new package, new integration) may take longer
+
+If you don't hear back within 14 days, please ping the PR with a polite reminder.
+
+## Code of Conduct
+
+By participating, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you agree your contributions are licensed under the MIT License (see [LICENSE](LICENSE)).


### PR DESCRIPTION
Governance round per v1.0.0 roadmap (#2). 7 files (~254 lines).

**CONTRIBUTING.md** — engagement channels, "open an Issue before writing code" rule for non-trivial PRs, code style, best-effort review timeline.

**CODE_OF_CONDUCT.md** — adopts Contributor Covenant 2.1 by reference (linked, not inlined). Reports to admin@slopweaver.ai.

**Issue templates** (3 + config):
- `bug_report.yml` — structured form
- `feature_request.yml` — with willingness-to-contribute dropdown
- `integration_request.yml` — platform-add requests
- `config.yml` — disables blank issues; routes questions to Discussions and security to Private Vulnerability Reporting

**PR template** — standard what / why / test plan structure.