### PR TITLE
feat(cli-tools): add `pnpm cli doctor` + Vitest scaffolding

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -27,7 +27,7 @@ If the issue is ambiguous or under-specified, **don't guess**. Comment on the is
 Use the project CLI:
 
 ```bash
-pnpm cli worktree new fix-issue-<N>
+pnpm cli worktree-new fix-issue-<N>
 # creates ~/dev/worktrees/fix-issue-<N> on branch worktree/fix-issue-<N>
 # runs pnpm install
 ```

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -7,7 +7,7 @@ How AI agents (and humans) work in this repo.
 Never edit files in the main checkout (`~/dev/slopweaver` on the `main` branch). All work happens in a git worktree:
 
 ```bash
-pnpm cli worktree new fix-issue-42
+pnpm cli worktree-new fix-issue-42
 # → ~/dev/worktrees/fix-issue-42 on branch worktree/fix-issue-42, deps installed
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,16 @@ Thanks for your interest. SlopWeaver is **pre-alpha** and built by one person �
 - v1.0.0 is in active scaffolding. Most packages and apps **don't exist yet** — see the [v1.0.0 roadmap](https://github.com/slopweaver/slopweaver/issues/2) for what's coming and in what order.
 - The architecture is documented in [CLAUDE.md](CLAUDE.md). Skim it before contributing — it explains the package boundaries, dev principles, and what's intentionally NOT in scope for v1.
 
+## First-time local setup
+
+After `pnpm install`, run the environment health check:
+
+```bash
+pnpm cli doctor
+```
+
+This verifies your Node and pnpm versions, that port `60701` (the local API port) is free, and that the `~/.slopweaver/` data directory exists -- offering to create it for you. It's the fastest way to confirm your machine is ready before you touch any code. See [`packages/cli-tools/README.md`](packages/cli-tools/README.md#doctor) for sample output.
+
 ## How to engage
 
 - **Questions, ideas, use-case discussion** → [GitHub Discussions](https://github.com/slopweaver/slopweaver/discussions). Not Issues.

--- a/docs/contributing/ai-workflow.md
+++ b/docs/contributing/ai-workflow.md
@@ -33,7 +33,7 @@ Read an issue, spawn a worktree, implement the work, open a PR. The default for 
 What the agent does:
 
 1. Fetches the issue body and any existing comments
-2. Creates a worktree via `pnpm cli worktree new fix-issue-42`
+2. Creates a worktree via `pnpm cli worktree-new fix-issue-42`
 3. Implements changes against the acceptance criteria in the issue
 4. Runs the four CI checks locally (`format:check`, `lint`, `compile`, `test`)
 5. Opens a PR with `closes #42` in the body
@@ -118,8 +118,8 @@ To open a decision-record:
 The CLI provides:
 
 ```bash
-pnpm cli worktree new <name>          # create ~/dev/worktrees/<name>, install deps
-pnpm cli worktree new <name> --no-install  # skip pnpm install
+pnpm cli worktree-new <name>          # create ~/dev/worktrees/<name>, install deps
+pnpm cli worktree-new <name> --no-install  # skip pnpm install
 ```
 
 The convention: one worktree = one branch = one PR. Branch is named `worktree/<name>`. Main checkout (`~/dev/slopweaver` on `main`) stays clean and read-only.

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -9,34 +9,101 @@ pnpm cli <subcommand> [options]
 ```
 
 Implementation: `tsx`-executed TypeScript source (no build step). Modern ESM.
-[`cac`](https://github.com/cacjs/cac) for argument parsing.
+[`cac`](https://github.com/cacjs/cac) for argument parsing,
+[`@inquirer/prompts`](https://github.com/SBoudrias/Inquirer.js) for interactive
+prompts, [`picocolors`](https://github.com/alexeyraspopov/picocolors) for color.
+[`vitest`](https://vitest.dev) runs the unit tests.
 
 ## Subcommands
 
-### `worktree new <name>`
+### `worktree-new <name>`
 
 Creates a fresh git worktree from `origin/main`, one directory up from the
 monorepo root, on a new branch `worktree/<name>`. Installs dependencies in
 the new worktree by default.
 
 ```bash
-pnpm cli worktree new fix-issue-42
+pnpm cli worktree-new fix-issue-42
 # creates ~/dev/worktrees/fix-issue-42 on branch worktree/fix-issue-42
 # runs pnpm install in the new worktree
 
-pnpm cli worktree new quick-fix --no-install
+pnpm cli worktree-new quick-fix --no-install
 # skip the pnpm install step
 ```
 
 This is the recommended way to start work on an issue or feature so the
 main checkout stays clean and you can run multiple parallel work streams.
 
+### `doctor`
+
+Checks that your local environment is ready for SlopWeaver development.
+
+```bash
+pnpm cli doctor
+```
+
+It runs four checks:
+
+- **Node version** -- requires Node ≥ 22 (matches `.nvmrc`).
+- **pnpm version** -- requires pnpm ≥ 10 (matches `packageManager` in root `package.json`).
+- **Port 60701 free** -- the local API port; doctor fails if something is bound.
+- **Data dir** -- `~/.slopweaver/`. If missing, doctor offers to create it interactively.
+
+Example output (all checks green):
+
+```
+SlopWeaver doctor
+
+✓ Node version  node 22.19.0 (>=22)
+✓ pnpm version  pnpm 10.0.0 (>=10)
+✓ Port 60701 free  port 60701 available
+✓ Data dir  /Users/you/.slopweaver (writable)
+
+All good. You are ready to develop.
+```
+
+Example output when the data dir is missing (interactive prompt fires):
+
+```
+SlopWeaver doctor
+
+✓ Node version  node 22.19.0 (>=22)
+✓ pnpm version  pnpm 10.0.0 (>=10)
+✓ Port 60701 free  port 60701 available
+! Data dir  /Users/you/.slopweaver (missing -- will offer to create)
+
+? Create data dir at /Users/you/.slopweaver? (Y/n) y
+✔ Create data dir at /Users/you/.slopweaver? Yes
+✓ Data dir  /Users/you/.slopweaver (writable)
+
+All good. You are ready to develop.
+```
+
+Exit code is 0 when everything is green or only warnings remain, 1 when any check fails.
+
 ## Adding a subcommand
 
 1. Create `src/<subcommand>/index.ts` exporting a `run<Subcommand>(...)` function.
-2. Wire it up in `src/cli.ts` with a new `cli.command(...).action(...)` block.
-3. Update this README under `## Subcommands`.
-4. Add tests when the subcommand has logic worth testing (sanitisation, parsing, etc.).
+2. Put pure logic (parsing, validation, environment checks) in sibling files
+   like `src/<subcommand>/checks.ts` so they're easy to unit-test.
+3. Wire it up in `src/cli.ts` with a new `cli.command(...).action(...)` block.
+4. Add colocated `*.test.ts` files next to the code they cover. Tests run via
+   `pnpm --filter @slopweaver/cli-tools test` (or just `pnpm test` from root).
+5. Update this README under `## Subcommands`.
+
+For interactive prompts, use `@inquirer/prompts` (`confirm`, `input`, `select`,
+etc.) and inject the prompt function in your orchestrator so tests can stub it.
 
 Keep subcommands narrow. If a subcommand grows beyond ~150 lines or pulls in
 heavyweight deps, consider promoting it to its own package.
