### PR TITLE
feat(contracts): add @slopweaver/contracts package with MCP token Zod schemas

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@slopweaver/contracts",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Zod schemas + ts-rest contracts shared between SlopWeaver apps and MCP clients.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "compile": "tsc",
+    "test": "echo 'no tests yet' && exit 0"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "typescript": "6.0.3"
+  }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @slopweaver/contracts — Zod schemas + ts-rest contracts shared between
+ * SlopWeaver apps and MCP clients.
+ *
+ * v1 surface is small (one MCP token contract) and grows as new endpoints
+ * land. ts-rest contract definitions arrive once `apps/cloud/` adds the
+ * REST endpoints they describe.
+ */
+export * from './mcp/token.js';

--- a/packages/contracts/src/mcp/token.ts
+++ b/packages/contracts/src/mcp/token.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+/**
+ * MCP bearer token format: `slop_mcp_<24 hex chars>`.
+ *
+ * Plaintext is returned to the user exactly once at issuance. The persisted
+ * record stores only a bcrypt hash; the plaintext cannot be recovered.
+ */
+export const McpTokenStringSchema = z
+  .string()
+  .regex(/^slop_mcp_[0-9a-f]{24}$/, 'must be slop_mcp_<24 hex chars>');
+
+export type McpTokenString = z.infer<typeof McpTokenStringSchema>;
+
+/** A persisted MCP token record (no plaintext — only its bcrypt hash). */
+export const McpTokenSchema = z.object({
+  id: z.string().uuid(),
+  workspaceId: z.string().uuid(),
+  userId: z.string().uuid(),
+  name: z.string().min(1).max(100),
+  scopes: z.array(z.string()).default(['*']),
+  lastUsedAt: z.iso.datetime().nullable(),
+  expiresAt: z.iso.datetime().nullable(),
+  createdAt: z.iso.datetime(),
+  revokedAt: z.iso.datetime().nullable(),
+});
+
+export type McpToken = z.infer<typeof McpTokenSchema>;
+
+/** Request body for `POST /mcp/tokens`. */
+export const McpTokenCreateInputSchema = z.object({
+  name: z.string().min(1).max(100),
+  scopes: z.array(z.string()).optional(),
+  expiresInDays: z.number().int().positive().max(365).optional(),
+});
+
+export type McpTokenCreateInput = z.infer<typeof McpTokenCreateInputSchema>;
+
+/**
+ * Response from `POST /mcp/tokens`. The plaintext bearer is included exactly
+ * once here and never again; clients must save it on receipt.
+ */
+export const McpTokenCreateResponseSchema = z.object({
+  token: McpTokenSchema,
+  plaintext: McpTokenStringSchema,
+});
+
+export type McpTokenCreateResponse = z.infer<typeof McpTokenCreateResponseSchema>;
+
+/** Response from `GET /mcp/tokens`. Plaintext is never returned here. */
+export const McpTokenListResponseSchema = z.object({
+  tokens: z.array(McpTokenSchema),
+});
+
+export type McpTokenListResponse = z.infer<typeof McpTokenListResponseSchema>;

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,16 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  packages/contracts:
+    dependencies:
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.2
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
 packages:
 
   '@biomejs/biome@2.4.13':
@@ -532,6 +542,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.4.2:
+    resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
+
 snapshots:
 
   '@biomejs/biome@2.4.13':
@@ -993,3 +1006,5 @@ snapshots:
   wordwrap@1.0.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.2: {}


### PR DESCRIPTION
Per v1.0.0 roadmap (#2). First real package — minimal warm-up that validates the workspace mechanics end-to-end (Turbo discovery, TS project compilation, workspace import resolution, CI gating).

| File | Purpose |
|---|---|
| `packages/contracts/package.json` | `@slopweaver/contracts` (private). NodeNext ESM. Single dep: `zod ^4`. |
| `packages/contracts/tsconfig.json` | Extends `../../tsconfig.base.json`. outDir → `dist/`, rootDir → `src/`. |
| `packages/contracts/src/index.ts` | Re-exports from `mcp/token`. |
| `packages/contracts/src/mcp/token.ts` | Zod schemas for MCP token CRUD (token format regex, persisted record shape, create input/response, list response). Matches what PR503-REFERENCE-NOTES.md (private repo) describes for the upcoming `packages/auth` work. |

ts-rest contract definitions land later when `apps/cloud/` adds the REST endpoints they describe.

**Local verification** (the same 4 checks CI runs):
- `pnpm format:check` ✅
- `pnpm lint` ✅
- `pnpm compile` ✅ (Turbo discovers + builds `@slopweaver/contracts`)
- `pnpm test` ✅ (placeholder)

**Test plan**: CI must pass on this PR. After merge, the next package PR (`packages/env/` or `packages/db/`) can import from `@slopweaver/contracts` to verify cross-package workspace resolution works.