### PR TITLE
feat(contracts): scaffold zod schemas for v1 MCP tools

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@slopweaver/contracts",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared Zod contracts and domain types for SlopWeaver v1 MCP tools.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "compile": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "zod": "4.4.2"
+  },
+  "devDependencies": {
+    "typescript": "6.0.3",
+    "vitest": "4.1.5"
+  }
+}

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -48,4 +48,98 @@ describe('PingResult', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('rejects unknown extra props (strict)', () => {
+    const result = PingResult.safeParse({
+      ok: true,
+      version: '0.1.0',
+      uptime_s: 0,
+      extra: 'not allowed',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('Reference', () => {
+  it('accepts url variant', () => {
+    const result = Reference.safeParse({
+      kind: 'url',
+      url: 'https://github.com/slopweaver/slopweaver/pull/24',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts canonical variant', () => {
+    const result = Reference.safeParse({
+      kind: 'canonical',
+      integration: 'github',
+      id: 'pr/24',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown discriminant', () => {
+    const result = Reference.safeParse({
+      kind: 'something-else',
+      url: 'https://example.com',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects mixed-shape inputs', () => {
+    const result = Reference.safeParse({
+      kind: 'url',
+      integration: 'github',
+      id: 'pr/24',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('Freshness', () => {
+  it('accepts a never-polled-yet integration with last_polled_at: null', () => {
+    const result = Freshness.safeParse({
+      integration: 'github',
+      last_polled_at: null,
+      stale: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing last_polled_at field', () => {
+    const result = Freshness.safeParse({
+      integration: 'github',
+      stale: true,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('EvidenceLogEntry', () => {
+  it('accepts payload_json as an object', () => {
+    const result = EvidenceLogEntry.safeParse({
+      id: 'gh:pr:24',
+      integration: 'github',
+      kind: 'pull_request',
+      ref: { kind: 'canonical', integration: 'github', id: 'pr/24' },
+      occurred_at: '2026-05-03T18:00:00+10:00',
+      payload_json: { title: 'feat(contracts)', state: 'open' },
+      citation_url: 'https://github.com/slopweaver/slopweaver/pull/24',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts payload_json as an array (any JSON value)', () => {
+    const result = EvidenceLogEntry.safeParse({
+      id: 'gh:commit:abc',
+      integration: 'github',
+      kind: 'commit',
+      ref: { kind: 'url', url: 'https://github.com/slopweaver/slopweaver/commit/abc' },
+      occurred_at: '2026-05-03T18:00:00+10:00',
+      payload_json: ['file1.ts', 'file2.ts'],
+      citation_url: null,
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EvidenceLogEntry,
+  Freshness,
+  PingArgs,
+  PingResult,
+  Reference,
+  StartSessionArgs,
+  StartSessionResult,
+} from './index.ts';
+
+describe('contracts surface', () => {
+  it('exports the v1 schema surface', () => {
+    expect(PingArgs).toBeDefined();
+    expect(PingResult).toBeDefined();
+    expect(Reference).toBeDefined();
+    expect(Freshness).toBeDefined();
+    expect(EvidenceLogEntry).toBeDefined();
+    expect(StartSessionArgs).toBeDefined();
+    expect(StartSessionResult).toBeDefined();
+  });
+});
+
+describe('PingResult', () => {
+  it('safeParses the v1 mcp-server ping response shape', () => {
+    const result = PingResult.safeParse({
+      ok: true,
+      version: '0.1.0',
+      uptime_s: 42,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        ok: true,
+        version: '0.1.0',
+        uptime_s: 42,
+      });
+    }
+  });
+
+  it('rejects negative uptime_s', () => {
+    const result = PingResult.safeParse({
+      ok: true,
+      version: '0.1.0',
+      uptime_s: -1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+
+const NonEmptyStringSchema = z.string().min(1);
+const IsoDatetimeSchema = z.string().datetime({ offset: true });
+
+type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+
+type JsonObject = { [key: string]: JsonValue };
+
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(z.string(), JsonValueSchema),
+  ]),
+);
+
+const JsonObjectSchema: z.ZodType<JsonObject> = z.record(z.string(), JsonValueSchema);
+
+export const PingArgs = z.object({}).strict();
+export type PingArgs = z.infer<typeof PingArgs>;
+
+export const PingResult = z
+  .object({
+    ok: z.literal(true),
+    version: NonEmptyStringSchema,
+    uptime_s: z.number().int().nonnegative(),
+  })
+  .strict();
+export type PingResult = z.infer<typeof PingResult>;
+
+export const Reference = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('url'),
+      url: z.string().url(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('canonical'),
+      integration: NonEmptyStringSchema,
+      id: NonEmptyStringSchema,
+    })
+    .strict(),
+]);
+export type Reference = z.infer<typeof Reference>;
+
+export const Freshness = z
+  .object({
+    integration: NonEmptyStringSchema,
+    last_polled_at: IsoDatetimeSchema.nullable(),
+    stale: z.boolean(),
+  })
+  .strict();
+export type Freshness = z.infer<typeof Freshness>;
+
+export const EvidenceLogEntry = z
+  .object({
+    id: NonEmptyStringSchema,
+    integration: NonEmptyStringSchema,
+    kind: NonEmptyStringSchema,
+    ref: Reference,
+    occurred_at: IsoDatetimeSchema,
+    payload_json: JsonObjectSchema,
+    citation_url: z.string().url().nullable(),
+  })
+  .strict();
+export type EvidenceLogEntry = z.infer<typeof EvidenceLogEntry>;
+
+export const StartSessionArgs = z
+  .object({
+    integrations: z.array(NonEmptyStringSchema).min(1).optional(),
+    max_items: z.number().int().positive().max(25).optional(),
+    force_refresh: z.boolean().optional(),
+  })
+  .strict();
+export type StartSessionArgs = z.infer<typeof StartSessionArgs>;
+
+const StartSessionItemSchema = z
+  .object({
+    ref: Reference,
+    priority: z.number().int().positive(),
+    title: NonEmptyStringSchema,
+    why: NonEmptyStringSchema,
+    evidence_ids: z.array(NonEmptyStringSchema).min(1),
+  })
+  .strict();
+
+export const StartSessionResult = z
+  .object({
+    items: z.array(StartSessionItemSchema),
+    evidence: z.array(EvidenceLogEntry),
+    freshness: z.array(Freshness),
+    generated_at: IsoDatetimeSchema,
+  })
+  .strict();
+export type StartSessionResult = z.infer<typeof StartSessionResult>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 
 const NonEmptyStringSchema = z.string().min(1);
-const IsoDatetimeSchema = z.string().datetime({ offset: true });
+const IsoDatetimeSchema = z.iso.datetime({ offset: true });
 
 type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
-
-type JsonObject = { [key: string]: JsonValue };
 
 const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
   z.union([
@@ -17,8 +15,6 @@ const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
     z.record(z.string(), JsonValueSchema),
   ]),
 );
-
-const JsonObjectSchema: z.ZodType<JsonObject> = z.record(z.string(), JsonValueSchema);
 
 export const PingArgs = z.object({}).strict();
 export type PingArgs = z.infer<typeof PingArgs>;
@@ -36,7 +32,7 @@ export const Reference = z.discriminatedUnion('kind', [
   z
     .object({
       kind: z.literal('url'),
-      url: z.string().url(),
+      url: z.url(),
     })
     .strict(),
   z
@@ -65,8 +61,8 @@ export const EvidenceLogEntry = z
     kind: NonEmptyStringSchema,
     ref: Reference,
     occurred_at: IsoDatetimeSchema,
-    payload_json: JsonObjectSchema,
-    citation_url: z.string().url().nullable(),
+    payload_json: JsonValueSchema,
+    citation_url: z.url().nullable(),
   })
   .strict();
 export type EvidenceLogEntry = z.infer<typeof EvidenceLogEntry>;

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,19 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@types/node@22.10.5)(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
+  packages/contracts:
+    dependencies:
+      zod:
+        specifier: 4.4.2
+        version: 4.4.2
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@22.10.5)(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
 packages:
 
   '@biomejs/biome@2.4.14':


### PR DESCRIPTION
## What this PR does

Scaffolds the `@slopweaver/contracts` leaf package with Zod schemas for the v1 MCP tool surface. This is the type spine the rest of the v1 packages depend on.

Schemas exported (per #19 acceptance):

- `PingArgs` / `PingResult` — locked to `{ ok, version, uptime_s }` for #21's mcp-server
- `Reference` — discriminated union of `{ kind: 'url' }` and `{ kind: 'canonical', integration, id }`
- `Freshness` — per-integration last-poll + stale flag
- `EvidenceLogEntry` — DB-row-shaped record (also aligns with #20)
- `StartSessionArgs` / `StartSessionResult` — flagship tool I/O for #12 / `start_session()`

Strict mode TS, named-object inputs, no `any`, no `unknown`. Pure Zod (ts-rest deferred until it pulls weight).

## Why

closes #19. Sequential precondition for #20 (db), #21 (mcp-server), #22 (mcp-local — the v1 MVP install milestone).

## Test plan

- [x] Tests added: `src/index.test.ts` covers (1) public-surface smoke for all 7 schemas and (2) `PingResult` happy + sad path via `safeParse`
- [x] `pnpm validate` green locally (format/lint/compile/test/knip — five gates per the public CI)
- [ ] CI green (will run when this PR is converted from draft)

## Breaking changes

None — new package.

## Notes for the reviewer

- The package stays source-first / `private: true` (matches `@slopweaver/cli-tools`); no build step, exports point at `src/index.ts`.
- `Reference` uses `integration` (not `platform`) to match repo language. If you'd prefer `platform`, easier to rename here than after `db` and `mcp-server` consume it.
- `priority` on `StartSessionItem` is a positive integer rank (1 = highest). If you want enum priorities (`high`/`medium`/`low`) instead, flag now before #20-22.
- `payload_json` uses a recursive `JsonObject` schema rather than `z.unknown()` — keeps the contract honest about what the DB will actually store.
- Pre-existing biome lint `infos` in `cli-tools/` (5 `useLiteralKeys` and a schema-version note) are intentionally **not** touched here per scope discipline; happy to file a separate cleanup issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched a new contracts package providing type-safe, validated schema definitions for API requests, responses, and data entities.

* **Tests**
  * Added comprehensive test coverage for schema validation, type safety, and data conformance scenarios.

* **Chores**
  * Configured package infrastructure with TypeScript support and automated testing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->