+
+> **Convention:** subcommand names should be single tokens like `doctor`,
+> `worktree-new`, `connect-local`. `cac` 7.0.0 does not dispatch multi-word
+> command names (`cli.command('worktree new <name>', ...)`'s action never
+> fires), so use a hyphen instead of a space for compound commands.
+
+## Scripts
+
+- `pnpm --filter @slopweaver/cli-tools test` -- run the Vitest suite once.
+- `pnpm --filter @slopweaver/cli-tools test:watch` -- run Vitest in watch mode.
+- `pnpm --filter @slopweaver/cli-tools compile` -- type-check (`tsc --noEmit`).

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -2,7 +2,7 @@
   "name": "@slopweaver/cli-tools",
   "version": "0.0.0",
   "private": true,
-  "description": "SlopWeaver developer CLI. Subcommand pattern (`pnpm cli <subcommand>`). v1 subcommands: worktree.",
+  "description": "SlopWeaver developer CLI. Subcommand pattern (`pnpm cli <subcommand>`). v1 subcommands: worktree, doctor.",
   "license": "MIT",
   "type": "module",
   "bin": {
@@ -11,12 +11,16 @@
   "main": "./src/cli.ts",
   "scripts": {
     "compile": "tsc --noEmit",
-    "test": "echo 'no tests yet' && exit 0"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "cac": "7.0.0"
+    "@inquirer/prompts": "8.4.2",
+    "cac": "7.0.0",
+    "picocolors": "1.1.1"
   },
   "devDependencies": {
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "4.1.5"
   }
 }

--- a/packages/cli-tools/src/cli.ts
+++ b/packages/cli-tools/src/cli.ts
@@ -7,23 +7,44 @@
  * `tsx packages/cli-tools/src/cli.ts <subcommand>` (configured in root
  * package.json). Subcommands live under `src/<name>/`.
  *
- * v1: just `worktree`. More land as the project grows.
+ * v1 subcommands: `worktree`, `doctor`. More land as the project grows.
  */
 
 import { cac } from 'cac';
+import { runDoctor } from './doctor/index.ts';
 import { runWorktreeNew } from './worktree/index.ts';
 
 const cli = cac('slopweaver-cli');
 
 cli
   .command(
-    'worktree new <name>',
+    'worktree-new <name>',
     'Create a fresh git worktree from origin/main, on branch worktree/<name>',
   )
   .option('--no-install', 'Skip `pnpm install` in the new worktree')
-  .example('  pnpm cli worktree new fix-issue-42')
+  .example('  pnpm cli worktree-new fix-issue-42')
   .action((name: string, options: { install: boolean }) => {
-    runWorktreeNew({ rawName: name, options: { install: options.install } });
+    const result = runWorktreeNew({ rawName: name, options: { install: options.install } });
+    if (!result.ok) {
+      console.error(`error: ${result.error}`);
+      process.exit(result.exitCode);
+    }
+  });
+
+cli
+  .command('doctor', 'Check your local environment is ready for SlopWeaver dev')
+  .example('  pnpm cli doctor')
+  .action(() => {
+    runDoctor()
+      .then((result) => {
+        if (!result.ok) {
+          process.exit(result.exitCode);
+        }
+      })
+      .catch((err: unknown) => {
+        console.error(err instanceof Error ? err.message : err);
+        process.exit(1);
+      });
   });
 
 cli.help();

--- a/packages/cli-tools/src/doctor/checks.test.ts
+++ b/packages/cli-tools/src/doctor/checks.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  checkDataDir,
+  checkNodeVersion,
+  checkPnpmVersion,
+  checkPortFree,
+  type GetVersionResult,
+  LOCAL_API_PORT,
+  PNPM_VERSION_TIMEOUT_MS,
+  REQUIRED_NODE_MAJOR,
+  REQUIRED_PNPM_MAJOR,
+  type TryBindFn,
+} from './checks.ts';
+
+describe('checkNodeVersion', () => {
+  it('returns ok when the major version meets the minimum', () => {
+    const result = checkNodeVersion({ nodeVersion: `${REQUIRED_NODE_MAJOR}.0.0` });
+    expect(result.status).toBe('ok');
+    expect(result.detail).toContain(`${REQUIRED_NODE_MAJOR}.0.0`);
+  });
+
+  it('returns ok when the major version exceeds the minimum', () => {
+    const result = checkNodeVersion({ nodeVersion: `${REQUIRED_NODE_MAJOR + 2}.5.1` });
+    expect(result.status).toBe('ok');
+  });
+
+  it('returns fail when the major version is below the minimum', () => {
+    const result = checkNodeVersion({ nodeVersion: `${REQUIRED_NODE_MAJOR - 1}.99.99` });
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('.nvmrc');
+  });
+
+  it('uses the live process version when none is supplied', () => {
+    const result = checkNodeVersion();
+    expect(result.detail).toContain(process.versions.node);
+  });
+});
+
+describe('checkPnpmVersion', () => {
+  function getVersion(result: GetVersionResult): () => GetVersionResult {
+    return () => result;
+  }
+
+  it('returns fail with an install hint when pnpm is not on PATH', () => {
+    const result = checkPnpmVersion({
+      getVersion: getVersion({ ok: false, reason: 'not-found' }),
+    });
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('PATH');
+  });
+
+  it('returns fail with a timeout hint when the subprocess times out', () => {
+    const result = checkPnpmVersion({
+      getVersion: getVersion({ ok: false, reason: 'timeout' }),
+    });
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain(`${PNPM_VERSION_TIMEOUT_MS}ms`);
+    expect(result.detail).toContain('corepack');
+  });
+
+  it('returns fail with the underlying error when pnpm exits non-zero', () => {
+    const result = checkPnpmVersion({
+      getVersion: getVersion({ ok: false, reason: 'error', detail: 'exit 1' }),
+    });
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('exit 1');
+  });
+
+  it('returns ok when the major meets the minimum', () => {
+    const result = checkPnpmVersion({
+      getVersion: getVersion({ ok: true, version: `${REQUIRED_PNPM_MAJOR}.0.0` }),
+    });
+    expect(result.status).toBe('ok');
+  });
+
+  it('returns fail with an upgrade hint when the major is too low', () => {
+    const result = checkPnpmVersion({
+      getVersion: getVersion({ ok: true, version: `${REQUIRED_PNPM_MAJOR - 1}.99.0` }),
+    });
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('corepack');
+  });
+});
+
+describe('checkPortFree', () => {
+  it('returns ok when tryBind succeeds', async () => {
+    const tryBind: TryBindFn = async () => ({ ok: true });
+    const result = await checkPortFree({ port: 12345, tryBind });
+    expect(result.status).toBe('ok');
+    expect(result.detail).toContain('12345');
+    expect(result.detail).toContain('available');
+  });
+
+  it('returns the in-use phrasing only for EADDRINUSE', async () => {
+    const tryBind: TryBindFn = async () => ({ ok: false, code: 'EADDRINUSE' });
+    const result = await checkPortFree({ port: 60701, tryBind });
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('in use');
+  });
+
+  it('surfaces the actual error code for other bind failures', async () => {
+    const tryBind: TryBindFn = async () => ({ ok: false, code: 'EACCES' });
+    const result = await checkPortFree({ port: 80, tryBind });
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('EACCES');
+    expect(result.detail).not.toContain('in use');
+  });
+
+  it('exposes the local API port constant', () => {
+    expect(LOCAL_API_PORT).toBe(60701);
+  });
+});
+
+describe('checkDataDir', () => {
+  let dir: string | null = null;
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+      dir = null;
+    }
+  });
+
+  it('returns ok when the data dir exists and is writable', () => {
+    dir = mkdtempSync(join(tmpdir(), 'slopweaver-doctor-'));
+    const result = checkDataDir({ dataDir: dir });
+    expect(result.status).toBe('ok');
+    expect(result.detail).toContain(dir);
+    expect(result.detail).toContain('writable');
+  });
+
+  it('returns warn with fixable=create-data-dir when the path does not exist', () => {
+    const missing = join(tmpdir(), `slopweaver-missing-${Date.now()}-${Math.random()}`);
+    const result = checkDataDir({ dataDir: missing });
+    expect(result.status).toBe('warn');
+    expect(result.fixable).toBe('create-data-dir');
+    expect(result.detail).toContain(missing);
+  });
+
+  it('returns fail when the path exists but is not a directory', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'slopweaver-doctor-'));
+    dir = parent;
+    const filePath = join(parent, 'not-a-dir');
+    writeFileSync(filePath, 'this is a regular file, not a directory');
+    const result = checkDataDir({ dataDir: filePath });
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('not a directory');
+  });
+});

