### PR TITLE
feat(mcp-server): scaffold @slopweaver/mcp-server with stdio transport + ping tool

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,36 @@
+# @slopweaver/mcp-server
+
+Framework-agnostic MCP server for SlopWeaver. Owns the tool registry, the
+builtin `ping` tool, and the stdio transport helper. Consumed as TypeScript
+source (`main: ./src/index.ts`); no build step.
+
+## API
+
+- `createMcpServer({ db, tools, version })` — registers each `Tool` against an
+  `@modelcontextprotocol/sdk` `McpServer` and returns it. Caller owns
+  lifecycle (transport connection, shutdown).
+- `createPingTool({ version, startedAtMs })` — builtin smoke-test tool.
+  Returns `{ ok: true, version, uptime_s }` per the `PingResult` contract.
+- `startStdio({ server })` — convenience wrapper that constructs a
+  `StdioServerTransport` and calls `server.connect()`. v1 ships stdio-only
+  per decision #11; HTTP/auth lands in v2 cloud-tier.
+- `Tool`, `ToolHandler`, `ToolHandlerContext` — registry types. A `Tool`
+  declares Zod input/output schemas (typically from `@slopweaver/contracts`)
+  and an async handler that receives the parsed input plus a context bag.
+
+## Scope
+
+- v1: stdio transport, builtin `ping`, registry surface for the composite
+  tools that land in subsequent PRs.
+- Out of scope here: composite tools (`start_session`, `catch_me_up`, …),
+  HTTP transport, OAuth/auth, integrations.
+
+## Development
+
+```bash
+pnpm --filter @slopweaver/mcp-server compile
+pnpm --filter @slopweaver/mcp-server test
+```
+
+The integration test pairs an `InMemoryTransport` with a real MCP `Client`,
+so it catches regressions in tool registration without spawning a process.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@slopweaver/mcp-server",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Framework-agnostic MCP server for SlopWeaver. Tool registry, builtin tools, stdio transport.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "compile": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@slopweaver/contracts": "workspace:*",
+    "@slopweaver/db": "workspace:*",
+    "zod": "4.4.2"
+  },
+  "devDependencies": {
+    "typescript": "6.0.3",
+    "vitest": "4.1.5"
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @slopweaver/mcp-server public entry.
+ *
+ * Re-exports the framework-agnostic surface: the server factory, the tool
+ * registry types, the builtin `ping` tool, and the stdio transport helper.
+ * Apps wire these together; packages don't import from apps.
+ */
+
+export { createMcpServer } from './server.ts';
+export type { CreateMcpServerArgs } from './server.ts';
+export { defineTool } from './tools/registry.ts';
+export type {
+  Tool,
+  ToolDefinition,
+  ToolHandler,
+  ToolHandlerArgs,
+  ToolHandlerContext,
+} from './tools/registry.ts';
+export { createPingTool } from './tools/builtin/ping.ts';
+export type { CreatePingToolArgs } from './tools/builtin/ping.ts';
+export { startStdio } from './transports/stdio.ts';
+export type { StartStdioArgs, StartStdioHandle } from './transports/stdio.ts';

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Integration test for the createMcpServer + ping wiring.
+ *
+ * Pairs an `InMemoryTransport` with a real MCP `Client`, registers the ping
+ * tool through the public registry surface, and asserts:
+ *   - the tool appears in `tools/list`,
+ *   - `tools/call` returns a `structuredContent` shape that matches the
+ *     `PingResult` contract.
+ *
+ * No process I/O, no stdio — the in-memory transport is the same MCP wire
+ * protocol so this catches schema regressions across the registry boundary.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { PingResult } from '@slopweaver/contracts';
+import { createDb } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createMcpServer } from './server.ts';
+import { createPingTool } from './tools/builtin/ping.ts';
+
+describe('createMcpServer + ping', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it('registers ping and returns the v1 PingResult shape over an in-memory transport', async () => {
+    // Arrange: deterministic uptime — startedAt 5s before now.
+    const now = 1_762_000_000_000;
+    const server = createMcpServer({
+      db: dbHandle.db,
+      version: '0.1.0',
+      tools: [createPingTool({ version: '0.1.0', startedAtMs: now - 5_000, now: () => now })],
+    });
+
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      // Assert: ping is advertised.
+      const list = await client.listTools();
+      const names = list.tools.map((t) => t.name);
+      expect(names).toContain('ping');
+
+      const pingTool = list.tools.find((t) => t.name === 'ping');
+      expect(pingTool?.description).toMatch(/smoke-test/i);
+      // The MCP protocol requires inputSchema to be a JSON Schema object.
+      expect(pingTool?.inputSchema.type).toBe('object');
+
+      // Assert: tools/call returns the PingResult contract shape.
+      const callResult = await client.callTool({ name: 'ping', arguments: {} });
+      expect(callResult.isError).toBeUndefined();
+
+      const parsed = PingResult.safeParse(callResult.structuredContent);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data).toEqual({ ok: true, version: '0.1.0', uptime_s: 5 });
+      }
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('returns an MCP error result for an unknown tool name', async () => {
+    const server = createMcpServer({
+      db: dbHandle.db,
+      version: '0.1.0',
+      tools: [createPingTool({ version: '0.1.0', startedAtMs: Date.now() })],
+    });
+
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      const result = await client.callTool({ name: 'does-not-exist', arguments: {} });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toMatch(/does-not-exist/);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -1,14 +1,10 @@
 /**
- * Integration test for the createMcpServer + ping wiring.
+ * Integration test for the createMcpServer + registry wiring.
  *
- * Pairs an `InMemoryTransport` with a real MCP `Client`, registers the ping
- * tool through the public registry surface, and asserts:
- *   - the tool appears in `tools/list`,
- *   - `tools/call` returns a `structuredContent` shape that matches the
- *     `PingResult` contract.
- *
- * No process I/O, no stdio — the in-memory transport is the same MCP wire
- * protocol so this catches schema regressions across the registry boundary.
+ * Pairs an `InMemoryTransport` with a real MCP `Client` so the assertions
+ * exercise the actual MCP wire protocol — `tools/list` schema discovery,
+ * `tools/call` round-trips, and SDK-level input validation. No process I/O,
+ * no stdio.
  */
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -16,8 +12,10 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { PingResult } from '@slopweaver/contracts';
 import { createDb } from '@slopweaver/db';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import { createMcpServer } from './server.ts';
 import { createPingTool } from './tools/builtin/ping.ts';
+import { defineTool, type Tool } from './tools/registry.ts';
 
 describe('createMcpServer + ping', () => {
   let dbHandle: ReturnType<typeof createDb>;
@@ -45,14 +43,13 @@ describe('createMcpServer + ping', () => {
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
 
     try {
-      // Assert: ping is advertised.
+      // Assert: ping is advertised with an object-shaped JSON-Schema input.
       const list = await client.listTools();
       const names = list.tools.map((t) => t.name);
       expect(names).toContain('ping');
 
       const pingTool = list.tools.find((t) => t.name === 'ping');
       expect(pingTool?.description).toMatch(/smoke-test/i);
-      // The MCP protocol requires inputSchema to be a JSON Schema object.
       expect(pingTool?.inputSchema.type).toBe('object');
 
       // Assert: tools/call returns the PingResult contract shape.
@@ -64,6 +61,106 @@ describe('createMcpServer + ping', () => {
       if (parsed.success) {
         expect(parsed.data).toEqual({ ok: true, version: '0.1.0', uptime_s: 5 });
       }
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('publishes input/output schema keys via tools/list (regression for ZodObject constraint)', async () => {
+    // A tool with non-trivial input + output object schemas must round-trip
+    // its property keys through tools/list — otherwise MCP clients can't
+    // discover argument shapes. This pins the registry's ZodObject contract.
+    const echoTool = defineTool({
+      name: 'echo',
+      description: 'Returns the message and a length.',
+      inputSchema: z.object({ message: z.string().min(1) }).strict(),
+      outputSchema: z
+        .object({ message: z.string(), length: z.number().int().nonnegative() })
+        .strict(),
+      handler: async ({ input }) => ({ message: input.message, length: input.message.length }),
+    });
+
+    const server = createMcpServer({
+      db: dbHandle.db,
+      version: '0.1.0',
+      tools: [echoTool],
+    });
+
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      const list = await client.listTools();
+      const echo = list.tools.find((t) => t.name === 'echo');
+
+      expect(echo).toBeDefined();
+      expect(echo?.inputSchema.type).toBe('object');
+      expect(Object.keys(echo?.inputSchema.properties ?? {})).toContain('message');
+      expect(echo?.inputSchema.required).toContain('message');
+
+      expect(echo?.outputSchema?.type).toBe('object');
+      expect(Object.keys(echo?.outputSchema?.properties ?? {})).toEqual(
+        expect.arrayContaining(['message', 'length']),
+      );
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('rejects invalid tool input at the SDK boundary without invoking the handler', async () => {
+    // The defineTool soundness argument depends on McpServer validating
+    // input against inputSchema *before* calling the handler. If that
+    // invariant breaks, the handler runs on unvalidated data — exactly the
+    // hole the type erasure assumes the SDK will plug.
+    let handlerCalled = 0;
+
+    const requireNameTool: Tool = defineTool({
+      name: 'require-name',
+      description: 'Test tool that requires a non-empty `name` field.',
+      inputSchema: z.object({ name: z.string().min(1) }).strict(),
+      outputSchema: z.object({ greeting: z.string() }).strict(),
+      handler: async ({ input }) => {
+        handlerCalled += 1;
+        return { greeting: `hello, ${input.name}` };
+      },
+    });
+
+    const server = createMcpServer({
+      db: dbHandle.db,
+      version: '0.1.0',
+      tools: [requireNameTool],
+    });
+
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      // Missing required `name`.
+      const missing = await client.callTool({ name: 'require-name', arguments: {} });
+      expect(missing.isError).toBe(true);
+      expect(handlerCalled).toBe(0);
+
+      // Wrong type for `name`.
+      const wrongType = await client.callTool({
+        name: 'require-name',
+        arguments: { name: 42 } as unknown as Record<string, unknown>,
+      });
+      expect(wrongType.isError).toBe(true);
+      expect(handlerCalled).toBe(0);
+
+      // Sanity-check: a valid call DOES invoke the handler.
+      const ok = await client.callTool({
+        name: 'require-name',
+        arguments: { name: 'world' },
+      });
+      expect(ok.isError).toBeUndefined();
+      expect(handlerCalled).toBe(1);
     } finally {
       await client.close();
       await server.close();

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,0 +1,47 @@
+/**
+ * `createMcpServer` — wires the SlopWeaver tool registry onto an MCP SDK
+ * `McpServer`. Returns the high-level wrapper; advanced consumers can reach
+ * the underlying `Server` via `result.server`.
+ *
+ * The function is transport-agnostic: callers attach a transport via
+ * {@link startStdio} (or by calling `result.connect(transport)` themselves).
+ * The app layer owns lifecycle so that `createMcpServer` can be exercised
+ * from in-memory tests without spawning a child process.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SlopweaverDatabase } from '@slopweaver/db';
+import type { Tool } from './tools/registry.ts';
+
+export type CreateMcpServerArgs = {
+  db: SlopweaverDatabase;
+  tools: ReadonlyArray<Tool>;
+  /** Server version string advertised to clients and reachable via the `ping` tool. */
+  version: string;
+};
+
+const SERVER_NAME = 'slopweaver';
+
+export function createMcpServer({ db, tools, version }: CreateMcpServerArgs): McpServer {
+  const server = new McpServer({ name: SERVER_NAME, version }, { capabilities: { tools: {} } });
+
+  for (const tool of tools) {
+    server.registerTool(
+      tool.name,
+      {
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        outputSchema: tool.outputSchema,
+      },
+      async (input: unknown) => {
+        const output = await tool.handler({ input, ctx: { db } });
+        return {
+          structuredContent: output as Record<string, unknown>,
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+        };
+      },
+    );
+  }
+
+  return server;
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,12 +1,13 @@
 /**
  * `createMcpServer` — wires the SlopWeaver tool registry onto an MCP SDK
- * `McpServer`. Returns the high-level wrapper; advanced consumers can reach
- * the underlying `Server` via `result.server`.
+ * `McpServer` and returns it directly. Advanced consumers can reach the
+ * underlying low-level `Server` via the returned instance's `.server`
+ * property.
  *
  * The function is transport-agnostic: callers attach a transport via
- * {@link startStdio} (or by calling `result.connect(transport)` themselves).
- * The app layer owns lifecycle so that `createMcpServer` can be exercised
- * from in-memory tests without spawning a child process.
+ * {@link startStdio} or by calling `.connect(transport)` on the returned
+ * server themselves. The app layer owns lifecycle so that `createMcpServer`
+ * can be exercised from in-memory tests without spawning a child process.
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';

--- a/packages/mcp-server/src/tools/builtin/ping.ts
+++ b/packages/mcp-server/src/tools/builtin/ping.ts
@@ -1,0 +1,38 @@
+/**
+ * Builtin `ping` tool: the smoke-test surface for the MCP server. Returns the
+ * server's reported version and process uptime in seconds. Useful for health
+ * checks from MCP clients and for verifying the registry/transport wiring in
+ * tests.
+ */
+
+import { PingArgs, PingResult } from '@slopweaver/contracts';
+import { defineTool, type Tool } from '../registry.ts';
+
+export type CreatePingToolArgs = {
+  /** Server version string surfaced in the response. */
+  version: string;
+  /**
+   * `performance.now()`-style monotonic millisecond timestamp captured when
+   * the server was created. Injected so tests can pin uptime deterministically.
+   */
+  startedAtMs: number;
+  /** Clock used to compute uptime; defaults to `Date.now`. */
+  now?: () => number;
+};
+
+export function createPingTool({ version, startedAtMs, now = Date.now }: CreatePingToolArgs): Tool {
+  return defineTool({
+    name: 'ping',
+    description: 'Smoke-test tool. Returns the server version and uptime in whole seconds.',
+    inputSchema: PingArgs,
+    outputSchema: PingResult,
+    handler: async () => {
+      const elapsedMs = Math.max(0, now() - startedAtMs);
+      return {
+        ok: true,
+        version,
+        uptime_s: Math.floor(elapsedMs / 1000),
+      };
+    },
+  });
+}

--- a/packages/mcp-server/src/tools/builtin/ping.ts
+++ b/packages/mcp-server/src/tools/builtin/ping.ts
@@ -12,11 +12,16 @@ export type CreatePingToolArgs = {
   /** Server version string surfaced in the response. */
   version: string;
   /**
-   * `performance.now()`-style monotonic millisecond timestamp captured when
-   * the server was created. Injected so tests can pin uptime deterministically.
+   * Wall-clock millisecond timestamp (Unix epoch, as returned by
+   * `Date.now()`) captured when the server started. Must share a clock
+   * domain with `now`; mixing `Date.now()` with `performance.now()` produces
+   * nonsense uptime values.
    */
   startedAtMs: number;
-  /** Clock used to compute uptime; defaults to `Date.now`. */
+  /**
+   * Clock used to compute uptime. Must share a domain with `startedAtMs`.
+   * Defaults to `Date.now`. Injected so tests can pin uptime deterministically.
+   */
   now?: () => number;
 };
 
@@ -29,7 +34,7 @@ export function createPingTool({ version, startedAtMs, now = Date.now }: CreateP
     handler: async () => {
       const elapsedMs = Math.max(0, now() - startedAtMs);
       return {
-        ok: true,
+        ok: true as const,
         version,
         uptime_s: Math.floor(elapsedMs / 1000),
       };

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -1,0 +1,63 @@
+/**
+ * Tool registry types.
+ *
+ * Authors call {@link defineTool} with strongly-typed Zod schemas (typically
+ * imported from `@slopweaver/contracts`) and an async handler. The helper
+ * returns a type-erased {@link Tool} so heterogeneous tools share a single
+ * `ReadonlyArray<Tool>` storage type. Type erasure is sound because
+ * `McpServer` validates input against `inputSchema` before invoking the
+ * handler — the cast inside `defineTool` only affects compile time.
+ */
+
+import type { z } from 'zod';
+import type { SlopweaverDatabase } from '@slopweaver/db';
+
+/**
+ * Per-call context handed to every tool handler. v1 only carries the Drizzle
+ * database handle; later iterations will add an integration registry, an
+ * evidence-log writer, etc.
+ */
+export type ToolHandlerContext = {
+  db: SlopweaverDatabase;
+};
+
+export type ToolHandlerArgs<TInput> = {
+  input: TInput;
+  ctx: ToolHandlerContext;
+};
+
+export type ToolHandler<TInput, TOutput> = (args: ToolHandlerArgs<TInput>) => Promise<TOutput>;
+
+/** Author-facing tool spec; `defineTool` converts this into a {@link Tool}. */
+export type ToolDefinition<TInput, TOutput extends Record<string, unknown>> = {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: z.ZodType<TInput>;
+  readonly outputSchema: z.ZodType<TOutput>;
+  readonly handler: ToolHandler<TInput, TOutput>;
+};
+
+/**
+ * Storage-level tool type. Generics are erased so `ReadonlyArray<Tool>` is
+ * variance-safe. `outputSchema` keeps `Record<string, unknown>` because
+ * MCP's `CallToolResult.structuredContent` is a JSON object.
+ */
+export type Tool = {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: z.ZodType<unknown>;
+  readonly outputSchema: z.ZodType<Record<string, unknown>>;
+  readonly handler: ToolHandler<unknown, Record<string, unknown>>;
+};
+
+export function defineTool<TInput, TOutput extends Record<string, unknown>>(
+  definition: ToolDefinition<TInput, TOutput>,
+): Tool {
+  return {
+    name: definition.name,
+    description: definition.description,
+    inputSchema: definition.inputSchema as z.ZodType<unknown>,
+    outputSchema: definition.outputSchema as z.ZodType<Record<string, unknown>>,
+    handler: definition.handler as ToolHandler<unknown, Record<string, unknown>>,
+  };
+}

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -1,12 +1,18 @@
 /**
  * Tool registry types.
  *
- * Authors call {@link defineTool} with strongly-typed Zod schemas (typically
- * imported from `@slopweaver/contracts`) and an async handler. The helper
- * returns a type-erased {@link Tool} so heterogeneous tools share a single
- * `ReadonlyArray<Tool>` storage type. Type erasure is sound because
+ * Authors call {@link defineTool} with strongly-typed Zod object schemas
+ * (typically imported from `@slopweaver/contracts`) and an async handler.
+ * The helper returns a type-erased {@link Tool} so heterogeneous tools share
+ * a single `ReadonlyArray<Tool>` storage type. Type erasure is sound because
  * `McpServer` validates input against `inputSchema` before invoking the
  * handler — the cast inside `defineTool` only affects compile time.
+ *
+ * Both schemas are constrained to `z.ZodObject`. The MCP wire protocol
+ * publishes `inputSchema` / `outputSchema` as JSON-Schema objects via
+ * `tools/list`; non-object Zod schemas (effects, transforms, unions) round-
+ * trip as `{}` and break client discovery, so we reject them at the type
+ * boundary.
  */
 
 import type { z } from 'zod';
@@ -29,35 +35,35 @@ export type ToolHandlerArgs<TInput> = {
 export type ToolHandler<TInput, TOutput> = (args: ToolHandlerArgs<TInput>) => Promise<TOutput>;
 
 /** Author-facing tool spec; `defineTool` converts this into a {@link Tool}. */
-export type ToolDefinition<TInput, TOutput extends Record<string, unknown>> = {
+export type ToolDefinition<TInputSchema extends z.ZodObject, TOutputSchema extends z.ZodObject> = {
   readonly name: string;
   readonly description: string;
-  readonly inputSchema: z.ZodType<TInput>;
-  readonly outputSchema: z.ZodType<TOutput>;
-  readonly handler: ToolHandler<TInput, TOutput>;
+  readonly inputSchema: TInputSchema;
+  readonly outputSchema: TOutputSchema;
+  readonly handler: ToolHandler<z.infer<TInputSchema>, z.infer<TOutputSchema>>;
 };
 
 /**
  * Storage-level tool type. Generics are erased so `ReadonlyArray<Tool>` is
- * variance-safe. `outputSchema` keeps `Record<string, unknown>` because
- * MCP's `CallToolResult.structuredContent` is a JSON object.
+ * variance-safe. Both schemas remain `z.ZodObject` so the protocol-level
+ * invariant survives the erasure.
  */
 export type Tool = {
   readonly name: string;
   readonly description: string;
-  readonly inputSchema: z.ZodType<unknown>;
-  readonly outputSchema: z.ZodType<Record<string, unknown>>;
+  readonly inputSchema: z.ZodObject;
+  readonly outputSchema: z.ZodObject;
   readonly handler: ToolHandler<unknown, Record<string, unknown>>;
 };
 
-export function defineTool<TInput, TOutput extends Record<string, unknown>>(
-  definition: ToolDefinition<TInput, TOutput>,
+export function defineTool<TInputSchema extends z.ZodObject, TOutputSchema extends z.ZodObject>(
+  definition: ToolDefinition<TInputSchema, TOutputSchema>,
 ): Tool {
   return {
     name: definition.name,
     description: definition.description,
-    inputSchema: definition.inputSchema as z.ZodType<unknown>,
-    outputSchema: definition.outputSchema as z.ZodType<Record<string, unknown>>,
+    inputSchema: definition.inputSchema,
+    outputSchema: definition.outputSchema,
     handler: definition.handler as ToolHandler<unknown, Record<string, unknown>>,
   };
 }

--- a/packages/mcp-server/src/transports/stdio.ts
+++ b/packages/mcp-server/src/transports/stdio.ts
@@ -1,0 +1,27 @@
+/**
+ * Stdio transport wiring.
+ *
+ * v1 ships stdio-only (per decision #11): no HTTP, no auth. The app layer
+ * (apps/mcp-local) calls `startStdio({ server })` after constructing the
+ * server with `createMcpServer`. Lifecycle ownership stays with the app so
+ * that signal handling, graceful shutdown, and process exit codes are not
+ * baked into a shared package.
+ */
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export type StartStdioArgs = {
+  server: McpServer;
+};
+
+export type StartStdioHandle = {
+  /** The stdio transport bound to the server. Exposed for tests and graceful shutdown. */
+  transport: StdioServerTransport;
+};
+
+export async function startStdio({ server }: StartStdioArgs): Promise<StartStdioHandle> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  return { transport };
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,28 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@types/node@22.10.5)(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
+  packages/mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.2)
+      '@slopweaver/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      '@slopweaver/db':
+        specifier: workspace:*
+        version: link:../db
+      zod:
+        specifier: 4.4.2
+        version: 4.4.2
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@22.10.5)(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
 packages:
 
   '@biomejs/biome@2.4.14':
@@ -646,6 +668,12 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -802,6 +830,16 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1209,6 +1247,10 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1219,8 +1261,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1247,6 +1300,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -1261,9 +1318,21 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1290,8 +1359,28 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1324,6 +1413,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1425,8 +1518,23 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
@@ -1434,6 +1542,10 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -1449,6 +1561,9 @@ packages:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1529,6 +1644,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -1536,6 +1663,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1551,6 +1688,9 @@ packages:
 
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -1578,6 +1718,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1594,6 +1738,14 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -1605,6 +1757,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
@@ -1615,6 +1775,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
@@ -1624,9 +1788,21 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  hono@4.12.16:
+    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1649,6 +1825,14 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
@@ -1665,6 +1849,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1672,11 +1859,20 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1770,9 +1966,29 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1806,6 +2022,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -1813,8 +2033,20 @@ packages:
     resolution: {integrity: sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==}
     engines: {node: '>=10'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1838,6 +2070,10 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1848,6 +2084,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1863,6 +2102,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1877,12 +2120,28 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1891,6 +2150,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -1905,6 +2168,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1916,6 +2183,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1923,6 +2201,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1954,6 +2248,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -2003,6 +2301,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2022,6 +2324,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -2039,11 +2345,19 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -2161,6 +2475,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.4.2:
     resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
@@ -2507,6 +2826,10 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@hono/node-server@1.19.14(hono@4.12.16)':
+    dependencies:
+      hono: 4.12.16
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2643,6 +2966,28 @@ snapshots:
       '@types/node': 22.10.5
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.2)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.16)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.16
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.2
+      zod-to-json-schema: 3.25.2(zod@4.4.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2927,11 +3272,20 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:
@@ -2939,6 +3293,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-styles@4.3.0:
     dependencies:
@@ -2965,6 +3326,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -2980,7 +3355,19 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bytes@3.1.2: {}
+
   cac@7.0.0: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@6.2.2: {}
 
@@ -3001,7 +3388,20 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3025,6 +3425,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2: {}
 
   drizzle-kit@0.31.10:
@@ -3039,13 +3441,29 @@ snapshots:
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.2.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -3129,6 +3547,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3234,9 +3654,55 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -3249,6 +3715,8 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
+
+  fast-uri@3.1.0: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -3272,6 +3740,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -3288,12 +3767,34 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -3304,6 +3805,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  gopd@1.2.0: {}
 
   handlebars@4.7.9:
     dependencies:
@@ -3316,9 +3819,21 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.12.16: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   iconv-lite@0.7.2:
     dependencies:
@@ -3334,6 +3849,10 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.3
@@ -3346,13 +3865,21 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-promise@4.0.0: {}
+
   isexe@2.0.0: {}
 
   jiti@2.6.1: {}
 
+  jose@6.2.3: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -3442,10 +3969,22 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-response@3.1.0: {}
 
@@ -3467,13 +4006,23 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   node-abi@3.90.0:
     dependencies:
       semver: 7.7.4
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -3547,11 +4096,15 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -3560,6 +4113,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.13:
     dependencies:
@@ -3584,12 +4139,30 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -3603,6 +4176,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3634,17 +4209,82 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3670,6 +4310,8 @@ snapshots:
   source-map@0.6.1: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -3717,6 +4359,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -3744,6 +4388,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@6.0.3: {}
 
   uglify-js@3.19.3:
@@ -3753,11 +4403,15 @@ snapshots:
 
   undici-types@6.20.0: {}
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
@@ -3821,5 +4475,9 @@ snapshots:
   yaml@2.8.4: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.2):
+    dependencies:
+      zod: 4.4.2
 
   zod@4.4.2: {}


### PR DESCRIPTION
## What this PR does

Scaffolds `packages/mcp-server/` — the framework-agnostic MCP server. It
ships v1's stdio transport, a typed tool registry, the builtin `ping` tool,
and a Vitest test that exercises the wiring through an in-memory MCP
transport.

## Why

closes #21. Sequential precondition for #22 (the `apps/mcp-local` binary
that wires this package into the published `slopweaver` CLI). Stdio-only,
no auth, per decision #11.

## What's in the package

- `src/server.ts` — `createMcpServer({ db, tools, version })` returns a
  configured `McpServer` from `@modelcontextprotocol/sdk@1.29.0` (v1.x line
  per the issue, not the pre-alpha v2 `main`). Each `Tool` is registered via
  the SDK's `registerTool` so input/output validation and JSON-Schema
  generation happen in the SDK.
- `src/tools/registry.ts` — `Tool` storage type plus `defineTool<TInput,
  TOutput>` for authors. The split exists because TypeScript variance forbids
  storing `Tool<PingArgs, PingResult>` inside `ReadonlyArray<Tool<unknown,
  unknown>>` directly; `defineTool` keeps strong types at the call site and
  erases generics at storage. Casts are sound because the SDK validates
  input against `inputSchema` before invoking the handler.
- `src/tools/builtin/ping.ts` — `createPingTool({ version, startedAtMs,
  now? })` returns the smoke-test tool wired to `PingArgs` / `PingResult`
  from `@slopweaver/contracts`. The `now` injection lets the test pin uptime
  deterministically.
- `src/transports/stdio.ts` — `startStdio({ server })` constructs a
  `StdioServerTransport` and connects it. Lifecycle (signals, exit codes)
  stays with the app layer.
- `src/server.test.ts` — pairs an `InMemoryTransport` with a real MCP
  `Client`, asserts `ping` is advertised under `tools/list`, and round-trips
  a `tools/call` whose `structuredContent` validates against the
  `PingResult` contract. A second case asserts that an unknown tool name
  comes back with `isError: true`.

## Test plan

Run from this branch:

- [x] `pnpm format:check` — green
- [x] `pnpm lint` — green
- [x] `pnpm compile` — green
- [x] `pnpm test` — green (2 new tests in `@slopweaver/mcp-server`, all
  prior packages still passing)
- [x] `pnpm knip` — green (no unused exports)

`pnpm validate` runs all five gates in sequence and is also green.

## Breaking changes

None. New package; no existing consumers.

## Notes for the reviewer

- **`Server` vs `McpServer`** — the issue says "configured MCP `Server`
  instance". I used the SDK's high-level `McpServer` because it owns
  validation, JSON-Schema conversion, and tool error wrapping that we'd
  otherwise reimplement on top of the lower-level `Server`. `McpServer.server`
  exposes the underlying `Server` for advanced consumers. Easy to flip the
  return type if you'd rather it return `Server` literally.
- **Tool type erasure** — see `defineTool` rationale above. The alternative
  was relaxing storage to `Tool<any, any>`, which CLAUDE.md disallows.
- **Output schema not in the issue criteria** — the issue lists `inputSchema`
  + handler. I added `outputSchema` because the SDK validates
  `structuredContent` against it; dropping it would mean unvalidated tool
  output. Happy to remove if you'd rather defer until composite tools land.
- **No HTTP / no auth** — per #11. The SDK still pulls `express` and
  friends as transitive deps, but nothing in this package imports them;
  `apps/mcp-local` will only call `startStdio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New MCP server package for registering tools, running via stdio, and a builtin ping health tool.
* **Tests**
  * Integration tests for tool listing, calling, schema round-trips, and SDK-side input validation.
* **Documentation**
  * Package README documenting API surface, usage, and local development.
* **Chores**
  * Build/test config and npm scripts for local development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->