--- a/packages/cli-tools/src/doctor/checks.ts
+++ b/packages/cli-tools/src/doctor/checks.ts
@@ -1,0 +1,204 @@
+import { spawnSync } from 'node:child_process';
+import { accessSync, constants as fsConstants, statSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { resolveDataDir } from '../lib/data-dir.ts';
+
+export const REQUIRED_NODE_MAJOR = 22;
+export const REQUIRED_PNPM_MAJOR = 10;
+export const LOCAL_API_PORT = 60701;
+export const PNPM_VERSION_TIMEOUT_MS = 5_000;
+
+export type CheckStatus = 'ok' | 'warn' | 'fail';
+export type Fixable = 'create-data-dir';
+
+export type CheckResult = {
+  name: string;
+  status: CheckStatus;
+  detail: string;
+  fixable?: Fixable;
+};
+
+function majorOf(version: string): number {
+  return Number.parseInt(version.split('.')[0] ?? '0', 10);
+}
+
+export function checkNodeVersion({
+  nodeVersion = process.versions.node,
+}: {
+  nodeVersion?: string;
+} = {}): CheckResult {
+  const major = majorOf(nodeVersion);
+  if (major >= REQUIRED_NODE_MAJOR) {
+    return {
+      name: 'Node version',
+      status: 'ok',
+      detail: `node ${nodeVersion} (>=${REQUIRED_NODE_MAJOR})`,
+    };
+  }
+  return {
+    name: 'Node version',
+    status: 'fail',
+    detail: `node ${nodeVersion} -- need >=${REQUIRED_NODE_MAJOR} (see .nvmrc)`,
+  };
+}
+
+export type GetVersionResult =
+  | { ok: true; version: string }
+  | { ok: false; reason: 'not-found' | 'timeout' | 'error'; detail?: string };
+
+function defaultGetPnpmVersion(): GetVersionResult {
+  const result = spawnSync('pnpm', ['--version'], {
+    encoding: 'utf8',
+    timeout: PNPM_VERSION_TIMEOUT_MS,
+  });
+  if (result.error) {
+    const code = (result.error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return { ok: false, reason: 'not-found' };
+    return { ok: false, reason: 'error', detail: code ?? result.error.message };
+  }
+  if (result.signal === 'SIGTERM') {
+    return { ok: false, reason: 'timeout' };
+  }
+  if (result.status !== 0) {
+    return { ok: false, reason: 'error', detail: `exit ${result.status}` };
+  }
+  return { ok: true, version: result.stdout.trim() };
+}
+
+export function checkPnpmVersion({
+  getVersion = defaultGetPnpmVersion,
+}: {
+  getVersion?: () => GetVersionResult;
+} = {}): CheckResult {
+  const result = getVersion();
+  if (!result.ok) {
+    if (result.reason === 'not-found') {
+      return {
+        name: 'pnpm version',
+        status: 'fail',
+        detail:
+          'pnpm not on PATH (install: corepack enable && corepack prepare pnpm@latest --activate)',
+      };
+    }
+    if (result.reason === 'timeout') {
+      return {
+        name: 'pnpm version',
+        status: 'fail',
+        detail: `pnpm --version timed out after ${PNPM_VERSION_TIMEOUT_MS}ms (broken corepack shim?)`,
+      };
+    }
+    return {
+      name: 'pnpm version',
+      status: 'fail',
+      detail: `pnpm --version failed: ${result.detail ?? 'unknown error'}`,
+    };
+  }
+  const major = majorOf(result.version);
+  if (major >= REQUIRED_PNPM_MAJOR) {
+    return {
+      name: 'pnpm version',
+      status: 'ok',
+      detail: `pnpm ${result.version} (>=${REQUIRED_PNPM_MAJOR})`,
+    };
+  }
+  return {
+    name: 'pnpm version',
+    status: 'fail',
+    detail: `pnpm ${result.version} -- need >=${REQUIRED_PNPM_MAJOR} (run: corepack prepare pnpm@latest --activate)`,
+  };
+}
+
+export type TryBindResult = { ok: true } | { ok: false; code: string };
+export type TryBindFn = (port: number) => Promise<TryBindResult>;
+
+const defaultTryBind: TryBindFn = (port) =>
+  new Promise((resolve) => {
+    const server = createServer();
+    let settled = false;
+    const settle = (result: TryBindResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    server.once('error', (err) => {
+      const code = (err as NodeJS.ErrnoException).code ?? 'unknown';
+      settle({ ok: false, code });
+    });
+    server.listen(port, '127.0.0.1', () => {
+      server.close(() => settle({ ok: true }));
+    });
+  });
+
+export async function checkPortFree({
+  port,
+  tryBind = defaultTryBind,
+}: {
+  port: number;
+  tryBind?: TryBindFn;
+}): Promise<CheckResult> {
+  const result = await tryBind(port);
+  if (result.ok) {
+    return {
+      name: `Port ${port} free`,
+      status: 'ok',
+      detail: `port ${port} available`,
+    };
+  }
+  if (result.code === 'EADDRINUSE') {
+    return {
+      name: `Port ${port} free`,
+      status: 'fail',
+      detail: `port ${port} is in use (kill the process bound to it, then re-run)`,
+    };
+  }
+  return {
+    name: `Port ${port} free`,
+    status: 'fail',
+    detail: `failed to probe port ${port}: ${result.code}`,
+  };
+}
+
+export function checkDataDir({
+  dataDir = resolveDataDir(),
+}: {
+  dataDir?: string;
+} = {}): CheckResult {
+  try {
+    const stats = statSync(dataDir);
+    if (!stats.isDirectory()) {
+      return {
+        name: 'Data dir',
+        status: 'fail',
+        detail: `${dataDir} (exists but is not a directory)`,
+      };
+    }
+    accessSync(dataDir, fsConstants.W_OK);
+    return {
+      name: 'Data dir',
+      status: 'ok',
+      detail: `${dataDir} (writable)`,
+    };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return {
+        name: 'Data dir',
+        status: 'warn',
+        detail: `${dataDir} (missing -- will offer to create)`,
+        fixable: 'create-data-dir',
+      };
+    }
+    if (code === 'EACCES' || code === 'EPERM') {
+      return {
+        name: 'Data dir',
+        status: 'fail',
+        detail: `${dataDir} (exists but not writable: ${code})`,
+      };
+    }
+    return {
+      name: 'Data dir',
+      status: 'fail',
+      detail: `${dataDir} (filesystem error: ${code ?? 'unknown'})`,
+    };
+  }
+}

--- a/packages/cli-tools/src/doctor/index.test.ts
+++ b/packages/cli-tools/src/doctor/index.test.ts
@@ -1,0 +1,117 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runDoctor } from './index.ts';
+
+describe('runDoctor (interactive contract)', () => {
+  let originalHome: string | undefined;
+  let tempHome: string | null = null;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    tempHome = mkdtempSync(join(tmpdir(), 'slopweaver-rundoctor-'));
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    }
+    if (tempHome) {
+      rmSync(tempHome, { recursive: true, force: true });
+      tempHome = null;
+    }
+  });
+
+  it('prompts to create the data dir when missing and creates it on yes', async () => {
+    const prompt = vi.fn(async (_message: string) => true);
+    const mkdir = vi.fn();
+    const log = vi.fn();
+
+    const result = await runDoctor({ prompt, mkdir, log });
+
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(prompt.mock.calls[0]?.[0]).toContain('Create data dir at');
+    expect(prompt.mock.calls[0]?.[0]).toContain('.slopweaver');
+
+    expect(mkdir).toHaveBeenCalledOnce();
+    expect(mkdir.mock.calls[0]?.[0]).toContain('.slopweaver');
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('does not prompt when the data dir already exists', async () => {
+    if (!tempHome) throw new Error('tempHome should be set');
+    // Pre-create the data dir so checkDataDir reports ok.
+    const dataDir = join(tempHome, '.slopweaver');
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(dataDir);
+
+    const prompt = vi.fn(async () => true);
+    const mkdir = vi.fn();
+    const log = vi.fn();
+
+    await runDoctor({ prompt, mkdir, log });
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(mkdir).not.toHaveBeenCalled();
+
+    const summary = log.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(summary).toContain('All good');
+  });
+
+  it('skips the mkdir when the user declines the prompt and reports a warning summary', async () => {
+    const prompt = vi.fn(async () => false);
+    const mkdir = vi.fn();
+    const log = vi.fn();
+
+    await runDoctor({ prompt, mkdir, log });
+
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(mkdir).not.toHaveBeenCalled();
+
+    if (!tempHome) throw new Error('tempHome should be set');
+    expect(existsSync(join(tempHome, '.slopweaver'))).toBe(false);
+
+    const summary = log.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(summary).toMatch(/warning/i);
+  });
+
+  it('actually creates the directory when mkdir uses the real filesystem', async () => {
+    const { mkdirSync } = await import('node:fs');
+    const prompt = vi.fn(async () => true);
+    const mkdir = vi.fn((path: string) => mkdirSync(path, { recursive: true }));
+    const log = vi.fn();
+
+    const result = await runDoctor({ prompt, mkdir, log });
+
+    if (!tempHome) throw new Error('tempHome should be set');
+    expect(existsSync(join(tempHome, '.slopweaver'))).toBe(true);
+    expect(result).toEqual({ ok: true });
+
+    const summary = log.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(summary).toContain('All good');
+  });
+
+  it('returns ok=false with a non-zero exit code when any check fails', async () => {
+    if (!tempHome) throw new Error('tempHome should be set');
+    // Pre-create the data dir as a regular file so checkDataDir reports fail
+    // (the new "exists but is not a directory" branch).
+    const dataDirPath = join(tempHome, '.slopweaver');
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(dataDirPath, 'not a directory');
+
+    const prompt = vi.fn(async () => true);
+    const mkdir = vi.fn();
+    const log = vi.fn();
+
+    const result = await runDoctor({ prompt, mkdir, log });
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, failed: 1, exitCode: 1 });
+
+    const summary = log.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(summary).toMatch(/failed/i);
+  });
+});

--- a/packages/cli-tools/src/doctor/index.ts
+++ b/packages/cli-tools/src/doctor/index.ts
@@ -1,0 +1,100 @@
+/**
+ * `pnpm cli doctor`
+ *
+ * Checks that the local environment is ready for SlopWeaver development:
+ * Node version, pnpm version, the local API port, and the data directory.
+ *
+ * Each check is a pure function in `./checks.ts`. This file orchestrates
+ * them: runs each, prints the result with a colored status icon, and (if
+ * the data dir is missing) prompts to create it. Returns a result object;
+ * the dispatcher in `cli.ts` maps that to a process exit code.
+ *
+ * `prompt` and `mkdir` are injectable so the orchestrator stays unit-
+ * testable without touching real stdin or filesystem.
+ */
+
+import { confirm } from '@inquirer/prompts';
+import { mkdirSync } from 'node:fs';
+import pc from 'picocolors';
+import { resolveDataDir } from '../lib/data-dir.ts';
+import {
+  type CheckResult,
+  LOCAL_API_PORT,
+  checkDataDir,
+  checkNodeVersion,
+  checkPnpmVersion,
+  checkPortFree,
+} from './checks.ts';
+
+export type RunDoctorDeps = {
+  prompt?: (message: string) => Promise<boolean>;
+  mkdir?: (path: string) => void;
+  log?: (line: string) => void;
+};
+
+export type RunDoctorResult = { ok: true } | { ok: false; failed: number; exitCode: number };
+
+const ICON: Record<CheckResult['status'], string> = {
+  ok: pc.green('✓'),
+  warn: pc.yellow('!'),
+  fail: pc.red('✗'),
+};
+
+function formatRow(result: CheckResult): string {
+  return `${ICON[result.status]} ${pc.bold(result.name)}  ${pc.dim(result.detail)}`;
+}
+
+const defaultPrompt = async (message: string): Promise<boolean> =>
+  confirm({ message, default: true });
+
+const defaultMkdir = (path: string): void => {
+  mkdirSync(path, { recursive: true });
+};
+
+export async function runDoctor({
+  prompt = defaultPrompt,
+  mkdir = defaultMkdir,
+  log = console.log,
+}: RunDoctorDeps = {}): Promise<RunDoctorResult> {
+  log(pc.bold('SlopWeaver doctor'));
+  log('');
+
+  const results: CheckResult[] = [
+    checkNodeVersion(),
+    checkPnpmVersion(),
+    await checkPortFree({ port: LOCAL_API_PORT }),
+    checkDataDir(),
+  ];
+
+  for (const result of results) {
+    log(formatRow(result));
+  }
+
+  // Offer the one fix we know how to apply.
+  const dataDirIndex = results.findIndex((r) => r.fixable === 'create-data-dir');
+  if (dataDirIndex !== -1) {
+    const dataDir = resolveDataDir();
+    log('');
+    const shouldCreate = await prompt(`Create data dir at ${dataDir}?`);
+    if (shouldCreate) {
+      mkdir(dataDir);
+      const recheck = checkDataDir();
+      results[dataDirIndex] = recheck;
+      log(formatRow(recheck));
+    }
+  }
+
+  const failed = results.filter((r) => r.status === 'fail').length;
+  const warned = results.filter((r) => r.status === 'warn').length;
+  log('');
+  if (failed === 0 && warned === 0) {
+    log(pc.green('All good. You are ready to develop.'));
+    return { ok: true };
+  }
+  if (failed === 0) {
+    log(pc.yellow(`OK with ${warned} warning${warned === 1 ? '' : 's'} (see above).`));
+    return { ok: true };
+  }
+  log(pc.red(`${failed} check${failed === 1 ? '' : 's'} failed. Fix the items above and re-run.`));
+  return { ok: false, failed, exitCode: 1 };
+}

--- a/packages/cli-tools/src/lib/data-dir.test.ts
+++ b/packages/cli-tools/src/lib/data-dir.test.ts
@@ -1,0 +1,14 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveDataDir } from './data-dir.ts';
+
+describe('resolveDataDir', () => {
+  it('joins .slopweaver onto the supplied home directory', () => {
+    expect(resolveDataDir({ home: '/tmp/fakehome' })).toBe('/tmp/fakehome/.slopweaver');
+  });
+
+  it('defaults to os.homedir() when no home is supplied', () => {
+    expect(resolveDataDir()).toBe(join(homedir(), '.slopweaver'));
+  });
+});

--- a/packages/cli-tools/src/lib/data-dir.ts
+++ b/packages/cli-tools/src/lib/data-dir.ts
@@ -1,0 +1,14 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Where SlopWeaver stores its local data (database, cached tokens, logs).
+ *
+ * Cross-platform: `~/.slopweaver` everywhere. We can move to platform-native
+ * data dirs (Library/Application Support on macOS, %LOCALAPPDATA% on Windows,
+ * $XDG_DATA_HOME on Linux) when there's a reason to — for v1 a single
+ * predictable path is easier to document and debug.
+ */
+export function resolveDataDir({ home }: { home?: string } = {}): string {
+  return join(home ?? homedir(), '.slopweaver');
+}

--- a/packages/cli-tools/src/lib/paths.test.ts
+++ b/packages/cli-tools/src/lib/paths.test.ts
@@ -1,0 +1,23 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { findMonorepoRoot, resolveWorktreesRoot } from './paths.ts';
+
+describe('findMonorepoRoot', () => {
+  it('returns a directory that contains pnpm-workspace.yaml', () => {
+    const root = findMonorepoRoot();
+    expect(existsSync(join(root, 'pnpm-workspace.yaml'))).toBe(true);
+  });
+});
+
+describe('resolveWorktreesRoot', () => {
+  it('returns the sibling worktrees directory next to the repo', () => {
+    expect(resolveWorktreesRoot({ repoRoot: '/Users/me/dev/slopweaver' })).toBe(
+      '/Users/me/dev/worktrees',
+    );
+  });
+
+  it('handles short paths', () => {
+    expect(resolveWorktreesRoot({ repoRoot: '/a/b/c' })).toBe('/a/b/worktrees');
+  });
+});

--- a/packages/cli-tools/src/worktree/index.test.ts
+++ b/packages/cli-tools/src/worktree/index.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type ExecFn, type ExecResult, runWorktreeNew, type RunWorktreeNewDeps } from './index.ts';
+
+const FAKE_ROOTS = { repoRoot: '/repo', worktreesRoot: '/wt' };
+
+const okExec: ExecFn = () => ({ status: 0 });
+
+function deps({
+  exec = okExec,
+  log = vi.fn(),
+  resolveRoots = () => FAKE_ROOTS,
+}: Partial<RunWorktreeNewDeps> = {}): RunWorktreeNewDeps {
+  return { exec, log, resolveRoots };
+}
+
+describe('runWorktreeNew', () => {
+  it('runs git fetch, git worktree add, and pnpm install in order', () => {
+    const calls: { cmd: string; args: string[]; cwd: string }[] = [];
+    const exec: ExecFn = (cmd, args, opts) => {
+      calls.push({ cmd, args, cwd: opts.cwd });
+      return { status: 0 };
+    };
+
+    const result = runWorktreeNew({
+      rawName: 'fix-issue-42',
+      options: { install: true },
+      deps: deps({ exec }),
+    });
+
+    expect(result).toEqual({ ok: true, worktreePath: '/wt/fix-issue-42' });
+    expect(calls).toEqual([
+      { cmd: 'git', args: ['fetch', 'origin', 'main'], cwd: '/repo' },
+      {
+        cmd: 'git',
+        args: ['worktree', 'add', '-b', 'worktree/fix-issue-42', '/wt/fix-issue-42', 'origin/main'],
+        cwd: '/repo',
+      },
+      { cmd: 'pnpm', args: ['install'], cwd: '/wt/fix-issue-42' },
+    ]);
+  });
+
+  it('skips pnpm install when options.install is false', () => {
+    const exec = vi.fn<ExecFn>(() => ({ status: 0 }) as ExecResult);
+
+    const result = runWorktreeNew({
+      rawName: 'quick-fix',
+      options: { install: false },
+      deps: deps({ exec }),
+    });
+
+    expect(result).toEqual({ ok: true, worktreePath: '/wt/quick-fix' });
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns an error when sanitisation produces an empty slug', () => {
+    const exec = vi.fn<ExecFn>(() => ({ status: 0 }) as ExecResult);
+
+    const result = runWorktreeNew({
+      rawName: '!!!',
+      options: { install: true },
+      deps: deps({ exec }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/empty slug/);
+      expect(result.exitCode).toBe(1);
+    }
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('returns the failing exit code when git fetch fails', () => {
+    const exec: ExecFn = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'fetch') return { status: 128 };
+      return { status: 0 };
+    };
+
+    const result = runWorktreeNew({
+      rawName: 'fix-x',
+      options: { install: true },
+      deps: deps({ exec }),
+    });
+
+    expect(result).toEqual({ ok: false, error: 'git fetch origin main failed', exitCode: 128 });
+  });
+
+  it('returns the failing exit code when git worktree add fails', () => {
+    const exec: ExecFn = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'worktree') return { status: 128 };
+      return { status: 0 };
+    };
+
+    const result = runWorktreeNew({
+      rawName: 'fix-x',
+      options: { install: true },
+      deps: deps({ exec }),
+    });
+
+    expect(result).toEqual({ ok: false, error: 'git worktree add failed', exitCode: 128 });
+  });
+
+  it('returns the failing exit code when pnpm install fails', () => {
+    const exec: ExecFn = (cmd) => {
+      if (cmd === 'pnpm') return { status: 1 };
+      return { status: 0 };
+    };
+
+    const result = runWorktreeNew({
+      rawName: 'fix-x',
+      options: { install: true },
+      deps: deps({ exec }),
+    });
+
+    expect(result).toEqual({ ok: false, error: 'pnpm install failed', exitCode: 1 });
+  });
+
+  it('emits human-readable log lines via the injected log function', () => {
+    const log = vi.fn();
+    runWorktreeNew({
+      rawName: 'fix-issue-42',
+      options: { install: false },
+      deps: deps({ log }),
+    });
+    const lines = log.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(lines).toContain('creating worktree: /wt/fix-issue-42');
+    expect(lines).toContain('new branch:        worktree/fix-issue-42');
+    expect(lines).toContain('worktree ready');
+  });
+});

--- a/packages/cli-tools/src/worktree/index.ts
+++ b/packages/cli-tools/src/worktree/index.ts
@@ -1,84 +1,95 @@
 /**
- * `pnpm cli worktree new <name>`
+ * `pnpm cli worktree-new <name>`
  *
  * Creates a fresh git worktree from the latest `origin/main`, one directory
  * above the monorepo root, on a new branch `worktree/<name>`. Optionally
  * runs `pnpm install` in the new worktree (default: yes).
  *
- * Adapted from slopweaver-private/packages/cli-tools/src/worktree/index.ts.
- * Simpler here — no .env sync, no platform-specific patches; just create
- * the worktree and install deps.
+ * Pure plan-building lives in `./plan.ts`. This file orchestrates: it
+ * resolves the monorepo root, builds the plan, then runs git + pnpm via
+ * the injected `exec` so tests can stub the subprocess layer.
  */
 
 import { spawnSync } from 'node:child_process';
-import { join } from 'node:path';
 import { findMonorepoRoot, resolveWorktreesRoot } from '../lib/paths.ts';
-
-/** Sanitises a free-text task name into a slug-safe branch + path component. */
-export function sanitiseTaskName({ input }: { input: string }): string {
-  return input
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9-_]+/g, '-')
-    .replace(/--+/g, '-')
-    .replace(/(^-|-$)/g, '');
-}
+import { buildWorktreePlan } from './plan.ts';
 
 export type WorktreeNewOptions = { install: boolean };
+
+export type ExecResult = { status: number };
+
+export type ExecFn = (cmd: string, args: string[], opts: { cwd: string }) => ExecResult;
+
+export type RunWorktreeNewResult =
+  | { ok: true; worktreePath: string }
+  | { ok: false; error: string; exitCode: number };
+
+export type RunWorktreeNewDeps = {
+  exec?: ExecFn;
+  log?: (line: string) => void;
+  resolveRoots?: () => { repoRoot: string; worktreesRoot: string };
+};
+
+const defaultExec: ExecFn = (cmd, args, opts) => {
+  const result = spawnSync(cmd, args, { cwd: opts.cwd, stdio: 'inherit' });
+  return { status: result.status ?? 1 };
+};
+
+const defaultResolveRoots = (): { repoRoot: string; worktreesRoot: string } => {
+  const repoRoot = findMonorepoRoot();
+  return { repoRoot, worktreesRoot: resolveWorktreesRoot({ repoRoot }) };
+};
 
 export function runWorktreeNew({
   rawName,
   options,
+  deps = {},
 }: {
   rawName: string;
   options: WorktreeNewOptions;
-}): void {
-  const safeName = sanitiseTaskName({ input: rawName });
-  if (!safeName) {
-    console.error('error: task name produced an empty slug after sanitisation');
-    process.exit(1);
+  deps?: RunWorktreeNewDeps;
+}): RunWorktreeNewResult {
+  const exec = deps.exec ?? defaultExec;
+  const log = deps.log ?? console.log;
+  const resolveRoots = deps.resolveRoots ?? defaultResolveRoots;
+
+  const { repoRoot, worktreesRoot } = resolveRoots();
+  const planResult = buildWorktreePlan({ rawName, worktreesRoot });
+  if (!planResult.ok) {
+    return { ok: false, error: planResult.error, exitCode: 1 };
   }
+  const { plan } = planResult;
 
-  const repoRoot = findMonorepoRoot();
-  const worktreesRoot = resolveWorktreesRoot({ repoRoot });
-  const worktreePath = join(worktreesRoot, safeName);
-  const branchName = `worktree/${safeName}`;
-  const baseRef = 'origin/main';
+  log(`creating worktree: ${plan.worktreePath}`);
+  log(`new branch:        ${plan.branchName}`);
+  log(`from:              ${plan.baseRef}`);
+  log('');
 
-  console.log(`creating worktree: ${worktreePath}`);
-  console.log(`new branch:        ${branchName}`);
-  console.log(`from:              ${baseRef}`);
-  console.log('');
-
-  const fetchResult = spawnSync('git', ['fetch', 'origin', 'main'], {
-    cwd: repoRoot,
-    stdio: 'inherit',
-  });
+  const fetchResult = exec('git', ['fetch', 'origin', 'main'], { cwd: repoRoot });
   if (fetchResult.status !== 0) {
-    process.exit(fetchResult.status ?? 1);
+    return { ok: false, error: 'git fetch origin main failed', exitCode: fetchResult.status };
   }
 
-  const addResult = spawnSync('git', ['worktree', 'add', '-b', branchName, worktreePath, baseRef], {
-    cwd: repoRoot,
-    stdio: 'inherit',
-  });
+  const addResult = exec(
+    'git',
+    ['worktree', 'add', '-b', plan.branchName, plan.worktreePath, plan.baseRef],
+    { cwd: repoRoot },
+  );
   if (addResult.status !== 0) {
-    process.exit(addResult.status ?? 1);
+    return { ok: false, error: 'git worktree add failed', exitCode: addResult.status };
   }
 
   if (options.install) {
-    console.log('');
-    console.log(`installing deps in ${worktreePath}`);
-    const installResult = spawnSync('pnpm', ['install'], {
-      cwd: worktreePath,
-      stdio: 'inherit',
-    });
+    log('');
+    log(`installing deps in ${plan.worktreePath}`);
+    const installResult = exec('pnpm', ['install'], { cwd: plan.worktreePath });
     if (installResult.status !== 0) {
-      process.exit(installResult.status ?? 1);
+      return { ok: false, error: 'pnpm install failed', exitCode: installResult.status };
     }
   }
 
-  console.log('');
-  console.log('✓ worktree ready');
-  console.log(`next: cd ${worktreePath}`);
+  log('');
+  log('✓ worktree ready');
+  log(`next: cd ${plan.worktreePath}`);
+  return { ok: true, worktreePath: plan.worktreePath };
 }

--- a/packages/cli-tools/src/worktree/plan.test.ts
+++ b/packages/cli-tools/src/worktree/plan.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { buildWorktreePlan, sanitiseTaskName } from './plan.ts';
+
+describe('sanitiseTaskName', () => {
+  it('lowercases and keeps hyphens, digits, underscores', () => {
+    expect(sanitiseTaskName({ input: 'Fix-Issue_42' })).toBe('fix-issue_42');
+  });
+
+  it('replaces runs of disallowed characters with single hyphens', () => {
+    expect(sanitiseTaskName({ input: 'fix the broken thing!!' })).toBe('fix-the-broken-thing');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    expect(sanitiseTaskName({ input: '  --hello-world--  ' })).toBe('hello-world');
+  });
+
+  it('collapses repeated hyphens', () => {
+    expect(sanitiseTaskName({ input: 'foo---bar' })).toBe('foo-bar');
+  });
+
+  it('returns empty string for input that has no allowed characters', () => {
+    expect(sanitiseTaskName({ input: '!!!' })).toBe('');
+  });
+
+  it('handles unicode by replacing it with hyphens', () => {
+    expect(sanitiseTaskName({ input: 'café-naïve' })).toBe('caf-na-ve');
+  });
+});
+
+describe('buildWorktreePlan', () => {
+  it('returns a plan with the worktree path, branch name, and base ref', () => {
+    const result = buildWorktreePlan({
+      rawName: 'fix-issue-42',
+      worktreesRoot: '/Users/me/dev/worktrees',
+    });
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        safeName: 'fix-issue-42',
+        worktreePath: '/Users/me/dev/worktrees/fix-issue-42',
+        branchName: 'worktree/fix-issue-42',
+        baseRef: 'origin/main',
+      },
+    });
+  });
+
+  it('sanitises the raw name before building the path', () => {
+    const result = buildWorktreePlan({
+      rawName: 'Fix Issue 42!!',
+      worktreesRoot: '/wt',
+    });
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        safeName: 'fix-issue-42',
+        worktreePath: '/wt/fix-issue-42',
+        branchName: 'worktree/fix-issue-42',
+        baseRef: 'origin/main',
+      },
+    });
+  });
+
+  it('returns an error when the sanitised name is empty', () => {
+    const result = buildWorktreePlan({ rawName: '!!!', worktreesRoot: '/wt' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/empty slug/);
+    }
+  });
+});

--- a/packages/cli-tools/src/worktree/plan.ts
+++ b/packages/cli-tools/src/worktree/plan.ts
@@ -1,0 +1,45 @@
+import { join } from 'node:path';
+
+/** Sanitises a free-text task name into a slug-safe branch + path component. */
+export function sanitiseTaskName({ input }: { input: string }): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, '-')
+    .replace(/--+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+export type WorktreePlan = {
+  safeName: string;
+  worktreePath: string;
+  branchName: string;
+  baseRef: string;
+};
+
+export type BuildPlanResult = { ok: true; plan: WorktreePlan } | { ok: false; error: string };
+
+export function buildWorktreePlan({
+  rawName,
+  worktreesRoot,
+}: {
+  rawName: string;
+  worktreesRoot: string;
+}): BuildPlanResult {
+  const safeName = sanitiseTaskName({ input: rawName });
+  if (!safeName) {
+    return {
+      ok: false,
+      error: 'task name produced an empty slug after sanitisation',
+    };
+  }
+  return {
+    ok: true,
+    plan: {
+      safeName,
+      worktreePath: join(worktreesRoot, safeName),
+      branchName: `worktree/${safeName}`,
+      baseRef: 'origin/main',
+    },
+  };
+}

--- a/packages/cli-tools/vitest.config.ts
+++ b/packages/cli-tools/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,13 +32,22 @@ importers:
 
   packages/cli-tools:
     dependencies:
+      '@inquirer/prompts':
+        specifier: 8.4.2
+        version: 8.4.2(@types/node@22.10.5)
       cac:
         specifier: 7.0.0
         version: 7.0.0
+      picocolors:
+        specifier: 1.1.1
+        version: 1.1.1
     devDependencies:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@22.10.5)(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
 
@@ -98,6 +107,15 @@ packages:
   '@boundaries/elements@2.0.1':
     resolution: {integrity: sha512-sAWO3D8PFP6pBXdxxW93SQi/KQqqhE2AAHo3AgWfdtJXwO6bfK6/wUN81XnOZk0qRC6vHzUEKhjwVD9dtDWvxg==}
     engines: {node: '>=18.18'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -305,6 +323,247 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/checkbox@5.1.4':
+    resolution: {integrity: sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.12':
+    resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.9':
+    resolution: {integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.1.1':
+    resolution: {integrity: sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.13':
+    resolution: {integrity: sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.0':
+    resolution: {integrity: sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@5.0.12':
+    resolution: {integrity: sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.12':
+    resolution: {integrity: sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.12':
+    resolution: {integrity: sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.4.2':
+    resolution: {integrity: sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.8':
+    resolution: {integrity: sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.8':
+    resolution: {integrity: sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.1.4':
+    resolution: {integrity: sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@turbo/darwin-64@2.9.7':
     resolution: {integrity: sha512-wnvOWuVWJ5EUHNKxExEWiGlTeVpLG1L0PCu5MUozyC1P2SHGiWsmpW6/yAuShH91Fa2TAHOvdCRBzriZh4j4Eg==}
     cpu: [x64]
@@ -335,6 +594,15 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -346,6 +614,35 @@ packages:
 
   '@types/node@22.10.5':
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -364,6 +661,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -380,9 +681,20 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -390,6 +702,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -415,9 +730,16 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -496,9 +818,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -508,6 +837,24 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -556,6 +903,10 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -599,9 +950,82 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -617,11 +1041,23 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -646,9 +1082,23 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -666,6 +1116,14 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -674,9 +1132,26 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -686,9 +1161,27 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -719,9 +1212,98 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -785,6 +1367,22 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -910,6 +1508,189 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/checkbox@5.1.4(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/confirm@6.0.12(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/core@11.1.9(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/editor@5.1.1(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/external-editor': 3.0.0(@types/node@22.10.5)
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/expand@5.0.13(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/external-editor@3.0.0(@types/node@22.10.5)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/input@5.0.12(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/number@4.0.12(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/password@5.0.12(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/prompts@8.4.2(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.4(@types/node@22.10.5)
+      '@inquirer/confirm': 6.0.12(@types/node@22.10.5)
+      '@inquirer/editor': 5.1.1(@types/node@22.10.5)
+      '@inquirer/expand': 5.0.13(@types/node@22.10.5)
+      '@inquirer/input': 5.0.12(@types/node@22.10.5)
+      '@inquirer/number': 4.0.12(@types/node@22.10.5)
+      '@inquirer/password': 5.0.12(@types/node@22.10.5)
+      '@inquirer/rawlist': 5.2.8(@types/node@22.10.5)
+      '@inquirer/search': 4.1.8(@types/node@22.10.5)
+      '@inquirer/select': 5.1.4(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/rawlist@5.2.8(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/search@4.1.8(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/select@5.1.4(@types/node@22.10.5)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@22.10.5)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.10.5)
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@inquirer/type@4.0.5(@types/node@22.10.5)':
+    optionalDependencies:
+      '@types/node': 22.10.5
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
   '@turbo/darwin-64@2.9.7':
     optional: true
 
@@ -928,6 +1709,18 @@ snapshots:
   '@turbo/windows-arm64@2.9.7':
     optional: true
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -937,6 +1730,47 @@ snapshots:
   '@types/node@22.10.5':
     dependencies:
       undici-types: 6.20.0
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -955,6 +1789,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  assertion-error@2.0.1: {}
+
   balanced-match@4.0.4: {}
 
   brace-expansion@5.0.5:
@@ -967,16 +1803,24 @@ snapshots:
 
   cac@7.0.0: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chardet@2.1.1: {}
+
+  cli-width@4.1.0: {}
 
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -994,7 +1838,11 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  detect-libc@2.1.2: {}
+
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1121,13 +1969,33 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -1177,6 +2045,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   imurmurhash@0.1.4: {}
@@ -1210,9 +2082,62 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   micromatch@4.0.8:
     dependencies:
@@ -1227,9 +2152,15 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mute-stream@3.0.0: {}
+
+  nanoid@3.3.12: {}
+
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
+
+  obug@2.1.1: {}
 
   optionator@0.9.4:
     dependencies:
@@ -1254,7 +2185,19 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
   picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -1269,13 +2212,46 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  safer-buffer@2.1.2: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
   source-map@0.6.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -1283,9 +2259,23 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.21.0:
     dependencies:
@@ -1318,9 +2308,54 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.10.5
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@4.1.5(@types/node@22.10.5)(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.10.5
+    transitivePeerDependencies:
+      - msw
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## What this PR does

Adds the first interactive subcommand to `@slopweaver/cli-tools` -- `pnpm cli doctor` -- and stands up the Vitest infrastructure that future subcommands will hang off. Backfills the existing `worktree` subcommand to the same testable pattern and fixes the `cac` multi-word dispatch issue along the way (renaming `worktree new` -> `worktree-new`).

`doctor` runs four environment checks (Node ≥22, pnpm ≥10, port 60701 free, `~/.slopweaver/` data dir writable) and prompts interactively to create the data dir if it's missing. Exits 0 on success or warnings-only, 1 on failure.

## Why

Sub-task of #10 (Scaffolding & DevOps tracking) -- knocks off two of its checklist items in one PR (`pnpm cli doctor` + Vitest scaffolding for cli-tools) and incidentally fixes #15 (the silent `worktree new` cac bug) by renaming the broken multi-word command. Establishes the testable + interactive subcommand pattern the next round of subcommands (e.g. `connect-local`) will follow.

closes #12
closes #15
refs #10

## Test plan

- [x] **42 unit tests** across 6 colocated `*.test.ts` files (sanitiseTaskName + plan, paths, data-dir, all 4 doctor checks, runDoctor orchestrator, runWorktreeNew orchestrator)
- [x] Manually verified end-to-end via `expect`-driven PTY: doctor's all-green path, missing-data-dir prompt → accept (dir created), prompt → decline (warning summary), and exit-code-1 fail path
- [x] CI green locally:
  - `pnpm format:check` ✓
  - `pnpm lint` ✓
  - `pnpm compile` ✓
  - `pnpm test` ✓ (42 tests, ~1.1s)
- [x] Smoke-tested `pnpm cli worktree-new` -- action callback now fires (was silently broken before #15)
- [x] Single squashed commit

## Breaking changes

`pnpm cli worktree new` -> `pnpm cli worktree-new`. The old multi-word form never actually worked (cac 7.0.0 doesn't dispatch multi-word commands -- silent exit 0), so this is fixing rather than breaking. All in-repo references updated (workflow rule, slash command, AI workflow doc, package README).

## Notes for the reviewer

**Conventions established** (worth pushing back on if you'd rather differ):
- Tests colocated as `*.test.ts` next to the file under test (vs. private repo's `__tests__/` layout). Colocation is more discoverable for a package this size and matches modern Vitest defaults.
- Pure logic in sibling files (`checks.ts`, `plan.ts`); orchestrators (`index.ts`) inject all I/O (`prompt`, `mkdir`, `exec`, `tryBind`, `getVersion`, `log`) so they're testable without module mocking.
- Orchestrators return `{ ok, exitCode }`; the dispatcher in `cli.ts` owns `process.exit`. Keeps fail paths unit-testable.
- Single-word command names only -- cac 7.0.0 doesn't dispatch multi-word.

**Codex review addressed** -- ran a Codex review pass against the squashed PR. Findings actioned in this same PR:
- *Directory check in `checkDataDir`* -- previously a regular file at `~/.slopweaver` would falsely pass; now `statSync` confirms it's a directory.
- *Subprocess timeout for `checkPnpmVersion`* -- 5s timeout via `spawnSync({ timeout })`; typed `GetVersionResult` distinguishes not-found / timeout / error.
- *`checkPortFree` error mapping* -- `EADDRINUSE` only triggers the "port in use" phrasing; other codes (`EACCES` etc.) surface their actual code.
- *Race in port test* -- replaced ephemeral-port trick with injected `tryBind` stub; both branches now deterministic.
- *`process.exit` inside `runDoctor`* -- removed; orchestrator returns a result, dispatcher exits.

**Deliberately NOT in this PR**:
- Auto-fix mode beyond the data-dir prompt
- Root-level Vitest config (per-package is fine for one package)
- `--json` output flag
- npm-publish decision (still open in #10)
- Doctor data dir is `~/.slopweaver/` cross-platform (not XDG/AppData) -- easier to document and debug for v1; can move to platform-native paths later if anyone asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)