### PR TITLE
feat(integrations): packages/integrations/slack polling for mentions/DMs

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -56,6 +56,19 @@ All five gates must pass. CI also runs `gitleaks detect` as a sixth gate; the pr
 
 If you change formatting, run `pnpm format` (no `:check`) to auto-fix, then re-run `validate` to verify.
 
+## Tests live next to source
+
+Tests are co-located with source as `<name>.test.ts`. No `__tests__/` directories, no `unit/component/integration/e2e` subtrees — that ceremony is in `slopweaver-private` because it has hundreds of integration tests against real platform APIs; this repo doesn't (yet).
+
+When a test class needs to be filtered separately (e.g. cassette-replay tests that hit the network on `POLLY_MODE=record`, or smoke tests that spawn a process), tag the file with a suffix:
+
+- `<name>.smoke.test.ts` — exercises a real binary or process; slow.
+- `<name>.cassette.test.ts` — replays Polly cassettes; offline-but-disk-bound.
+
+Vitest's `include` pattern in each package's `vitest.config.ts` decides which run. Do not introduce these suffixes pre-emptively; add the tag the first time you actually need to filter.
+
+Shared per-package test helpers go in `src/test/` (e.g. `packages/integrations/slack/src/test/db.ts`, `setup-polly.ts`). Cassette fixtures go under `src/__recordings__/`. Both are package-local — there is no cross-package test-helpers package.
+
 ## Decisions live in GitHub Issues
 
 Significant design decisions (architecture, tradeoffs, naming, scope cuts) get filed as GitHub Issues with the `decision-record` label. The discussion happens in issue comments. The closing comment captures the resolution.

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ coverage/
 *.har
 # Allow committed Polly cassettes (scrubbed) for github integration tests
 !packages/integrations/github/**/__recordings__/**/*.har
+# Allow committed Polly cassettes (scrubbed) for slack integration tests
+!packages/integrations/slack/**/__recordings__/**/*.har
 
 # Logs
 *.log

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ export default [
       'boundaries/elements': [
         { type: 'app', pattern: 'apps/*' },
         { type: 'package', pattern: 'packages/*' },
+        { type: 'package', pattern: 'packages/integrations/*' },
       ],
     },
     rules: {

--- a/packages/integrations/core/README.md
+++ b/packages/integrations/core/README.md
@@ -1,0 +1,20 @@
+# @slopweaver/integrations-core
+
+Shared building blocks for SlopWeaver integration packages.
+
+## What's here
+
+- **`upsertEvidence` / `markPollStarted` / `markPollCompleted` / `readCursor`** — write helpers for `evidence_log` and `integration_state`. Generic over `integration: string`. Every integration package's poll functions delegate to these.
+- **`definePollySetup({ extraRedactors?, extraRequestRewriter? })`** (re-exported from `./test-setup/polly`) — the Polly + nock + node-fetch cassette plumbing. Each integration package's vitest setup file is a 5-line call into this factory; package-specific concerns (e.g. github's `/user` PII placeholders, slack's message-text scrubbing) plug in via `extraRedactors`.
+
+The factory pattern keeps the integration packages free of HTTP-mocking ceremony while still letting them extend the redactor pipeline for platform-specific PII.
+
+## Why this package exists
+
+When `@slopweaver/integrations-github` (#33) and `@slopweaver/integrations-slack` (#31) shipped, both copied the upsert helpers and the 280-line setup-polly module. Two consumers is enough to justify extracting. Future integrations (linear, jira, notion, …) depend on the same surface.
+
+## Out of scope (today)
+
+- Domain-specific shapes that don't generalize — kind prefixing, permalink derivation, paginator strategy. Each platform ships its own.
+- `WebClient` / `Octokit` factory wrappers — token + retry policy is per-platform.
+- Cassette redaction *content* — only the redaction *machinery* lives here. Each platform ships its own scrubbers.

--- a/packages/integrations/core/package.json
+++ b/packages/integrations/core/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@slopweaver/integrations-github",
+  "name": "@slopweaver/integrations-core",
   "version": "0.0.0",
   "private": false,
-  "description": "GitHub polling integration for SlopWeaver. Writes PRs, issues, mentions into evidence_log and the authenticated identity into identity_graph.",
+  "description": "Shared building blocks for SlopWeaver integration packages: evidence_log + integration_state upsert helpers, and the Polly cassette setup.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
@@ -11,6 +11,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./test-setup/polly": {
+      "types": "./dist/test-setup/polly.d.ts",
+      "import": "./dist/test-setup/polly.js"
     }
   },
   "files": [
@@ -27,15 +31,16 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@octokit/plugin-throttling": "11.0.3",
-    "@octokit/request-error": "7.1.0",
-    "@octokit/rest": "22.0.1",
+    "@pollyjs/adapter-node-http": "6.0.6",
+    "@pollyjs/core": "6.0.6",
+    "@pollyjs/persister-fs": "6.0.6",
     "@slopweaver/db": "workspace:*",
-    "@slopweaver/integrations-core": "workspace:*",
-    "drizzle-orm": "0.45.2"
+    "drizzle-orm": "0.45.2",
+    "nock": "13.5.6",
+    "node-fetch": "3.3.2",
+    "vitest": "4.1.5"
   },
   "devDependencies": {
-    "typescript": "6.0.3",
-    "vitest": "4.1.5"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/integrations/core/src/index.ts
+++ b/packages/integrations/core/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @slopweaver/integrations-core public entry.
+ *
+ * Re-exports the shared upsert helpers. The Polly cassette setup is exposed
+ * via the dedicated `@slopweaver/integrations-core/test-setup/polly` subpath
+ * (declared in `package.json` `exports`) so non-test consumers don't pull
+ * the polly + nock + node-fetch dependency tree at runtime.
+ */
+
+export {
+  markPollCompleted,
+  markPollStarted,
+  readCursor,
+  upsertEvidence,
+  type UpsertEvidenceArgs,
+} from './upsert.ts';

--- a/packages/integrations/core/src/test-setup/polly.ts
+++ b/packages/integrations/core/src/test-setup/polly.ts
@@ -1,0 +1,413 @@
+/**
+ * Polly cassette plumbing shared across SlopWeaver integration packages.
+ *
+ * Each package's vitest setup file is a 5-line call into `definePollySetup`.
+ * Package-specific concerns (PII placeholders, request rewriting, additional
+ * redactors) plug in via the `extraRedactors` and `extraRequestRewriter`
+ * options.
+ *
+ * Wired via `vitest.config.ts` `setupFiles`. Each test gets its own cassette
+ * under `<test-file-dir>/__recordings__/<suite>/<test>/recording.har`.
+ *
+ * Modes (POLLY_MODE env):
+ *   - replay (default): read from cassette; missing cassette → test fails
+ *   - record: hit live API, write cassette (requires platform token)
+ *   - passthrough: skip Polly entirely (debug only)
+ *
+ * Native `fetch` (undici) bypasses Polly's node-http adapter, so we replace
+ * `globalThis.fetch` with `node-fetch` at load time. node-fetch routes through
+ * the http module where Polly intercepts. Restored in `afterAll`.
+ *
+ * `nock.disableNetConnect()` is a defense-in-depth net guard — any HTTP call
+ * that slips past Polly fails immediately instead of silently hitting live APIs.
+ *
+ * Header/body redaction runs at `beforePersist`, so cassettes never contain
+ * raw `Authorization: Bearer …` tokens even when recorded locally.
+ *
+ * Adapted from the SaaS repo's test setup, with SSE / Linear / Anthropic
+ * specifics removed.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { brotliDecompressSync, gunzipSync, inflateSync } from 'node:zlib';
+import NodeHttpAdapter from '@pollyjs/adapter-node-http';
+import { Polly, type PollyConfig } from '@pollyjs/core';
+import FSPersister from '@pollyjs/persister-fs';
+import nock from 'nock';
+import { afterAll, afterEach, beforeEach } from 'vitest';
+
+export type RedactableHeader = { name: string; value?: string };
+export type RedactableCookie = { name: string; value?: string };
+
+type RecordingContent = { encoding?: string; size?: number; text?: string };
+
+/**
+ * Recording shape the redactor hooks receive. Loose by design — Polly's own
+ * types are too strict against the runtime payload, and integration packages
+ * only need to mutate `request` / `response` in well-defined places.
+ */
+export type PollyRecording = {
+  request?: {
+    url?: string;
+    headers?: RedactableHeader[];
+    cookies?: RedactableCookie[];
+    postData?: { text?: string };
+  };
+  response?: {
+    headers?: RedactableHeader[];
+    cookies?: RedactableCookie[];
+    content?: RecordingContent;
+  };
+};
+
+export type ExtraRedactor = (recording: PollyRecording) => void;
+
+export type DefinePollySetupArgs = {
+  /**
+   * Per-package redactors run after the default header/cookie/token-string
+   * redaction. Use these to scrub platform-specific PII (display names,
+   * channel names, message bodies, etc.) before cassette persistence.
+   */
+  extraRedactors?: ExtraRedactor[];
+  /**
+   * Per-package request URL rewriter applied only in record mode. The github
+   * package uses this to scope `/search/issues` queries to a public repo so
+   * even an over-scoped PAT can only return public data.
+   */
+  extraRequestRewriter?: (urlString: string) => string;
+};
+
+const DEFAULT_REDACT_HEADER_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-github-request-id',
+  'github-authentication-token-expiration',
+]);
+const REDACT_KEY_REGEX = /token|secret|authorization|password|api[-_]?key/i;
+// Matches GitHub PATs (gh{p,o,u,s,r}_…), Slack tokens (xox{a,b,p,o,r,e,d,s}-…).
+const REDACT_VALUE_REGEX = /(gh[pousr]_[A-Za-z0-9]{16,}|xox[aboprdes]-[A-Za-z0-9-]{8,})/g;
+
+function loadDotEnvFromMonorepoRoot(): void {
+  try {
+    // /packages/integrations/core/src/test-setup/polly.ts → ../../../../../.env
+    const envPath = fileURLToPath(new URL('../../../../../.env', import.meta.url));
+    const envContent = readFileSync(envPath, 'utf8');
+    for (const rawLine of envContent.split('\n')) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const eqIdx = line.indexOf('=');
+      if (eqIdx < 0) continue;
+      const key = line.slice(0, eqIdx).trim();
+      const value = line
+        .slice(eqIdx + 1)
+        .trim()
+        .replace(/^['"]|['"]$/g, '');
+      if (process.env[key] === undefined) {
+        process.env[key] = value;
+      }
+    }
+  } catch {
+    // .env doesn't exist — fine for replay mode.
+  }
+}
+
+function redactHeaders({
+  headers,
+}: {
+  headers?: RedactableHeader[] | undefined;
+}): RedactableHeader[] {
+  if (!headers) return [];
+  return headers.filter((h) => !DEFAULT_REDACT_HEADER_NAMES.has(h.name.toLowerCase()));
+}
+
+function redactCookies({
+  cookies,
+}: {
+  cookies?: RedactableCookie[] | undefined;
+}): RedactableCookie[] {
+  if (!cookies) return [];
+  return cookies.map((c) => ({ ...c, value: '[REDACTED]' }));
+}
+
+export function redactJsonValue({ value }: { value: unknown }): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactJsonValue({ value: entry }));
+  }
+  if (value && typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      output[k] = REDACT_KEY_REGEX.test(k) ? '[REDACTED]' : redactJsonValue({ value: v });
+    }
+    return output;
+  }
+  if (typeof value === 'string') {
+    return value.replace(REDACT_VALUE_REGEX, '[REDACTED-TOKEN]');
+  }
+  return value;
+}
+
+function redactDefaultText({ text }: { text: string }): string {
+  const trimmed = text.trim();
+  if (!trimmed) return text;
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      return JSON.stringify(redactJsonValue({ value: JSON.parse(trimmed) }));
+    } catch {
+      // fall through
+    }
+  }
+  return text.replace(REDACT_VALUE_REGEX, '[REDACTED-TOKEN]');
+}
+
+/**
+ * Polly stores compressed-binary response bodies as base64 (sometimes
+ * wrapped in a JSON-array of chunks). When the recording SDK is axios-based
+ * (e.g. @slack/web-api), it sends `accept-encoding: gzip,br` regardless of
+ * any fetch override we install, so responses arrive compressed and Polly
+ * persists them as base64.
+ *
+ * `decompressIfNeeded` flattens that into plain text in-place: decode base64
+ * → gunzip / brotli / inflate based on the `content-encoding` header → store
+ * the plain text in `content.text`, drop `content.encoding`, strip the
+ * content-encoding header so the patched adapter doesn't try to double-
+ * decompress on replay (see /patches/@pollyjs__adapter-node-http@…).
+ *
+ * Crucially this runs BEFORE the per-package redactors so PII scrubbers see
+ * plain JSON and can do their job.
+ */
+function decompressBase64Body({ content }: { content: RecordingContent }): Buffer | null {
+  if (content.encoding !== 'base64' || typeof content.text !== 'string') return null;
+  const trimmed = content.text.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('[')) {
+    try {
+      const parts: unknown = JSON.parse(trimmed);
+      if (Array.isArray(parts) && parts.every((p) => typeof p === 'string')) {
+        return Buffer.concat(parts.map((p) => Buffer.from(p as string, 'base64')));
+      }
+    } catch {
+      // fall through to plain base64 decode
+    }
+  }
+  try {
+    return Buffer.from(trimmed, 'base64');
+  } catch {
+    return null;
+  }
+}
+
+function decompressIfNeeded({ response }: { response: PollyRecording['response'] }): void {
+  if (!response?.content || !Array.isArray(response.headers)) return;
+  const buffer = decompressBase64Body({ content: response.content });
+  if (!buffer) return;
+  const encodingIdx = response.headers.findIndex(
+    (h) => h.name.toLowerCase() === 'content-encoding',
+  );
+  if (encodingIdx < 0) {
+    // No content-encoding header. The body is base64 binary that may or may
+    // not be plain UTF-8 — try to decode and only commit if it round-trips.
+    const text = buffer.toString('utf8');
+    if (Buffer.from(text, 'utf8').equals(buffer)) {
+      response.content.text = text;
+      delete response.content.encoding;
+      response.content.size = text.length;
+    }
+    return;
+  }
+  const encoding = (response.headers[encodingIdx]?.value ?? '').toLowerCase();
+  let decompressed: Buffer | null = null;
+  try {
+    if (encoding === 'gzip') decompressed = gunzipSync(buffer);
+    else if (encoding === 'br') decompressed = brotliDecompressSync(buffer);
+    else if (encoding === 'deflate') decompressed = inflateSync(buffer);
+  } catch {
+    return;
+  }
+  if (!decompressed) return;
+  const text = decompressed.toString('utf8');
+  response.headers.splice(encodingIdx, 1);
+  delete response.content.encoding;
+  response.content.text = text;
+  response.content.size = text.length;
+}
+
+function isMissingReplayRecording({ error }: { error: unknown }): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes('Recording for the following request is not found') &&
+    error.message.includes('recordIfMissing') &&
+    error.message.includes('false')
+  );
+}
+
+/**
+ * Wires up Polly + nock + node-fetch for the calling package's vitest run.
+ * Returns nothing — registers `beforeEach` / `afterEach` / `afterAll` hooks
+ * that fire for every test in the calling package.
+ *
+ * Call this exactly once from a package's vitest `setupFiles` entry. Calling
+ * it twice will register the hooks twice and cause double-stop errors.
+ */
+export function definePollySetup({
+  extraRedactors = [],
+  extraRequestRewriter,
+}: DefinePollySetupArgs = {}): void {
+  loadDotEnvFromMonorepoRoot();
+
+  const nativeFetch = globalThis.fetch;
+  const POLLY_MODE = (process.env['POLLY_MODE'] ?? 'replay') as PollyConfig['mode'];
+
+  if (POLLY_MODE !== 'passthrough') {
+    // node-fetch v3 is ESM-only; top-level await is supported in vitest setup files.
+    void (async () => {
+      const { default: nodeFetchFn } = (await import('node-fetch')) as unknown as {
+        default: typeof fetch;
+      };
+      globalThis.fetch = (async (
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ): Promise<Response> => {
+        const headers = new Headers(init?.headers);
+        headers.set('accept-encoding', 'identity');
+        let resolvedInput = input;
+        if (POLLY_MODE === 'record' && extraRequestRewriter) {
+          const urlString =
+            typeof input === 'string' ? input : input instanceof URL ? input.toString() : null;
+          if (urlString) {
+            resolvedInput = extraRequestRewriter(urlString);
+          }
+        }
+        return (await nodeFetchFn(resolvedInput, { ...init, headers })) as Response;
+      }) as typeof fetch;
+    })();
+  }
+
+  if (POLLY_MODE === 'record' || POLLY_MODE === 'passthrough') {
+    nock.enableNetConnect();
+  } else {
+    nock.disableNetConnect();
+    nock.enableNetConnect(
+      (host) => host.includes('localhost') || host.includes('127.0.0.1') || host.includes('[::1]'),
+    );
+  }
+
+  // Polly's `register` typing is overly strict against default-exported CJS
+  // classes; the runtime call is fine.
+  Polly.register(NodeHttpAdapter as never);
+  Polly.register(FSPersister as never);
+
+  let polly: Polly | null = null;
+  let missingReplayRecordings: string[] = [];
+
+  beforeEach(async ({ task }) => {
+    missingReplayRecordings = [];
+
+    if (polly) {
+      try {
+        await polly.stop();
+      } catch {
+        // ignore double-stop
+      }
+      polly = null;
+    }
+
+    if (POLLY_MODE === 'passthrough') return;
+
+    const suiteName = task.suite?.name ?? 'unknown-suite';
+    const testName = task.name ?? 'unknown-test';
+    const cassetteName = `${suiteName}/${testName}`;
+    const testFilePath = task.file?.filepath ?? '';
+    const recordingsDir = path.join(path.dirname(testFilePath), '__recordings__');
+
+    polly = new Polly(cassetteName, {
+      adapters: ['node-http'],
+      flushRequestsOnStop: true,
+      logLevel: 'error',
+      matchRequestsBy: {
+        body: false,
+        headers: false,
+        method: true,
+        order: false,
+        url: { hostname: true, pathname: true, protocol: true, query: false },
+      },
+      mode: POLLY_MODE,
+      persister: 'fs',
+      persisterOptions: { fs: { recordingsDir } },
+      recordFailedRequests: true,
+      recordIfMissing: POLLY_MODE === 'record',
+    });
+
+    polly.server.any().on('beforePersist', (_req, recording: PollyRecording) => {
+      // Decompress base64+gzip/br/deflate response bodies BEFORE any redactor
+      // runs. SDKs that bypass our fetch override (axios-based @slack/web-api,
+      // for one) send `accept-encoding: gzip,br` and Polly stores the raw
+      // bytes as base64. Redactors that grep for tokens or parse JSON would
+      // otherwise see opaque base64 and silently ship workspace data to disk.
+      if (recording?.response) {
+        decompressIfNeeded({ response: recording.response });
+      }
+
+      if (recording?.request) {
+        if (Array.isArray(recording.request.headers)) {
+          recording.request.headers = redactHeaders({ headers: recording.request.headers });
+        }
+        if (Array.isArray(recording.request.cookies)) {
+          recording.request.cookies = redactCookies({ cookies: recording.request.cookies });
+        }
+        if (typeof recording.request.postData?.text === 'string') {
+          recording.request.postData.text = redactDefaultText({
+            text: recording.request.postData.text,
+          });
+        }
+      }
+      if (recording?.response) {
+        if (Array.isArray(recording.response.headers)) {
+          recording.response.headers = redactHeaders({ headers: recording.response.headers });
+        }
+        if (Array.isArray(recording.response.cookies)) {
+          recording.response.cookies = redactCookies({ cookies: recording.response.cookies });
+        }
+        if (typeof recording.response.content?.text === 'string') {
+          recording.response.content.text = redactDefaultText({
+            text: recording.response.content.text,
+          });
+        }
+      }
+      // Per-package extra redactors run last so they see the fully-decompressed,
+      // partially-cleaned recording and can apply platform-specific scrubbers.
+      for (const extra of extraRedactors) {
+        extra(recording);
+      }
+    });
+
+    polly.server.any().on('error', (req, error) => {
+      if (POLLY_MODE === 'replay' && isMissingReplayRecording({ error })) {
+        missingReplayRecordings.push(`${req?.method ?? 'UNKNOWN'} ${req?.url ?? 'unknown-url'}`);
+        process.exitCode = 1;
+      }
+    });
+  });
+
+  afterEach(async () => {
+    if (polly) {
+      await polly.flush();
+      await polly.stop();
+      polly = null;
+    }
+    if (missingReplayRecordings.length > 0) {
+      throw new Error(
+        `Missing Polly recording(s) in replay mode:\n${missingReplayRecordings.join('\n')}\n` +
+          'Run with POLLY_MODE=record to regenerate cassettes for this test.',
+      );
+    }
+  });
+
+  afterAll(() => {
+    globalThis.fetch = nativeFetch;
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+}

--- a/packages/integrations/core/src/upsert.test.ts
+++ b/packages/integrations/core/src/upsert.test.ts
@@ -83,6 +83,36 @@ describe('upsertEvidence', () => {
       updatedAtMs: 500,
     });
   });
+
+  it('keeps rows for different integrations independent under the same externalId', () => {
+    upsertEvidence({
+      db: handle.db,
+      integration: 'github',
+      externalId: 'shared_id',
+      kind: 'pull_request',
+      title: 'gh',
+      body: null,
+      citationUrl: null,
+      payloadJson: '{}',
+      occurredAtMs: 1,
+      now: 1,
+    });
+    upsertEvidence({
+      db: handle.db,
+      integration: 'slack',
+      externalId: 'shared_id',
+      kind: 'mention',
+      title: 'sl',
+      body: null,
+      citationUrl: null,
+      payloadJson: '{}',
+      occurredAtMs: 1,
+      now: 1,
+    });
+
+    const rows = handle.db.select().from(evidenceLog).all();
+    expect(rows).toHaveLength(2);
+  });
 });
 
 describe('integration_state helpers', () => {
@@ -115,7 +145,6 @@ describe('integration_state helpers', () => {
       .get();
     expect(row?.lastPollStartedAtMs).toBe(2000);
     expect(row?.updatedAtMs).toBe(2000);
-    // createdAtMs preserved from first insert
     expect(row?.createdAtMs).toBe(1000);
   });
 
@@ -138,6 +167,16 @@ describe('integration_state helpers', () => {
       lastPollCompletedAtMs: 1500,
       updatedAtMs: 1500,
     });
+  });
+
+  it('markPollCompleted returns 0 if markPollStarted never ran', () => {
+    const changes = markPollCompleted({
+      db: handle.db,
+      integration: 'github',
+      cursor: 'x',
+      now: 1,
+    });
+    expect(changes).toBe(0);
   });
 
   it('readCursor returns null when no row exists', () => {

--- a/packages/integrations/core/src/upsert.ts
+++ b/packages/integrations/core/src/upsert.ts
@@ -11,9 +11,12 @@
  * progress. `started_at` is set before the request; `completed_at` is set
  * only on success — divergence between the two is the "poll started but
  * never finished" doctor signal.
+ *
+ * Generic over `integration: string`. Integration packages call these
+ * directly with their slug (`'github'`, `'slack'`, …).
  */
 
-import { evidenceLog, integrationState, type SlopweaverDatabase } from '@slopweaver/db';
+import { type SlopweaverDatabase, evidenceLog, integrationState } from '@slopweaver/db';
 import { eq, sql } from 'drizzle-orm';
 
 export type UpsertEvidenceArgs = {

--- a/packages/integrations/core/tsconfig.build.json
+++ b/packages/integrations/core/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/integrations/core/tsconfig.json
+++ b/packages/integrations/core/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/integrations/core/vitest.config.ts
+++ b/packages/integrations/core/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    isolate: true,
+  },
+});

--- a/packages/integrations/github/src/polling.ts
+++ b/packages/integrations/github/src/polling.ts
@@ -14,7 +14,7 @@
 import type { RestEndpointMethodTypes } from '@octokit/rest';
 import type { SlopweaverDatabase } from '@slopweaver/db';
 import { createGithubClient } from './client.ts';
-import { markPollCompleted, markPollStarted, upsertEvidence } from './upsert.ts';
+import { markPollCompleted, markPollStarted, upsertEvidence } from '@slopweaver/integrations-core';
 
 const INTEGRATION = 'github';
 const PER_PAGE = 50;

--- a/packages/integrations/github/src/test-setup/polly.ts
+++ b/packages/integrations/github/src/test-setup/polly.ts
@@ -1,148 +1,37 @@
 /**
- * Polly setup for @slopweaver/integrations-github tests.
+ * Polly cassette setup for @slopweaver/integrations-github tests.
  *
- * Wired via vitest.config.ts `setupFiles`. Each test gets its own cassette under
- * `<test-file-dir>/__recordings__/<suite>/<test>/recording.har`.
+ * Wires the shared cassette plumbing from @slopweaver/integrations-core. The
+ * github-specific concerns are:
  *
- * Modes (POLLY_MODE env):
- *   - replay (default): read from cassette; missing cassette → test fails
- *   - record: hit live api.github.com, write cassette (requires GITHUB_PAT)
- *
- * Native `fetch` (undici) bypasses Polly's node-http adapter, so we replace
- * `globalThis.fetch` with `node-fetch` at load time. node-fetch routes through
- * the http module where Polly intercepts. Restored in afterAll.
- *
- * `nock.disableNetConnect()` is a defense-in-depth net guard — any HTTP call
- * that slips past Polly fails immediately instead of silently hitting live APIs.
- *
- * Header/body redaction runs at `beforePersist`, so cassettes never contain
- * raw `Authorization: Bearer ghp_…` even if a recording is taken locally.
- *
- * Adapted from the SaaS repo's test setup (apps/api/src/__tests__/setup-polly.ts),
- * with SSE / Linear / Anthropic-specific code removed.
+ * 1. **Repo scoping in record mode** — narrow `/search/issues` queries to a
+ *    public repo so even an over-scoped PAT can only return public data.
+ *    No-op in replay (the matcher ignores query params).
+ * 2. **`/user` PII redaction** — the GitHub `/user` endpoint returns the
+ *    recording user's full profile (login, name, avatar, follower counts,
+ *    creation date — every field a determined adversary could correlate).
+ *    Substitute every field with stable placeholders before the cassette
+ *    is persisted.
  */
 
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import NodeHttpAdapter from '@pollyjs/adapter-node-http';
-import { Polly, type PollyConfig } from '@pollyjs/core';
-import FSPersister from '@pollyjs/persister-fs';
-import nock from 'nock';
-import { afterAll, afterEach, beforeEach } from 'vitest';
+import {
+  definePollySetup,
+  type PollyRecording,
+} from '@slopweaver/integrations-core/test-setup/polly';
 
-// Load .env from monorepo root so `GH_TOKEN=...` in the dev's .env reaches
-// record-mode runs without a separate `source .env` step. Replay mode doesn't
-// need the token; missing .env is silently OK.
-try {
-  const envPath = fileURLToPath(new URL('../../../../../.env', import.meta.url));
-  const envContent = readFileSync(envPath, 'utf8');
-  for (const rawLine of envContent.split('\n')) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith('#')) continue;
-    const eqIdx = line.indexOf('=');
-    if (eqIdx < 0) continue;
-    const key = line.slice(0, eqIdx).trim();
-    const value = line
-      .slice(eqIdx + 1)
-      .trim()
-      .replace(/^['"]|['"]$/g, '');
-    if (process.env[key] === undefined) {
-      process.env[key] = value;
-    }
-  }
-} catch {
-  // .env doesn't exist — fine for replay mode.
-}
-
-// In record mode, scope GitHub search queries to slopweaver/slopweaver so any
-// `is:pr involves:@me` / `is:issue involves:@me` / `mentions:@me` query can only
-// return data from one public repo the maintainer owns. This keeps cassettes
-// safe-by-construction: even if the PAT had broader access, the search index
-// wouldn't return private-repo items because the qualifier excludes them.
-//
-// The matcher in beforeEach below ignores query params on replay, so the
-// scoped record-time URL replays cleanly against the production code's
-// unscoped query.
 const RECORD_REPO_SCOPE = process.env['RECORD_REPO_SCOPE'] ?? 'slopweaver/slopweaver';
 
-function maybeScopeGithubSearchUrl({ urlString }: { urlString: string }): string {
+function maybeScopeGithubSearchUrl(urlString: string): string {
   const url = new URL(urlString);
   if (url.hostname !== 'api.github.com' || url.pathname !== '/search/issues') {
     return urlString;
   }
   const q = url.searchParams.get('q') ?? '';
-  if (q.includes('repo:')) {
-    return urlString;
-  }
+  if (q.includes('repo:')) return urlString;
   url.searchParams.set('q', `${q} repo:${RECORD_REPO_SCOPE}`);
   return url.toString();
 }
 
-type RedactableHeader = { name: string; value?: string };
-type RedactableCookie = { name: string; value?: string };
-
-const nativeFetch = globalThis.fetch;
-const POLLY_MODE = (process.env['POLLY_MODE'] ?? 'replay') as PollyConfig['mode'];
-
-if (POLLY_MODE !== 'passthrough') {
-  // node-fetch v3 is ESM-only; top-level await is supported in vitest setup files.
-  // Native fetch (undici) bypasses Polly's node-http adapter, so we route through
-  // node-fetch which uses node:http internally.
-  const { default: nodeFetchFn } = (await import('node-fetch')) as unknown as {
-    default: typeof fetch;
-  };
-  globalThis.fetch = (async (
-    input: Parameters<typeof fetch>[0],
-    init?: Parameters<typeof fetch>[1],
-  ): Promise<Response> => {
-    const headers = new Headers(init?.headers);
-    headers.set('accept-encoding', 'identity');
-    // In record mode, narrow GitHub /search/issues queries to the configured
-    // public repo. No-op in replay because the matcher ignores query params.
-    let resolvedInput = input;
-    if (POLLY_MODE === 'record') {
-      const urlString =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : null;
-      if (urlString) {
-        resolvedInput = maybeScopeGithubSearchUrl({ urlString });
-      }
-    }
-    return (await nodeFetchFn(resolvedInput, { ...init, headers })) as Response;
-  }) as typeof fetch;
-}
-
-if (POLLY_MODE === 'record' || POLLY_MODE === 'passthrough') {
-  nock.enableNetConnect();
-} else {
-  nock.disableNetConnect();
-  nock.enableNetConnect(
-    (host) => host.includes('localhost') || host.includes('127.0.0.1') || host.includes('[::1]'),
-  );
-}
-
-// Polly's `register` typing is overly strict against default-exported CJS classes;
-// the runtime call is fine (matches the SaaS repo's setup verbatim).
-Polly.register(NodeHttpAdapter as never);
-Polly.register(FSPersister as never);
-
-let polly: Polly | null = null;
-let missingReplayRecordings: string[] = [];
-
-const REDACT_HEADER_NAMES = new Set([
-  'authorization',
-  'cookie',
-  'set-cookie',
-  'x-github-request-id',
-  // The auth token expiry header reveals when the recording PAT will expire.
-  'github-authentication-token-expiration',
-]);
-const REDACT_KEY_REGEX = /token|secret|authorization|password|api[-_]?key/i;
-const REDACT_VALUE_REGEX = /(gh[pousr]_[A-Za-z0-9]{16,})/g;
-
-// Stable placeholders substituted into recorded `/user` responses so the
-// cassettes commit zero personally-identifying fields. Tests assert only on
-// shape and the canonical-id format, so these values satisfy every expectation.
 const USER_PLACEHOLDERS: Record<string, unknown> = {
   login: 'test-user',
   id: 1,
@@ -169,9 +58,6 @@ const USER_PLACEHOLDERS: Record<string, unknown> = {
   hireable: null,
   twitter_username: null,
   notification_email: null,
-  // Account-fingerprint fields — technically public on github.com/<user>, but
-  // baking them into a cassette in our public repo creates a permanent link
-  // back to the recording user. Stable placeholders avoid that.
   public_repos: 0,
   public_gists: 0,
   followers: 0,
@@ -180,190 +66,32 @@ const USER_PLACEHOLDERS: Record<string, unknown> = {
   updated_at: '2020-01-01T00:00:00Z',
 };
 
-function redactUserResponseText({ text }: { text: string }): string {
+function redactGithubUserResponse(recording: PollyRecording): void {
+  const requestUrl = recording.request?.url ?? '';
+  const isUserEndpoint =
+    requestUrl.includes('api.github.com/user') && !requestUrl.includes('api.github.com/users/');
+  if (!isUserEndpoint) return;
+  const text = recording.response?.content?.text;
+  if (typeof text !== 'string') return;
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
   } catch {
-    return text;
+    return;
   }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return text;
-  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
   const replaced: Record<string, unknown> = { ...(parsed as Record<string, unknown>) };
   for (const [key, value] of Object.entries(USER_PLACEHOLDERS)) {
     if (key in replaced) {
       replaced[key] = value;
     }
   }
-  return JSON.stringify(replaced);
+  if (recording.response?.content) {
+    recording.response.content.text = JSON.stringify(replaced);
+  }
 }
 
-function redactHeaders({
-  headers,
-}: {
-  headers?: RedactableHeader[] | undefined;
-}): RedactableHeader[] {
-  if (!headers) {
-    return [];
-  }
-  return headers.filter((h) => !REDACT_HEADER_NAMES.has(h.name.toLowerCase()));
-}
-
-function redactCookies({
-  cookies,
-}: {
-  cookies?: RedactableCookie[] | undefined;
-}): RedactableCookie[] {
-  if (!cookies) {
-    return [];
-  }
-  return cookies.map((c) => ({ ...c, value: '[REDACTED]' }));
-}
-
-function redactJson({ value }: { value: unknown }): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => redactJson({ value: entry }));
-  }
-  if (value && typeof value === 'object') {
-    const output: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) {
-      output[k] = REDACT_KEY_REGEX.test(k) ? '[REDACTED]' : redactJson({ value: v });
-    }
-    return output;
-  }
-  if (typeof value === 'string') {
-    return value.replace(REDACT_VALUE_REGEX, '[REDACTED-PAT]');
-  }
-  return value;
-}
-
-function redactText({ text }: { text: string }): string {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return text;
-  }
-  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-    try {
-      return JSON.stringify(redactJson({ value: JSON.parse(trimmed) }));
-    } catch {
-      // fall through
-    }
-  }
-  return text.replace(REDACT_VALUE_REGEX, '[REDACTED-PAT]');
-}
-
-function isMissingReplayRecording({ error }: { error: unknown }): boolean {
-  return (
-    error instanceof Error &&
-    error.message.includes('Recording for the following request is not found') &&
-    error.message.includes('recordIfMissing') &&
-    error.message.includes('false')
-  );
-}
-
-beforeEach(async ({ task }) => {
-  missingReplayRecordings = [];
-
-  if (polly) {
-    try {
-      await polly.stop();
-    } catch {
-      // ignore double-stop
-    }
-    polly = null;
-  }
-
-  if (POLLY_MODE === 'passthrough') {
-    return;
-  }
-
-  const suiteName = task.suite?.name ?? 'unknown-suite';
-  const testName = task.name ?? 'unknown-test';
-  const cassetteName = `${suiteName}/${testName}`;
-  const testFilePath = task.file?.filepath ?? '';
-  const recordingsDir = path.join(path.dirname(testFilePath), '__recordings__');
-
-  polly = new Polly(cassetteName, {
-    adapters: ['node-http'],
-    flushRequestsOnStop: true,
-    logLevel: 'error',
-    matchRequestsBy: {
-      body: false,
-      headers: false,
-      method: true,
-      order: false,
-      url: { hostname: true, pathname: true, protocol: true, query: false },
-    },
-    mode: POLLY_MODE,
-    persister: 'fs',
-    persisterOptions: { fs: { recordingsDir } },
-    recordFailedRequests: true,
-    recordIfMissing: POLLY_MODE === 'record',
-  });
-
-  // biome-ignore lint/suspicious/noExplicitAny: Polly types for recording payload are loose
-  polly.server.any().on('beforePersist', (_req, recording: any) => {
-    if (recording?.request) {
-      if (Array.isArray(recording.request.headers)) {
-        recording.request.headers = redactHeaders({ headers: recording.request.headers });
-      }
-      if (Array.isArray(recording.request.cookies)) {
-        recording.request.cookies = redactCookies({ cookies: recording.request.cookies });
-      }
-      if (typeof recording.request.postData?.text === 'string') {
-        recording.request.postData.text = redactText({ text: recording.request.postData.text });
-      }
-    }
-    if (recording?.response) {
-      if (Array.isArray(recording.response.headers)) {
-        recording.response.headers = redactHeaders({ headers: recording.response.headers });
-      }
-      if (Array.isArray(recording.response.cookies)) {
-        recording.response.cookies = redactCookies({ cookies: recording.response.cookies });
-      }
-      if (typeof recording.response.content?.text === 'string') {
-        // /user response carries the recording user's full profile — substitute
-        // every PII field with a stable placeholder before generic redaction
-        // (which only catches token-shaped strings, not personal fields).
-        const requestUrl = typeof recording.request?.url === 'string' ? recording.request.url : '';
-        const isUserEndpoint =
-          requestUrl.includes('api.github.com/user') &&
-          !requestUrl.includes('api.github.com/users/');
-        if (isUserEndpoint) {
-          recording.response.content.text = redactUserResponseText({
-            text: recording.response.content.text,
-          });
-        }
-        recording.response.content.text = redactText({ text: recording.response.content.text });
-      }
-    }
-  });
-
-  polly.server.any().on('error', (req, error) => {
-    if (POLLY_MODE === 'replay' && isMissingReplayRecording({ error })) {
-      missingReplayRecordings.push(`${req?.method ?? 'UNKNOWN'} ${req?.url ?? 'unknown-url'}`);
-      process.exitCode = 1;
-    }
-  });
-});
-
-afterEach(async () => {
-  if (polly) {
-    await polly.flush();
-    await polly.stop();
-    polly = null;
-  }
-  if (missingReplayRecordings.length > 0) {
-    throw new Error(
-      `Missing Polly recording(s) in replay mode:\n${missingReplayRecordings.join('\n')}\n` +
-        'Run with POLLY_MODE=record to regenerate cassettes for this test.',
-    );
-  }
-});
-
-afterAll(() => {
-  globalThis.fetch = nativeFetch;
-  nock.cleanAll();
-  nock.enableNetConnect();
+definePollySetup({
+  extraRedactors: [redactGithubUserResponse],
+  extraRequestRewriter: maybeScopeGithubSearchUrl,
 });

--- a/packages/integrations/slack/README.md
+++ b/packages/integrations/slack/README.md
@@ -1,0 +1,40 @@
+# @slopweaver/integrations-slack
+
+Slack polling for SlopWeaver. Writes mentions and DMs into `evidence_log` and the auth'd bot identity into `identity_graph`. No write paths, no OAuth flow, no threads, no Socket Mode — those are out of scope for v1.
+
+## API
+
+Built on the official `@slack/web-api` SDK; we ship a thin factory plus three poll functions on top of `WebClient`.
+
+- `createSlackClient({ token, retryConfig? })` — returns a configured `WebClient`. Defaults to `{ retries: 0 }` under `NODE_ENV=test` and an exponential backoff (`retries: 3, factor: 2, minTimeout: 1s, maxTimeout: 30s`) otherwise. Override via `retryConfig`.
+- `pollMentions({ db, token, since?, client? })` — `auth.test` + `search.messages` for `<@U…>`; upserts into `evidence_log` with `kind='mention'`. Note: Slack's `search.messages` requires a user token (`xoxp-`) — bot tokens (`xoxb-`) get `not_allowed_token_type`.
+- `pollDMs({ db, token, since?, client? })` — `auth.test` + `conversations.list?types=im` + `conversations.history` per channel; upserts with `kind='message'`.
+- `fetchIdentity({ db, token, client? })` — `auth.test` + `users.info`. Writes one row to `identity_graph` for the auth'd user; preserves `canonical_id` and `created_at_ms` on subsequent calls.
+
+All three poll functions accept an optional pre-built `WebClient` via `client` for composition / test injection. The package re-exports nothing about Slack's wire shapes — consumers reach for `@slack/web-api`'s own response types (`AuthTestResponse`, `UsersInfoResponse`, etc.) directly.
+
+## Tests + cassettes
+
+The current scaffold tests inject a `WebClient` partial mock for hermetic CI. Polly + `@pollyjs/adapter-node-http` is wired in `src/test/setup-polly.ts` ready for end-to-end recording against a real workspace; `@slack/web-api` routes through Node's `http` module after the test setup replaces native `fetch` with `node-fetch`, so cassettes capture real SDK traffic when `POLLY_MODE=record`.
+
+Recordings live under `src/__recordings__/`. Auth headers (`authorization`, `cookie`) and any `token` / `secret` JSON fields are scrubbed before the cassette is written to disk.
+
+> **Note**: the repo's root `.gitignore` excludes `*.har` as a safety net against accidentally committing real auth headers. When the first cassettes are recorded, decide whether to commit them (and add a `!` exception under `__recordings__/`) or keep cassettes per-developer and require re-recording locally.
+
+```bash
+# Replay (default, hermetic, what CI runs):
+pnpm --filter @slopweaver/integrations-slack test
+
+# Re-record against a real workspace (overwrites existing cassettes):
+# Use a user token (xoxp-) — search.messages rejects bot tokens with not_allowed_token_type.
+POLLY_MODE=record SLACK_USER_TOKEN=xoxp-… pnpm --filter @slopweaver/integrations-slack test
+```
+
+The patched `@pollyjs/adapter-node-http@6.0.6` (see `patches/`) fixes HTTPS request handling and content-encoding edge cases; nock is pinned to `13.5.6` for compatibility with that adapter.
+
+## Development
+
+```bash
+pnpm --filter @slopweaver/integrations-slack compile
+pnpm --filter @slopweaver/integrations-slack test
+```

--- a/packages/integrations/slack/package.json
+++ b/packages/integrations/slack/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@slopweaver/integrations-github",
+  "name": "@slopweaver/integrations-slack",
   "version": "0.0.0",
   "private": false,
-  "description": "GitHub polling integration for SlopWeaver. Writes PRs, issues, mentions into evidence_log and the authenticated identity into identity_graph.",
+  "description": "SlopWeaver Slack integration. Polls mentions and DMs into evidence_log; writes the auth'd identity to identity_graph.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,9 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@octokit/plugin-throttling": "11.0.3",
-    "@octokit/request-error": "7.1.0",
-    "@octokit/rest": "22.0.1",
+    "@slack/web-api": "7.15.1",
     "@slopweaver/db": "workspace:*",
     "@slopweaver/integrations-core": "workspace:*",
     "drizzle-orm": "0.45.2"

--- a/packages/integrations/slack/src/__recordings__/fetchIdentity-cassette_1764600760/records-and-replays-a-real-workspace-identity-fetch_2657999230/recording.har
+++ b/packages/integrations/slack/src/__recordings__/fetchIdentity-cassette_1764600760/records-and-replays-a-real-workspace-identity-fetch_2657999230/recording.har
@@ -1,0 +1,385 @@
+{
+  "log": {
+    "_recordingName": "fetchIdentity (cassette)/records and replays a real workspace identity fetch",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "402790c507e65df3f991480425e1e2c3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@slack:web-api/7.15.1 node/22.19.0 darwin/25.3.0"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "slack.com"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [],
+          "url": "https://slack.com/api/auth.test"
+        },
+        "response": {
+          "bodySize": 130,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 174,
+            "text": "{\"ok\":true,\"url\":\"https://example.slack.com/\",\"team\":\"[redacted]\",\"user\":\"[redacted]\",\"team_id\":\"T0A63ULSH6K\",\"user_id\":\"U0A6P0984BE\",\"is_enterprise_install\":false}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 06 May 2026 12:56:25 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-slack-req-id",
+              "value": "74ecdaf333b91be7ae7973bd68d90530"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store, must-revalidate"
+            },
+            {
+              "name": "expires",
+              "value": "Sat, 26 Jul 1997 05:00:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": "identify,channels:history,groups:history,im:history,mpim:history,channels:read,files:read,groups:read,im:read,mpim:read,reactions:read,search:read,users:read,users:read.email,channels:write,chat:write,groups:write,im:write,mpim:write,reactions:write"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-slack-req-id, retry-after"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "no-referrer"
+            },
+            {
+              "name": "x-slack-unique-id",
+              "value": "afs6eSQprabcoiG0O0MgUgAAAB8"
+            },
+            {
+              "name": "x-slack-backend",
+              "value": "r"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "via",
+              "value": "1.1 slack-prod.tinyspeck.com, envoy-www-iad-zdlfmhgd,envoy-edge-syd-cujdzxnq"
+            },
+            {
+              "name": "content-length",
+              "value": "130"
+            },
+            {
+              "name": "x-envoy-attempt-count",
+              "value": "1"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "420"
+            },
+            {
+              "name": "x-backend",
+              "value": "api_normal"
+            },
+            {
+              "name": "x-server",
+              "value": "slack-www-hhvm-api-iad-u8ptoab2k6mg"
+            },
+            {
+              "name": "x-slack-shared-secret-outcome",
+              "value": "no-match"
+            },
+            {
+              "name": "x-edge-backend",
+              "value": "envoy-www"
+            },
+            {
+              "name": "timing-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000, h3-29=\":443\"; ma=2592000, quic=\":443\"; ma=2592000"
+            },
+            {
+              "name": "x-slack-edge-shared-secret-outcome",
+              "value": "no-match"
+            }
+          ],
+          "headersSize": 1492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-05-06T12:56:24.484Z",
+        "time": 600,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 600
+        }
+      },
+      {
+        "_id": "40c5bf3f2699b9edcb7374af49a8b265",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 16,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@slack:web-api/7.15.1 node/22.19.0 darwin/25.3.0"
+            },
+            {
+              "name": "content-length",
+              "value": "16"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "slack.com"
+            }
+          ],
+          "headersSize": 393,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "user=U0A6P0984BE"
+          },
+          "queryString": [],
+          "url": "https://slack.com/api/users.info"
+        },
+        "response": {
+          "bodySize": 562,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1784,
+            "text": "{\"ok\":true,\"user\":{\"id\":\"U0A6P0984BE\",\"name\":\"[redacted]\",\"is_bot\":false,\"updated\":1771332230,\"is_app_user\":false,\"team_id\":\"T0A63ULSH6K\",\"deleted\":false,\"color\":\"[redacted]\",\"is_email_confirmed\":true,\"real_name\":\"[redacted]\",\"tz\":\"[redacted]\",\"tz_label\":\"[redacted]\",\"tz_offset\":36000,\"is_admin\":true,\"is_owner\":true,\"is_primary_owner\":true,\"is_restricted\":false,\"is_ultra_restricted\":false,\"has_2fa\":false,\"who_can_share_contact_card\":\"[redacted]\",\"profile\":{\"real_name\":\"[redacted]\",\"display_name\":\"[redacted]\",\"avatar_hash\":\"[redacted]\",\"real_name_normalized\":\"[redacted]\",\"display_name_normalized\":\"[redacted]\",\"image_24\":\"[redacted]\",\"image_32\":\"[redacted]\",\"image_48\":\"[redacted]\",\"image_72\":\"[redacted]\",\"image_192\":\"[redacted]\",\"image_512\":\"[redacted]\",\"image_1024\":\"[redacted]\",\"image_original\":\"[redacted]\",\"is_custom_image\":true,\"first_name\":\"[redacted]\",\"last_name\":\"[redacted]\",\"team\":\"T0A63ULSH6K\",\"email\":\"[redacted]\",\"title\":\"[redacted]\",\"phone\":\"[redacted]\",\"skype\":\"\",\"status_text\":\"[redacted]\",\"status_text_canonical\":\"\",\"status_emoji\":\"[redacted]\",\"status_emoji_display_info\":[],\"status_expiration\":0,\"huddle_state\":\"default_unset\",\"huddle_state_expiration_ts\":0}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 06 May 2026 12:56:25 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-slack-req-id",
+              "value": "697c4a0d6f43486de7da26f472a918f2"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store, must-revalidate"
+            },
+            {
+              "name": "expires",
+              "value": "Sat, 26 Jul 1997 05:00:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-accepted-oauth-scopes",
+              "value": "users:read"
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": "identify,channels:history,groups:history,im:history,mpim:history,channels:read,files:read,groups:read,im:read,mpim:read,reactions:read,search:read,users:read,users:read.email,channels:write,chat:write,groups:write,im:write,mpim:write,reactions:write"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-slack-req-id, retry-after"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "no-referrer"
+            },
+            {
+              "name": "x-slack-unique-id",
+              "value": "afs6eTttBSrKuWyN8Gcv8QAAADQ"
+            },
+            {
+              "name": "x-slack-backend",
+              "value": "r"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "via",
+              "value": "1.1 slack-prod.tinyspeck.com, envoy-www-iad-mqzlsihz,envoy-edge-syd-cujdzxnq"
+            },
+            {
+              "name": "content-length",
+              "value": "562"
+            },
+            {
+              "name": "x-envoy-attempt-count",
+              "value": "1"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "418"
+            },
+            {
+              "name": "x-backend",
+              "value": "api_normal"
+            },
+            {
+              "name": "x-server",
+              "value": "slack-www-hhvm-api-iad-wm04xjrotpqc"
+            },
+            {
+              "name": "x-slack-shared-secret-outcome",
+              "value": "no-match"
+            },
+            {
+              "name": "x-edge-backend",
+              "value": "envoy-www"
+            },
+            {
+              "name": "timing-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000, h3-29=\":443\"; ma=2592000, quic=\":443\"; ma=2592000"
+            },
+            {
+              "name": "x-slack-edge-shared-secret-outcome",
+              "value": "no-match"
+            }
+          ],
+          "headersSize": 1529,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-05-06T12:56:25.092Z",
+        "time": 452,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 452
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/integrations/slack/src/__recordings__/pollDMs-cassette_2903054647/returns-a-fetched-count-and-writes-integration_state-for-slack_1146941219/recording.har
+++ b/packages/integrations/slack/src/__recordings__/pollDMs-cassette_2903054647/returns-a-fetched-count-and-writes-integration_state-for-slack_1146941219/recording.har
@@ -1,0 +1,577 @@
+{
+  "log": {
+    "_recordingName": "pollDMs (cassette)/returns a fetched count and writes integration_state for slack",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "402790c507e65df3f991480425e1e2c3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@slack:web-api/7.15.1 node/22.19.0 darwin/25.3.0"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "slack.com"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [],
+          "url": "https://slack.com/api/auth.test"
+        },
+        "response": {
+          "bodySize": 130,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 174,
+            "text": "{\"ok\":true,\"url\":\"https://example.slack.com/\",\"team\":\"[redacted]\",\"user\":\"[redacted]\",\"team_id\":\"T0A63ULSH6K\",\"user_id\":\"U0A6P0984BE\",\"is_enterprise_install\":false}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 06 May 2026 12:56:25 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-slack-req-id",
+              "value": "e2a61d348b2f6ce35a1130363f8f9497"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store, must-revalidate"
+            },
+            {
+              "name": "expires",
+              "value": "Sat, 26 Jul 1997 05:00:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": "identify,channels:history,groups:history,im:history,mpim:history,channels:read,files:read,groups:read,im:read,mpim:read,reactions:read,search:read,users:read,users:read.email,channels:write,chat:write,groups:write,im:write,mpim:write,reactions:write"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-slack-req-id, retry-after"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "no-referrer"
+            },
+            {
+              "name": "x-slack-unique-id",
+              "value": "afs6eZdy0shWN4zK4aMRsAAAAA0"
+            },
+            {
+              "name": "x-slack-backend",
+              "value": "r"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "via",
+              "value": "1.1 slack-prod.tinyspeck.com, envoy-www-iad-yvggpfjg,envoy-edge-syd-jquyzrje"
+            },
+            {
+              "name": "content-length",
+              "value": "130"
+            },
+            {
+              "name": "x-envoy-attempt-count",
+              "value": "1"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "412"
+            },
+            {
+              "name": "x-backend",
+              "value": "api_normal"
+            },
+            {
+              "name": "x-server",
+              "value": "slack-www-hhvm-api-iad-wb0cikjgq3jj"
+            },
+            {
+              "name": "x-slack-shared-secret-outcome",
+              "value": "no-match"
+            },
+            {
+              "name": "x-edge-backend",
+              "value": "envoy-www"
+            },
+            {
+              "name": "timing-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000, h3-29=\":443\"; ma=2592000, quic=\":443\"; ma=2592000"
+            },
+            {
+              "name": "x-slack-edge-shared-secret-outcome",
+              "value": "no-match"
+            }
+          ],
+          "headersSize": 1492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-05-06T12:56:24.489Z",
+        "time": 576,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 576
+        }
+      },
+      {
+        "_id": "d3eeeba4e36ec2c0ecaf017c913f008f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 18,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@slack:web-api/7.15.1 node/22.19.0 darwin/25.3.0"
+            },
+            {
+              "name": "content-length",
+              "value": "18"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "slack.com"
+            }
+          ],
+          "headersSize": 401,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "types=im&limit=200"
+          },
+          "queryString": [],
+          "url": "https://slack.com/api/conversations.list"
+        },
+        "response": {
+          "bodySize": 442,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1753,
+            "text": "{\"ok\":true,\"channels\":[{\"id\":\"D0B0DA7J2E6\",\"created\":1777388394,\"is_org_shared\":false,\"is_im\":true,\"is_archived\":false,\"context_team_id\":\"T0A63ULSH6K\",\"updated\":1777388394987,\"user\":\"U0B0S796HFT\",\"is_user_deleted\":false,\"priority\":0},{\"id\":\"D0AR3H97DKK\",\"created\":1775212974,\"is_org_shared\":false,\"is_im\":true,\"is_archived\":false,\"context_team_id\":\"T0A63ULSH6K\",\"updated\":1775212974394,\"user\":\"U0AQNJDA2BY\",\"is_user_deleted\":false,\"priority\":0},{\"id\":\"D0AFBRDNU77\",\"created\":1771331646,\"is_org_shared\":false,\"is_im\":true,\"is_archived\":false,\"context_team_id\":\"T0A63ULSH6K\",\"updated\":1774944668794,\"user\":\"U0AEZQSNC3Z\",\"is_user_deleted\":false,\"priority\":0,\"properties\":\"[redacted]\"},{\"id\":\"D0AF8SF99SP\",\"created\":1771331624,\"is_org_shared\":false,\"is_im\":true,\"is_archived\":false,\"context_team_id\":\"T0A63ULSH6K\",\"updated\":1774944668629,\"user\":\"U0AFF8JRW9G\",\"is_user_deleted\":false,\"priority\":0,\"properties\":\"[redacted]\"},{\"id\":\"D0A7DM98BCG\",\"created\":1767414815,\"is_org_shared\":false,\"is_im\":true,\"is_archived\":false,\"context_team_id\":\"T0A63ULSH6K\",\"updated\":1770204463620,\"user\":\"U0A6P0984BE\",\"is_user_deleted\":false,\"priority\":0,\"properties\":\"[redacted]\"},{\"id\":\"D0A6D0Z6F2P\",\"created\":1767414815,\"is_org_shared\":false,\"is_im\":true,\"is_archived\":false,\"context_team_id\":\"T0A63ULSH6K\",\"updated\":1774944668655,\"user\":\"USLACKBOT\",\"is_user_deleted\":false,\"priority\":0,\"properties\":\"[redacted]\"}],\"response_metadata\":{\"next_cursor\":\"\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 06 May 2026 12:56:25 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-slack-req-id",
+              "value": "49bae363d536fff0080506f5c1753f37"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store, must-revalidate"
+            },
+            {
+              "name": "expires",
+              "value": "Sat, 26 Jul 1997 05:00:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-accepted-oauth-scopes",
+              "value": "channels:read,groups:read,mpim:read,im:read,read"
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": "identify,channels:history,groups:history,im:history,mpim:history,channels:read,files:read,groups:read,im:read,mpim:read,reactions:read,search:read,users:read,users:read.email,channels:write,chat:write,groups:write,im:write,mpim:write,reactions:write"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-slack-req-id, retry-after"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "no-referrer"
+            },
+            {
+              "name": "x-slack-unique-id",
+              "value": "afs6ee5_p-vUPF14kvTyuwAAEBk"
+            },
+            {
+              "name": "x-slack-backend",
+              "value": "r"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "via",
+              "value": "1.1 slack-prod.tinyspeck.com, envoy-www-iad-ahveshvo,envoy-edge-syd-jquyzrje"
+            },
+            {
+              "name": "content-length",
+              "value": "442"
+            },
+            {
+              "name": "x-envoy-attempt-count",
+              "value": "1"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "448"
+            },
+            {
+              "name": "x-backend",
+              "value": "api_normal"
+            },
+            {
+              "name": "x-server",
+              "value": "slack-www-hhvm-api-iad-qpo4blbevav5"
+            },
+            {
+              "name": "x-slack-shared-secret-outcome",
+              "value": "no-match"
+            },
+            {
+              "name": "x-edge-backend",
+              "value": "envoy-www"
+            },
+            {
+              "name": "timing-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000, h3-29=\":443\"; ma=2592000, quic=\":443\"; ma=2592000"
+            },
+            {
+              "name": "x-slack-edge-shared-secret-outcome",
+              "value": "no-match"
+            }
+          ],
+          "headersSize": 1567,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-05-06T12:56:25.075Z",
+        "time": 497,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 497
+        }
+      },
+      {
+        "_id": "2c6726b00656da44b69b28720d9bd11d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 29,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@slack:web-api/7.15.1 node/22.19.0 darwin/25.3.0"
+            },
+            {
+              "name": "content-length",
+              "value": "29"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "slack.com"
+            }
+          ],
+          "headersSize": 404,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "channel=D0B0DA7J2E6&limit=100"
+          },
+          "queryString": [],
+          "url": "https://slack.com/api/conversations.history"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 127,
+            "text": "{\"ok\":true,\"messages\":[],\"has_more\":false,\"is_limited\":false,\"pin_count\":0,\"channel_actions_ts\":null,\"channel_actions_count\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 06 May 2026 12:56:25 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-slack-req-id",
+              "value": "3ead41c467ff615036a5cef70b220ded"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store, must-revalidate"
+            },
+            {
+              "name": "expires",
+              "value": "Sat, 26 Jul 1997 05:00:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-accepted-oauth-scopes",
+              "value": "channels:history,groups:history,mpim:history,im:history,read"
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": "identify,channels:history,groups:history,im:history,mpim:history,channels:read,files:read,groups:read,im:read,mpim:read,reactions:read,search:read,users:read,users:read.email,channels:write,chat:write,groups:write,im:write,mpim:write,reactions:write"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-slack-req-id, retry-after"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "no-referrer"
+            },
+            {
+              "name": "x-slack-unique-id",
+              "value": "afs6ebr2oB04oRsQLqfWogAAEB8"
+            },
+            {
+              "name": "x-slack-backend",
+              "value": "r"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "via",
+              "value": "1.1 slack-prod.tinyspeck.com, envoy-www-iad-cluyreif,envoy-edge-syd-jquyzrje"
+            },
+            {
+              "name": "content-length",
+              "value": "84"
+            },
+            {
+              "name": "x-envoy-attempt-count",
+              "value": "1"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "251"
+            },
+            {
+              "name": "x-backend",
+              "value": "api_normal"
+            },
+            {
+              "name": "x-server",
+              "value": "slack-www-hhvm-api-iad-2vd5mez0gxu2"
+            },
+            {
+              "name": "x-slack-shared-secret-outcome",
+              "value": "no-match"
+            },
+            {
+              "name": "x-edge-backend",
+              "value": "envoy-www"
+            },
+            {
+              "name": "timing-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000, h3-29=\":443\"; ma=2592000, quic=\":443\"; ma=2592000"
+            },
+            {
+              "name": "x-slack-edge-shared-secret-outcome",
+              "value": "no-match"
+            }
+          ],
+          "headersSize": 1578,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-05-06T12:56:25.577Z",
+        "time": 294,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 294
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/integrations/slack/src/__recordings__/pollMentions-cassette_1809669342/returns-a-fetched-count-and-writes-integration_state-for-slack_1146941219/recording.har
+++ b/packages/integrations/slack/src/__recordings__/pollMentions-cassette_1809669342/returns-a-fetched-count-and-writes-integration_state-for-slack_1146941219/recording.har
@@ -1,0 +1,385 @@
+{
+  "log": {
+    "_recordingName": "pollMentions (cassette)/returns a fetched count and writes integration_state for slack",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "402790c507e65df3f991480425e1e2c3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@slack:web-api/7.15.1 node/22.19.0 darwin/25.3.0"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "slack.com"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [],
+          "url": "https://slack.com/api/auth.test"
+        },
+        "response": {
+          "bodySize": 130,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 174,
+            "text": "{\"ok\":true,\"url\":\"https://example.slack.com/\",\"team\":\"[redacted]\",\"user\":\"[redacted]\",\"team_id\":\"T0A63ULSH6K\",\"user_id\":\"U0A6P0984BE\",\"is_enterprise_install\":false}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 06 May 2026 12:56:24 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-slack-req-id",
+              "value": "23ef786566d4c24626a1b5177b0231e6"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store, must-revalidate"
+            },
+            {
+              "name": "expires",
+              "value": "Sat, 26 Jul 1997 05:00:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": "identify,channels:history,groups:history,im:history,mpim:history,channels:read,files:read,groups:read,im:read,mpim:read,reactions:read,search:read,users:read,users:read.email,channels:write,chat:write,groups:write,im:write,mpim:write,reactions:write"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-slack-req-id, retry-after"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "no-referrer"
+            },
+            {
+              "name": "x-slack-unique-id",
+              "value": "afs6eF8CFJSMF_dxOn3qmgAAECQ"
+            },
+            {
+              "name": "x-slack-backend",
+              "value": "r"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "via",
+              "value": "1.1 slack-prod.tinyspeck.com, envoy-www-iad-vofazygi,envoy-edge-syd-vicgvfbc"
+            },
+            {
+              "name": "content-length",
+              "value": "130"
+            },
+            {
+              "name": "x-envoy-attempt-count",
+              "value": "1"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "226"
+            },
+            {
+              "name": "x-backend",
+              "value": "api_normal"
+            },
+            {
+              "name": "x-server",
+              "value": "slack-www-hhvm-api-iad-a7oltse0vjjw"
+            },
+            {
+              "name": "x-slack-shared-secret-outcome",
+              "value": "no-match"
+            },
+            {
+              "name": "x-edge-backend",
+              "value": "envoy-www"
+            },
+            {
+              "name": "timing-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000, h3-29=\":443\"; ma=2592000, quic=\":443\"; ma=2592000"
+            },
+            {
+              "name": "x-slack-edge-shared-secret-outcome",
+              "value": "no-match"
+            }
+          ],
+          "headersSize": 1492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-05-06T12:56:24.499Z",
+        "time": 379,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 379
+        }
+      },
+      {
+        "_id": "de32c827f4ceda70639e5b2c057149cf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 43,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@slack:web-api/7.15.1 node/22.19.0 darwin/25.3.0"
+            },
+            {
+              "name": "content-length",
+              "value": "43"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "slack.com"
+            }
+          ],
+          "headersSize": 398,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "query=%5Bredacted-query%5D&count=100&page=1"
+          },
+          "queryString": [],
+          "url": "https://slack.com/api/search.messages"
+        },
+        "response": {
+          "bodySize": 482,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1022,
+            "text": "{\"ok\":true,\"query\":\"<@U0A6P0984BE>\",\"messages\":{\"total\":1,\"pagination\":{\"total_count\":1,\"page\":1,\"per_page\":100,\"page_count\":1,\"first\":1,\"last\":1},\"paging\":{\"count\":100,\"total\":1,\"page\":1,\"pages\":1},\"matches\":[{\"db_message\":{},\"iid\":\"f82f808b-4390-41f4-b5db-83929f68241f\",\"team\":\"T0A63ULSH6K\",\"score\":3.8814123,\"channel\":{\"id\":\"D0AF8SF99SP\",\"is_channel\":false,\"is_group\":false,\"is_im\":true,\"is_mpim\":false,\"is_shared\":false,\"is_org_shared\":false,\"is_ext_shared\":false,\"is_private\":true,\"is_archived\":false,\"name\":\"[redacted]\",\"user\":\"U0AFF8JRW9G\"},\"type\":\"im\",\"user\":\"U0AFF8JRW9G\",\"username\":\"[redacted]\",\"ts\":\"1771331955.180809\",\"blocks\":[{\"type\":\"rich_text\",\"block_id\":\"iOqIU\",\"elements\":[{\"type\":\"rich_text_section\",\"elements\":[{\"type\":\"emoji\",\"name\":\"[redacted]\",\"unicode\":\"1f44b\"},{\"type\":\"text\",\"text\":\"[redacted-message-text]\"},{\"type\":\"user\",\"user_id\":\"U0A6P0984BE\"}]}]}],\"text\":\"[redacted-message-text]\",\"permalink\":\"https://example.slack.com/archives/D0AF8SF99SP/p1771331955180809\",\"no_reactions\":true}]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 06 May 2026 12:56:25 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-slack-req-id",
+              "value": "2a86e5fed79f8bd7ae8dd437cadc8c15"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store, must-revalidate"
+            },
+            {
+              "name": "expires",
+              "value": "Sat, 26 Jul 1997 05:00:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-accepted-oauth-scopes",
+              "value": "search:read"
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": "identify,channels:history,groups:history,im:history,mpim:history,channels:read,files:read,groups:read,im:read,mpim:read,reactions:read,search:read,users:read,users:read.email,channels:write,chat:write,groups:write,im:write,mpim:write,reactions:write"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-slack-req-id, retry-after"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "no-referrer"
+            },
+            {
+              "name": "x-slack-unique-id",
+              "value": "afs6efSHAE6mIqjF6kr00wAAAD4"
+            },
+            {
+              "name": "x-slack-backend",
+              "value": "r"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "via",
+              "value": "1.1 slack-prod.tinyspeck.com, envoy-www-iad-fkrwgtmy,envoy-edge-syd-vicgvfbc"
+            },
+            {
+              "name": "content-length",
+              "value": "482"
+            },
+            {
+              "name": "x-envoy-attempt-count",
+              "value": "1"
+            },
+            {
+              "name": "x-envoy-upstream-service-time",
+              "value": "514"
+            },
+            {
+              "name": "x-backend",
+              "value": "api_normal"
+            },
+            {
+              "name": "x-server",
+              "value": "slack-www-hhvm-api-iad-yzi5v0034zxq"
+            },
+            {
+              "name": "x-slack-shared-secret-outcome",
+              "value": "no-match"
+            },
+            {
+              "name": "x-edge-backend",
+              "value": "envoy-www"
+            },
+            {
+              "name": "timing-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000, h3-29=\":443\"; ma=2592000, quic=\":443\"; ma=2592000"
+            },
+            {
+              "name": "x-slack-edge-shared-secret-outcome",
+              "value": "no-match"
+            }
+          ],
+          "headersSize": 1530,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-05-06T12:56:24.889Z",
+        "time": 558,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 558
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/integrations/slack/src/client.test.ts
+++ b/packages/integrations/slack/src/client.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Smoke tests for createSlackClient.
+ *
+ * The wire-level concerns (bearer auth, 429 retry, JSON encoding,
+ * { ok: false } -> WebAPIPlatformError) live in `@slack/web-api` itself; we
+ * don't re-test them. These tests only pin our thin factory.
+ */
+
+import { WebClient } from '@slack/web-api';
+import { describe, expect, it } from 'vitest';
+import { createSlackClient } from './client.ts';
+
+describe('createSlackClient', () => {
+  it('returns a WebClient instance', () => {
+    const client = createSlackClient({ token: 'xoxb-test' });
+    expect(client).toBeInstanceOf(WebClient);
+  });
+
+  it('rejects empty tokens at construction time', () => {
+    expect(() => createSlackClient({ token: '' })).toThrowError(/non-empty string/);
+  });
+
+  it('accepts a custom retryConfig override', () => {
+    const client = createSlackClient({
+      token: 'xoxb-test',
+      retryConfig: { retries: 7 },
+    });
+    // The SDK doesn't expose the resolved retry config, so we settle for the
+    // construction-doesn't-throw assertion. The real behaviour is exercised
+    // by integration tests against cassettes.
+    expect(client).toBeInstanceOf(WebClient);
+  });
+});

--- a/packages/integrations/slack/src/client.ts
+++ b/packages/integrations/slack/src/client.ts
@@ -1,0 +1,42 @@
+/**
+ * Construct a configured `@slack/web-api` `WebClient`.
+ *
+ * Thin factory around the SDK constructor so callers don't have to remember
+ * the retry config. Production runs use exponential-backoff retries; tests
+ * default to `retries: 0` so failed cassette matches surface immediately
+ * instead of hanging on the SDK's default backoff. Callers can override via
+ * `retryConfig`.
+ *
+ * The retry config shape mirrors the private monorepo's `slack-client.provider.ts`
+ * so both repos behave the same against a real workspace.
+ */
+
+import { WebClient, type WebClientOptions } from '@slack/web-api';
+
+type RetryConfig = NonNullable<WebClientOptions['retryConfig']>;
+
+const PROD_RETRY_CONFIG: RetryConfig = {
+  retries: 3,
+  factor: 2,
+  minTimeout: 1_000,
+  maxTimeout: 30_000,
+};
+
+const TEST_RETRY_CONFIG: RetryConfig = {
+  retries: 0,
+};
+
+export function createSlackClient({
+  token,
+  retryConfig,
+}: {
+  token: string;
+  retryConfig?: RetryConfig;
+}): WebClient {
+  if (!token) {
+    throw new Error('createSlackClient: token must be a non-empty string');
+  }
+  const resolvedRetryConfig =
+    retryConfig ?? (process.env['NODE_ENV'] === 'test' ? TEST_RETRY_CONFIG : PROD_RETRY_CONFIG);
+  return new WebClient(token, { retryConfig: resolvedRetryConfig });
+}

--- a/packages/integrations/slack/src/dms.test.ts
+++ b/packages/integrations/slack/src/dms.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for pollDMs.
+ *
+ * Covers the `slack.paginate` flow for both `conversations.list` and
+ * `conversations.history`, the `oldest` cursor pass-through, multi-page
+ * aggregation, integration_state writes, and idempotent re-poll.
+ */
+
+import type { WebClient } from '@slack/web-api';
+import { evidenceLog, integrationState } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { pollDMs } from './dms.ts';
+import { openMemoryDb } from './test/db.ts';
+
+type DbHandle = ReturnType<typeof openMemoryDb>;
+
+function asyncIter<T>(items: T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const item of items) yield item;
+    },
+  };
+}
+
+describe('pollDMs', () => {
+  let dbHandle: DbHandle;
+
+  beforeEach(() => {
+    dbHandle = openMemoryDb();
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it('lists IMs, fetches history per channel via paginate, and writes each message as kind=message', async () => {
+    const client = {
+      auth: {
+        test: async () => ({
+          ok: true,
+          user_id: 'U0SLOPBOT',
+          user: 'slopbot',
+          team_id: 'T0WORKSPACE',
+          url: 'https://slopweaver.slack.com/',
+        }),
+      },
+      paginate: (method: string, opts: Record<string, unknown>) => {
+        if (method === 'conversations.list') {
+          return asyncIter([
+            {
+              ok: true,
+              channels: [
+                { id: 'D0ALICE', user: 'U0ALICE', is_im: true },
+                { id: 'D0BOB', user: 'U0BOB', is_im: true },
+              ],
+            },
+          ]);
+        }
+        if (method === 'conversations.history') {
+          const channel = opts['channel'] as string;
+          if (channel === 'D0ALICE') {
+            return asyncIter([
+              {
+                ok: true,
+                messages: [{ ts: '1762000010.000000', user: 'U0ALICE', text: 'hi from alice' }],
+              },
+            ]);
+          }
+          if (channel === 'D0BOB') {
+            return asyncIter([
+              {
+                ok: true,
+                messages: [
+                  { ts: '1762000020.000000', user: 'U0BOB', text: 'hi from bob' },
+                  { ts: '1762000021.000000', user: 'U0BOB', text: 'second message' },
+                ],
+              },
+            ]);
+          }
+        }
+        throw new Error(`unexpected paginate method: ${method}`);
+      },
+    } as unknown as WebClient;
+
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      now: () => 8_888,
+    });
+
+    expect(result.fetched).toBe(3);
+    expect(result.newCursor).toBe(new Date(1_762_000_021_000).toISOString());
+
+    const rows = dbHandle.db.select().from(evidenceLog).all();
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.kind === 'message')).toBe(true);
+    expect([...rows.map((r) => r.externalId)].sort()).toEqual([
+      'message_1762000010.000000:D0ALICE',
+      'message_1762000020.000000:D0BOB',
+      'message_1762000021.000000:D0BOB',
+    ]);
+  });
+
+  it('writes integration_state with started < completed and cursor at newest ts', async () => {
+    let nowCounter = 1000;
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      paginate: (method: string) => {
+        if (method === 'conversations.list') {
+          return asyncIter([{ ok: true, channels: [{ id: 'D1', user: 'U2', is_im: true }] }]);
+        }
+        if (method === 'conversations.history') {
+          return asyncIter([{ ok: true, messages: [{ ts: '7.0', user: 'U2', text: 'hello' }] }]);
+        }
+        throw new Error('unexpected');
+      },
+    } as unknown as WebClient;
+
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      now: () => nowCounter++,
+    });
+
+    expect(result.newCursor).toBe(new Date(7_000).toISOString());
+
+    const state = dbHandle.db.select().from(integrationState).all();
+    expect(state).toHaveLength(1);
+    expect(state[0]?.integration).toBe('slack');
+    expect(state[0]?.lastPollStartedAtMs).toBeLessThan(state[0]?.lastPollCompletedAtMs ?? 0);
+    expect(state[0]?.cursor).toBe(new Date(7_000).toISOString());
+  });
+
+  it('preserves prior cursor when the poll observes zero messages', async () => {
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      paginate: (method: string) => {
+        if (method === 'conversations.list') {
+          return asyncIter([{ ok: true, channels: [{ id: 'D1', user: 'U2', is_im: true }] }]);
+        }
+        if (method === 'conversations.history') {
+          return asyncIter([{ ok: true, messages: [] }]);
+        }
+        throw new Error('unexpected');
+      },
+    } as unknown as WebClient;
+
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      since: new Date('2026-05-01T00:00:00Z'),
+      now: () => 1,
+    });
+
+    expect(result.newCursor).toBe('2026-05-01T00:00:00.000Z');
+  });
+
+  it('aggregates messages across multiple history pages for one channel', async () => {
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      paginate: (method: string) => {
+        if (method === 'conversations.list') {
+          return asyncIter([{ ok: true, channels: [{ id: 'D1', user: 'U2', is_im: true }] }]);
+        }
+        if (method === 'conversations.history') {
+          return asyncIter([
+            { ok: true, messages: [{ ts: '1.0', user: 'U2', text: 'page1-msg1' }] },
+            { ok: true, messages: [{ ts: '2.0', user: 'U2', text: 'page2-msg1' }] },
+            { ok: true, messages: [{ ts: '3.0', user: 'U2', text: 'page3-msg1' }] },
+          ]);
+        }
+        throw new Error('unexpected');
+      },
+    } as unknown as WebClient;
+
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      now: () => 1,
+    });
+
+    expect(result.fetched).toBe(3);
+    expect(result.newCursor).toBe(new Date(3_000).toISOString());
+    expect(dbHandle.db.select().from(evidenceLog).all()).toHaveLength(3);
+  });
+
+  it('passes the since timestamp through as the `oldest` cursor on history calls', async () => {
+    const historySeen: Record<string, unknown>[] = [];
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      paginate: (method: string, opts: Record<string, unknown>) => {
+        if (method === 'conversations.list') {
+          return asyncIter([{ ok: true, channels: [{ id: 'D1', user: 'U2', is_im: true }] }]);
+        }
+        if (method === 'conversations.history') {
+          historySeen.push(opts);
+          return asyncIter([{ ok: true, messages: [] }]);
+        }
+        throw new Error('unexpected');
+      },
+    } as unknown as WebClient;
+
+    await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      since: new Date('2026-05-01T00:00:00Z'),
+      now: () => 1,
+    });
+
+    expect(historySeen).toHaveLength(1);
+    expect(historySeen[0]).toMatchObject({
+      channel: 'D1',
+      // 2026-05-01T00:00:00Z = 1777593600 unix seconds
+      oldest: '1777593600.000000',
+    });
+  });
+
+  it('treats a re-poll of the same DM history as an update, not an insert', async () => {
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      paginate: (method: string) => {
+        if (method === 'conversations.list') {
+          return asyncIter([{ ok: true, channels: [{ id: 'D1', user: 'U2', is_im: true }] }]);
+        }
+        if (method === 'conversations.history') {
+          return asyncIter([{ ok: true, messages: [{ ts: '1.0', user: 'U2', text: 'hello' }] }]);
+        }
+        throw new Error('unexpected');
+      },
+    } as unknown as WebClient;
+
+    await pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 100 });
+    await pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 200 });
+
+    expect(dbHandle.db.select().from(evidenceLog).all()).toHaveLength(1);
+  });
+});
+
+describe('pollDMs (cassette)', () => {
+  // Smoke test against a recorded cassette. Scrubbed at record-time:
+  // message text, channel names, and the workspace URL are all redacted.
+  let dbHandle: DbHandle;
+
+  beforeEach(() => {
+    dbHandle = openMemoryDb();
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it('returns a fetched count and writes integration_state for slack', async () => {
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
+      now: () => 1_000,
+    });
+
+    expect(typeof result.fetched).toBe('number');
+    expect(result.fetched).toBeGreaterThanOrEqual(0);
+
+    const state = dbHandle.db.select().from(integrationState).all();
+    expect(state).toHaveLength(1);
+    expect(state[0]?.integration).toBe('slack');
+    expect(state[0]?.lastPollStartedAtMs).toBeLessThanOrEqual(state[0]?.lastPollCompletedAtMs ?? 0);
+
+    const rows = dbHandle.db.select().from(evidenceLog).all();
+    for (const row of rows) {
+      expect(row.kind).toBe('message');
+      expect(row.externalId).toMatch(/^message_\d+\.\d+:[CDG][A-Z0-9]+$/);
+    }
+  });
+});

--- a/packages/integrations/slack/src/dms.ts
+++ b/packages/integrations/slack/src/dms.ts
@@ -1,0 +1,128 @@
+/**
+ * Poll Slack DMs (IM channels) and upsert into `evidence_log`.
+ *
+ * Two-step: `conversations.list?types=im` to enumerate IM channels the auth'd
+ * user/bot participates in, then `conversations.history` per channel. Both
+ * endpoints are cursor-paginated, so we use the SDK's `paginate()` helper —
+ * every page is iterated, no silent caps. `since` becomes the `oldest` cursor
+ * on each `conversations.history` call (Slack expects unix seconds with
+ * optional decimal microseconds).
+ *
+ * Each poll brackets its work with `markPollStarted` / `markPollCompleted` so
+ * `freshness` consumers (`start_session`, the Diagnostics UI) can see when
+ * Slack last ran. Cursor advances to the newest message ts observed across
+ * all channels in the poll; preserves prior watermark on empty.
+ */
+
+import type {
+  ConversationsHistoryResponse,
+  ConversationsListResponse,
+  WebClient,
+} from '@slack/web-api';
+import type { SlopweaverDatabase } from '@slopweaver/db';
+import { markPollCompleted, markPollStarted } from '@slopweaver/integrations-core';
+import { createSlackClient } from './client.ts';
+import { pickNewestTs, upsertSlackMessage } from './upsert.ts';
+
+const INTEGRATION = 'slack';
+
+export type PollDMsArgs = {
+  db: SlopweaverDatabase;
+  token: string;
+  since?: Date;
+  client?: WebClient;
+  now?: () => number;
+};
+
+export type PollResult = {
+  fetched: number;
+  newCursor: string | null;
+};
+
+export async function pollDMs({
+  db,
+  token,
+  since,
+  client,
+  now = Date.now,
+}: PollDMsArgs): Promise<PollResult> {
+  const slack = client ?? createSlackClient({ token });
+  const startedAt = now();
+  markPollStarted({ db, integration: INTEGRATION, now: startedAt });
+
+  const auth = await slack.auth.test();
+  // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees team_id on ok:true
+  const teamId = auth.team_id!;
+  const workspaceUrl = auth.url ?? null;
+
+  const oldest = since ? toSlackTs({ date: since }) : undefined;
+
+  let fetched = 0;
+  let newestTs: string | null = null;
+
+  const listIterable = slack.paginate('conversations.list', {
+    types: 'im',
+    limit: 200,
+  }) as AsyncIterable<ConversationsListResponse>;
+
+  for await (const listPage of listIterable) {
+    for (const channel of listPage.channels ?? []) {
+      if (channel.is_im === false || !channel.id) continue;
+      const historyIterable = slack.paginate('conversations.history', {
+        channel: channel.id,
+        limit: 100,
+        ...(oldest !== undefined && { oldest }),
+      }) as AsyncIterable<ConversationsHistoryResponse>;
+
+      for await (const historyPage of historyIterable) {
+        const messages = historyPage.messages ?? [];
+        fetched += messages.length;
+
+        const observedAt = now();
+        for (const message of messages) {
+          upsertSlackMessage({
+            db,
+            message,
+            kind: 'message',
+            teamId,
+            workspaceUrl,
+            channelId: channel.id,
+            now: observedAt,
+          });
+        }
+
+        const pageNewest = pickNewestTs(messages);
+        if (pageNewest && (newestTs === null || compareTs(pageNewest, newestTs) > 0)) {
+          newestTs = pageNewest;
+        }
+      }
+    }
+  }
+
+  // Cursors are always ISO-8601 so the public `since?: Date` /
+  // `newCursor: string | null` contract round-trips through `new Date(cursor)`.
+  // Match github's polling.ts:106 stable-format rule.
+  const newCursor = newestTs ? slackTsToIso(newestTs) : (since?.toISOString() ?? null);
+  markPollCompleted({ db, integration: INTEGRATION, cursor: newCursor, now: now() });
+  return { fetched, newCursor };
+}
+
+function compareTs(a: string, b: string): number {
+  const aN = Number.parseFloat(a);
+  const bN = Number.parseFloat(b);
+  if (!Number.isFinite(aN) || !Number.isFinite(bN)) return a.localeCompare(b);
+  return aN === bN ? 0 : aN > bN ? 1 : -1;
+}
+
+function toSlackTs({ date }: { date: Date }): string {
+  const seconds = Math.floor(date.getTime() / 1_000);
+  return `${seconds}.000000`;
+}
+
+function slackTsToIso(ts: string): string {
+  const seconds = Number.parseFloat(ts);
+  if (!Number.isFinite(seconds)) {
+    throw new Error(`slackTsToIso: cannot parse ts ${ts}`);
+  }
+  return new Date(Math.round(seconds * 1_000)).toISOString();
+}

--- a/packages/integrations/slack/src/identity.test.ts
+++ b/packages/integrations/slack/src/identity.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for fetchIdentity.
+ *
+ * The Slack client is a `WebClient` partial mock cast at the boundary —
+ * standard pattern when faking SDKs in TypeScript. Phase 6 of this PR
+ * replaces these fakes with real `WebClient` calls intercepted by Polly
+ * cassettes.
+ */
+
+import type { WebClient } from '@slack/web-api';
+import { identityGraph } from '@slopweaver/db';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { fetchIdentity } from './identity.ts';
+import { openMemoryDb } from './test/db.ts';
+
+type DbHandle = ReturnType<typeof openMemoryDb>;
+
+function fakeWebClient({
+  authResponse,
+  usersInfoResponse,
+}: {
+  authResponse: Record<string, unknown>;
+  usersInfoResponse: Record<string, unknown>;
+}): WebClient {
+  return {
+    auth: { test: async () => authResponse },
+    users: { info: async () => usersInfoResponse },
+  } as unknown as WebClient;
+}
+
+describe('fetchIdentity', () => {
+  let dbHandle: DbHandle;
+
+  beforeEach(() => {
+    dbHandle = openMemoryDb();
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it('inserts identity_graph row with deterministic canonical_id slack:<team>:<user>', async () => {
+    const client = fakeWebClient({
+      authResponse: {
+        ok: true,
+        user_id: 'U0SLOPBOT',
+        user: 'slopbot',
+        team_id: 'T0WORKSPACE',
+        url: 'https://slopweaver.slack.com/',
+      },
+      usersInfoResponse: {
+        ok: true,
+        user: {
+          id: 'U0SLOPBOT',
+          name: 'slopbot',
+          profile: { display_name: 'Slop Bot' },
+        },
+      },
+    });
+
+    const result = await fetchIdentity({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      now: () => 1_762_000_000_000,
+    });
+
+    expect(result).toEqual({
+      canonicalId: 'slack:T0WORKSPACE:U0SLOPBOT',
+      externalId: 'U0SLOPBOT',
+    });
+
+    const rows = dbHandle.db
+      .select()
+      .from(identityGraph)
+      .where(eq(identityGraph.externalId, 'U0SLOPBOT'))
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      canonicalId: 'slack:T0WORKSPACE:U0SLOPBOT',
+      integration: 'slack',
+      externalId: 'U0SLOPBOT',
+      username: 'slopbot',
+      displayName: 'Slop Bot',
+      profileUrl: 'https://slopweaver.slack.com/team/U0SLOPBOT',
+      createdAtMs: 1_762_000_000_000,
+      updatedAtMs: 1_762_000_000_000,
+    });
+  });
+
+  it('two machines on the same workspace agree on canonical_id by construction', async () => {
+    // The deterministic format means two independent installs polling the
+    // same workspace produce the same canonical_id without coordination.
+    const auth = { ok: true, user_id: 'U0', user: 'a', team_id: 'T0' };
+    const profile = { ok: true, user: { id: 'U0', name: 'a' } };
+
+    const machineA = fakeWebClient({ authResponse: auth, usersInfoResponse: profile });
+    const dbA = openMemoryDb();
+    const dbB = openMemoryDb();
+    try {
+      const a = await fetchIdentity({
+        db: dbA.db,
+        token: 'xoxb-test',
+        client: machineA,
+        now: () => 1,
+      });
+      const b = await fetchIdentity({
+        db: dbB.db,
+        token: 'xoxb-test',
+        client: fakeWebClient({ authResponse: auth, usersInfoResponse: profile }),
+        now: () => 2,
+      });
+      expect(a.canonicalId).toBe(b.canonicalId);
+      expect(a.canonicalId).toBe('slack:T0:U0');
+    } finally {
+      dbA.close();
+      dbB.close();
+    }
+  });
+
+  it('preserves canonical_id and created_at_ms across re-runs while refreshing the snapshot', async () => {
+    const initialClient = fakeWebClient({
+      authResponse: { ok: true, user_id: 'U0SLOPBOT', user: 'slopbot', team_id: 'T0WORKSPACE' },
+      usersInfoResponse: {
+        ok: true,
+        user: { id: 'U0SLOPBOT', name: 'slopbot', profile: { display_name: 'Slop Bot' } },
+      },
+    });
+
+    await fetchIdentity({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client: initialClient,
+      now: () => 1_000,
+    });
+
+    const refreshedClient = fakeWebClient({
+      authResponse: { ok: true, user_id: 'U0SLOPBOT', user: 'slopbot', team_id: 'T0WORKSPACE' },
+      usersInfoResponse: {
+        ok: true,
+        user: { id: 'U0SLOPBOT', name: 'slopbot', profile: { display_name: 'Slop Bot v2' } },
+      },
+    });
+
+    const result = await fetchIdentity({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client: refreshedClient,
+      now: () => 5_000,
+    });
+
+    expect(result.canonicalId).toBe('slack:T0WORKSPACE:U0SLOPBOT');
+
+    const rows = dbHandle.db.select().from(identityGraph).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      canonicalId: 'slack:T0WORKSPACE:U0SLOPBOT',
+      displayName: 'Slop Bot v2',
+      createdAtMs: 1_000,
+      updatedAtMs: 5_000,
+    });
+  });
+
+  it('falls back to real_name when display_name is empty', async () => {
+    const client = fakeWebClient({
+      authResponse: { ok: true, user_id: 'U1', user: 'alice', team_id: 'T1' },
+      usersInfoResponse: {
+        ok: true,
+        user: {
+          id: 'U1',
+          name: 'alice',
+          profile: { display_name: '', real_name: 'Alice Liddell' },
+        },
+      },
+    });
+
+    await fetchIdentity({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 1,
+    });
+
+    const row = dbHandle.db.select().from(identityGraph).get();
+    expect(row?.displayName).toBe('Alice Liddell');
+  });
+
+  it('propagates SDK errors from slack.auth.test', async () => {
+    const client = {
+      auth: {
+        test: async () => {
+          throw new Error('An API error occurred: invalid_auth');
+        },
+      },
+      users: { info: async () => ({ ok: true, user: { id: 'unused' } }) },
+    } as unknown as WebClient;
+
+    await expect(
+      fetchIdentity({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        now: () => 1,
+      }),
+    ).rejects.toThrowError(/invalid_auth/);
+  });
+});
+
+describe('fetchIdentity (cassette)', () => {
+  // Smoke test against a recorded cassette. The cassette was scrubbed by
+  // src/test/redact-slack.ts at record-time, so assertions only check shape:
+  // - canonicalId matches slack:<team>:<user>
+  // - identity_graph row exists with the right structural fields
+  // - mutable PII (display name) is whatever survived redaction
+  let dbHandle: DbHandle;
+
+  beforeEach(() => {
+    dbHandle = openMemoryDb();
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it('records and replays a real workspace identity fetch', async () => {
+    const result = await fetchIdentity({
+      db: dbHandle.db,
+      token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
+      now: () => 1_000,
+    });
+
+    expect(result.canonicalId).toMatch(/^slack:T[A-Z0-9]+:U[A-Z0-9]+$/);
+    expect(result.externalId).toMatch(/^U[A-Z0-9]+$/);
+
+    const row = dbHandle.db.select().from(identityGraph).get();
+    expect(row).toMatchObject({
+      canonicalId: result.canonicalId,
+      integration: 'slack',
+      externalId: result.externalId,
+      createdAtMs: 1_000,
+      updatedAtMs: 1_000,
+    });
+  });
+});

--- a/packages/integrations/slack/src/identity.ts
+++ b/packages/integrations/slack/src/identity.ts
@@ -1,0 +1,91 @@
+/**
+ * Fetch the auth'd user/bot identity from Slack and upsert into `identity_graph`.
+ *
+ * Uses `auth.test` to discover the user_id behind the token, then `users.info`
+ * to enrich with display name + avatar. Writes a single row keyed on
+ * `(integration='slack', external_id=<user_id>)`.
+ *
+ * `canonical_id` is deterministic: `slack:<team_id>:<user_id>`. Workspace-
+ * scoped, so two machines connecting to the same workspace agree on the
+ * canonical id by construction. Mirrors github's `github:<id>` strategy
+ * (#33), extended with team_id because Slack user ids are workspace-scoped.
+ *
+ * Why `auth.test` + `users.info` instead of `users.identity`: bot tokens
+ * (`xoxb-`) cannot call `users.identity` (which requires the user-token
+ * `identity.basic` scope). The two-step here works for both bot and user
+ * tokens.
+ */
+
+import type { WebClient } from '@slack/web-api';
+import { type SlopweaverDatabase, identityGraph } from '@slopweaver/db';
+import { sql } from 'drizzle-orm';
+import { createSlackClient } from './client.ts';
+
+const INTEGRATION = 'slack';
+
+export type FetchIdentityArgs = {
+  db: SlopweaverDatabase;
+  token: string;
+  client?: WebClient;
+  now?: () => number;
+};
+
+export type FetchIdentityResult = {
+  canonicalId: string;
+  externalId: string;
+};
+
+export async function fetchIdentity({
+  db,
+  token,
+  client,
+  now = Date.now,
+}: FetchIdentityArgs): Promise<FetchIdentityResult> {
+  const slack = client ?? createSlackClient({ token });
+
+  const auth = await slack.auth.test();
+  // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees user_id on ok:true
+  const userId = auth.user_id!;
+  // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees team_id on ok:true
+  const teamId = auth.team_id!;
+  const canonicalId = `${INTEGRATION}:${teamId}:${userId}`;
+
+  const usersInfo = await slack.users.info({ user: userId });
+  const user = usersInfo.user;
+  const profile = user?.profile;
+  const username = user?.name ?? auth.user ?? null;
+  const displayName = profile?.display_name?.trim() || profile?.real_name?.trim() || null;
+  const profileUrl = auth.url ? `${stripTrailingSlash(auth.url)}/team/${userId}` : null;
+
+  const stamp = now();
+
+  db.insert(identityGraph)
+    .values({
+      canonicalId,
+      integration: INTEGRATION,
+      externalId: userId,
+      username,
+      displayName,
+      profileUrl,
+      createdAtMs: stamp,
+      updatedAtMs: stamp,
+    })
+    .onConflictDoUpdate({
+      target: [identityGraph.integration, identityGraph.externalId],
+      // canonical_id and created_at_ms are preserved across re-runs by being
+      // absent from the conflict-update set.
+      set: {
+        username,
+        displayName,
+        profileUrl,
+        updatedAtMs: sql`excluded.updated_at_ms`,
+      },
+    })
+    .run();
+
+  return { canonicalId, externalId: userId };
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}

--- a/packages/integrations/slack/src/index.ts
+++ b/packages/integrations/slack/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @slopweaver/integrations-slack public entry.
+ *
+ * Polls Slack mentions and DMs into `evidence_log`, marks per-poll progress
+ * in `integration_state`, and upserts the auth'd identity into
+ * `identity_graph`. No write operations, no OAuth flow, no threads — see the
+ * README for scope.
+ *
+ * Built on `@slack/web-api`'s `WebClient`. Consumers can pass an existing
+ * `WebClient` via the `client` argument on each entrypoint, or rely on the
+ * factory to construct one from a token.
+ */
+
+export { createSlackClient } from './client.ts';
+export { fetchIdentity, type FetchIdentityArgs, type FetchIdentityResult } from './identity.ts';
+export {
+  pollMentions,
+  type PollMentionsArgs,
+  type PollResult as PollMentionsResult,
+  type AnySlackMessage,
+} from './mentions.ts';
+export { pollDMs, type PollDMsArgs, type PollResult as PollDMsResult } from './dms.ts';
+export {
+  upsertSlackMessage,
+  pickNewestTs,
+  type SlackMessageKind,
+} from './upsert.ts';

--- a/packages/integrations/slack/src/mentions.test.ts
+++ b/packages/integrations/slack/src/mentions.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for pollMentions.
+ *
+ * The SlackClient is a `WebClient` partial mock — Phase 6 swaps these for
+ * real cassettes. Tests cover: search query construction, evidence_log row
+ * shape (including the kind-prefixed external_id), idempotent re-poll,
+ * graceful skipping, page-based pagination, and integration_state writes.
+ */
+
+import type { WebClient } from '@slack/web-api';
+import { evidenceLog, integrationState } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { pollMentions } from './mentions.ts';
+import { openMemoryDb } from './test/db.ts';
+
+type DbHandle = ReturnType<typeof openMemoryDb>;
+
+describe('pollMentions', () => {
+  let dbHandle: DbHandle;
+
+  beforeEach(() => {
+    dbHandle = openMemoryDb();
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it("queries search.messages with the auth'd user mention and writes one row per match", async () => {
+    const searchSpy = vi.fn(async (args: { query: string; count: number; page?: number }) => {
+      expect(args).toMatchObject({ query: '<@U0SLOPBOT>', count: 100 });
+      return {
+        ok: true,
+        messages: {
+          matches: [
+            {
+              ts: '1762000000.000100',
+              user: 'U0ALICE',
+              text: 'hey <@U0SLOPBOT> can you check this?',
+              channel: { id: 'C0DESIGN', name: 'design' },
+            },
+            {
+              ts: '1762000000.000200',
+              user: 'U0BOB',
+              text: 'cc <@U0SLOPBOT>',
+              channel: { id: 'C0ENG' },
+              permalink: 'https://slopweaver.slack.com/archives/C0ENG/p1762000000000200',
+            },
+          ],
+          paging: { count: 2, total: 2, page: 1, pages: 1 },
+        },
+      };
+    });
+    const client = {
+      auth: {
+        test: async () => ({
+          ok: true,
+          user_id: 'U0SLOPBOT',
+          user: 'slopbot',
+          team_id: 'T0WORKSPACE',
+          url: 'https://slopweaver.slack.com/',
+        }),
+      },
+      search: { messages: searchSpy },
+    } as unknown as WebClient;
+
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 9_000_000,
+    });
+
+    expect(result.fetched).toBe(2);
+    // Cursor normalized to ISO-8601 from the newest match's ts. The `.000200`
+    // tail is microseconds, which round to 0 ms below epoch-ms granularity.
+    expect(result.newCursor).toBe(new Date(1_762_000_000_000).toISOString());
+    expect(searchSpy).toHaveBeenCalledOnce();
+
+    const rows = dbHandle.db.select().from(evidenceLog).all();
+    expect(rows).toHaveLength(2);
+
+    const designRow = rows.find((r) => r.externalId === 'mention_1762000000.000100:C0DESIGN');
+    expect(designRow).toMatchObject({
+      integration: 'slack',
+      kind: 'mention',
+      title: 'hey <@U0SLOPBOT> can you check this?',
+      body: 'hey <@U0SLOPBOT> can you check this?',
+      citationUrl: 'https://slopweaver.slack.com/archives/C0DESIGN/p1762000000000100',
+      occurredAtMs: 1_762_000_000_000,
+      firstSeenAtMs: 9_000_000,
+      lastSeenAtMs: 9_000_000,
+    });
+
+    const engRow = rows.find((r) => r.externalId === 'mention_1762000000.000200:C0ENG');
+    expect(engRow?.citationUrl).toBe(
+      'https://slopweaver.slack.com/archives/C0ENG/p1762000000000200',
+    );
+    expect(engRow?.payloadJson).toContain('"_team_id":"T0WORKSPACE"');
+  });
+
+  it('writes integration_state with started < completed and cursor at newest ts', async () => {
+    let nowCounter = 1000;
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      search: {
+        messages: async () => ({
+          ok: true,
+          messages: {
+            matches: [{ ts: '500.0', text: 'hi', user: 'U2', channel: { id: 'C1' } }],
+            paging: { count: 1, total: 1, page: 1, pages: 1 },
+          },
+        }),
+      },
+    } as unknown as WebClient;
+
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => nowCounter++,
+    });
+
+    expect(result.newCursor).toBe(new Date(500_000).toISOString());
+
+    const state = dbHandle.db.select().from(integrationState).all();
+    expect(state).toHaveLength(1);
+    expect(state[0]?.integration).toBe('slack');
+    expect(state[0]?.lastPollStartedAtMs).toBeLessThan(state[0]?.lastPollCompletedAtMs ?? 0);
+    expect(state[0]?.cursor).toBe(new Date(500_000).toISOString());
+  });
+
+  it('preserves prior cursor when the poll returns zero matches', async () => {
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      search: {
+        messages: async () => ({
+          ok: true,
+          messages: { matches: [], paging: { count: 0, total: 0, page: 1, pages: 1 } },
+        }),
+      },
+    } as unknown as WebClient;
+
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      since: new Date('2026-05-01T00:00:00Z'),
+      now: () => 1,
+    });
+
+    // The since fallback is the ISO date, since no matches yielded a ts.
+    expect(result.newCursor).toBe('2026-05-01T00:00:00.000Z');
+    expect(result.fetched).toBe(0);
+  });
+
+  it('appends a 1-day-padded after: filter when since is provided', async () => {
+    const searchSpy = vi.fn(async (args: { query: string }) => {
+      // 2026-05-01T12:00:00Z padded backward 1 day = 2026-04-30
+      expect(args.query).toBe('<@U1> after:2026-04-30');
+      return {
+        ok: true,
+        messages: { matches: [], paging: { count: 0, total: 0, page: 1, pages: 1 } },
+      };
+    });
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      search: { messages: searchSpy },
+    } as unknown as WebClient;
+
+    await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      since: new Date('2026-05-01T12:00:00Z'),
+      now: () => 1,
+    });
+  });
+
+  it('walks search.messages pages until messages.paging.pages is reached', async () => {
+    const seenPages: number[] = [];
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      search: {
+        messages: async (args: { page?: number }) => {
+          const page = args.page ?? 1;
+          seenPages.push(page);
+          return {
+            ok: true,
+            messages: {
+              matches: [
+                {
+                  ts: `${1_000_000 + page}.000000`,
+                  user: 'U2',
+                  text: `page ${page}`,
+                  channel: { id: 'C1' },
+                },
+              ],
+              paging: { count: 1, total: 3, page, pages: 3 },
+            },
+          };
+        },
+      },
+    } as unknown as WebClient;
+
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 1,
+    });
+
+    expect(seenPages).toEqual([1, 2, 3]);
+    expect(result.fetched).toBe(3);
+    // Newest ts = 1000003.000000 = 1000003000 ms.
+    expect(result.newCursor).toBe(new Date(1_000_003_000).toISOString());
+    expect(dbHandle.db.select().from(evidenceLog).all()).toHaveLength(3);
+  });
+
+  it('throws and does NOT advance the cursor when paging exceeds MAX_PAGES', async () => {
+    // Pre-seed integration_state with a baseline cursor so we can prove it
+    // wasn't advanced by the failed poll.
+    dbHandle.db
+      .insert(integrationState)
+      .values({
+        integration: 'slack',
+        cursor: 'baseline-cursor-value',
+        lastPollStartedAtMs: 0,
+        lastPollCompletedAtMs: 0,
+        createdAtMs: 0,
+        updatedAtMs: 0,
+      })
+      .run();
+
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      search: {
+        messages: async () => ({
+          ok: true,
+          messages: {
+            matches: [{ ts: '1.0', text: 'm', user: 'U2', channel: { id: 'C1' } }],
+            // Slack reports 21 total pages — over the 20-page safety cap.
+            paging: { count: 1, total: 21, page: 1, pages: 21 },
+          },
+        }),
+      },
+    } as unknown as WebClient;
+
+    await expect(
+      pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 1 }),
+    ).rejects.toThrowError(/exceeds MAX_PAGES/);
+
+    // Cursor must still be the baseline — markPollCompleted never ran.
+    const state = dbHandle.db.select().from(integrationState).get();
+    expect(state?.cursor).toBe('baseline-cursor-value');
+    expect(state?.lastPollCompletedAtMs).toBe(0);
+  });
+
+  it('is idempotent on re-poll: same ts:channel updates rather than duplicating', async () => {
+    const match = {
+      ts: '1762000000.000100',
+      user: 'U0ALICE',
+      text: 'hi <@U1>',
+      channel: { id: 'C0X' },
+    };
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      search: {
+        messages: async () => ({
+          ok: true,
+          messages: { matches: [match], paging: { count: 1, total: 1, page: 1, pages: 1 } },
+        }),
+      },
+    } as unknown as WebClient;
+
+    await pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 100 });
+    await pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 200 });
+
+    const rows = dbHandle.db.select().from(evidenceLog).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      firstSeenAtMs: 100,
+      lastSeenAtMs: 200,
+      createdAtMs: 100,
+      updatedAtMs: 200,
+    });
+  });
+
+  it.skip('cassette: real workspace happy path — see pollMentions (cassette) describe block', () => {
+    // Placeholder so this comment is searchable next to the other tests.
+  });
+
+  it('skips messages without a channel rather than failing the whole poll', async () => {
+    const client = {
+      auth: { test: async () => ({ ok: true, user_id: 'U1', user: 'a', team_id: 'T1' }) },
+      search: {
+        messages: async () => ({
+          ok: true,
+          messages: {
+            matches: [
+              { ts: '100.0', text: 'no channel', user: 'U2' },
+              { ts: '101.0', text: 'has channel', user: 'U2', channel: { id: 'C1' } },
+            ],
+            paging: { count: 2, total: 2, page: 1, pages: 1 },
+          },
+        }),
+      },
+    } as unknown as WebClient;
+
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 1,
+    });
+
+    expect(result.fetched).toBe(2); // counts what Slack returned, not what got upserted
+    const rows = dbHandle.db.select().from(evidenceLog).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.externalId).toBe('mention_101.0:C1');
+  });
+});
+
+describe('pollMentions (cassette)', () => {
+  // Smoke test against a recorded cassette of a real workspace's response.
+  // The cassette was scrubbed by src/test/redact-slack.ts at record-time —
+  // message text, channel names, and the workspace URL are all redacted —
+  // so assertions only check structural shape.
+  let dbHandle: DbHandle;
+
+  beforeEach(() => {
+    dbHandle = openMemoryDb();
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it('returns a fetched count and writes integration_state for slack', async () => {
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
+      now: () => 1_000,
+    });
+
+    expect(typeof result.fetched).toBe('number');
+    expect(result.fetched).toBeGreaterThanOrEqual(0);
+
+    const state = dbHandle.db.select().from(integrationState).all();
+    expect(state).toHaveLength(1);
+    expect(state[0]?.integration).toBe('slack');
+    expect(state[0]?.lastPollStartedAtMs).toBeLessThanOrEqual(state[0]?.lastPollCompletedAtMs ?? 0);
+
+    // If any rows landed, they must be kind='mention' with a kind-prefixed
+    // external_id keying on a Slack ts:channel. The redactor preserves IDs.
+    const rows = dbHandle.db.select().from(evidenceLog).all();
+    for (const row of rows) {
+      expect(row.kind).toBe('mention');
+      expect(row.externalId).toMatch(/^mention_\d+\.\d+:[CDG][A-Z0-9]+$/);
+    }
+  });
+});

--- a/packages/integrations/slack/src/mentions.ts
+++ b/packages/integrations/slack/src/mentions.ts
@@ -1,0 +1,153 @@
+/**
+ * Poll Slack for messages mentioning the auth'd user; upsert into `evidence_log`.
+ *
+ * Strategy: `auth.test` to discover the auth'd user_id, then `search.messages`
+ * with the query `<@U…>`. `search.messages` is page-based (not cursor-based),
+ * so the SDK's `paginate()` does not apply — we walk pages manually using the
+ * response's `messages.paging.{page, page_count}` until exhausted (or the
+ * `MAX_PAGES` safety cap, currently 20 = ~2k mentions).
+ *
+ * Slack's `search.messages` historically requires a user token (`xoxp-`); bot
+ * tokens get `not_allowed_token_type`. The SDK throws on that envelope; we
+ * surface the underlying error rather than swallowing it — token-type policy
+ * is an OAuth-flow concern outside this package.
+ *
+ * `since` (when provided) becomes a `after:YYYY-MM-DD` modifier on the search
+ * query. Slack search has no millisecond cursor and the `after:` operator's
+ * timezone semantics are undocumented — we pad backward by 1 day so we never
+ * miss boundary messages; the idempotent `(integration, kind_ts:channel)`
+ * upsert dedupes the extra rows that pulls in.
+ */
+
+import type { WebClient } from '@slack/web-api';
+import type { SlopweaverDatabase } from '@slopweaver/db';
+import { markPollCompleted, markPollStarted } from '@slopweaver/integrations-core';
+import { createSlackClient } from './client.ts';
+import { type AnySlackMessage, pickNewestTs, upsertSlackMessage } from './upsert.ts';
+
+const INTEGRATION = 'slack';
+const PER_PAGE = 100;
+const MAX_PAGES = 20;
+
+export type PollMentionsArgs = {
+  db: SlopweaverDatabase;
+  token: string;
+  since?: Date;
+  client?: WebClient;
+  now?: () => number;
+};
+
+export type PollResult = {
+  fetched: number;
+  newCursor: string | null;
+};
+
+export async function pollMentions({
+  db,
+  token,
+  since,
+  client,
+  now = Date.now,
+}: PollMentionsArgs): Promise<PollResult> {
+  const slack = client ?? createSlackClient({ token });
+  const startedAt = now();
+  markPollStarted({ db, integration: INTEGRATION, now: startedAt });
+
+  // Slack guarantees user_id / team_id on ok:true responses; the SDK throws
+  // WebAPIPlatformError on { ok: false } so the asserts below are reached
+  // only when Slack returned values.
+  const auth = await slack.auth.test();
+  // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees user_id on ok:true
+  const userId = auth.user_id!;
+  // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees team_id on ok:true
+  const teamId = auth.team_id!;
+  const workspaceUrl = auth.url ?? null;
+
+  const queryParts = [`<@${userId}>`];
+  if (since) {
+    const padded = new Date(since.getTime() - 24 * 60 * 60 * 1_000);
+    queryParts.push(`after:${formatSlackDate({ date: padded })}`);
+  }
+  const query = queryParts.join(' ');
+
+  let fetched = 0;
+  let newestTs: string | null = null;
+  let page = 1;
+  let totalPages = 1;
+
+  while (page <= MAX_PAGES) {
+    const response = await slack.search.messages({ query, count: PER_PAGE, page });
+    const matches = response.messages?.matches ?? [];
+    fetched += matches.length;
+
+    const observedAt = now();
+    for (const match of matches) {
+      upsertSlackMessage({
+        db,
+        message: match,
+        kind: 'mention',
+        teamId,
+        workspaceUrl,
+        now: observedAt,
+      });
+    }
+
+    const pageNewest = pickNewestTs(matches);
+    if (pageNewest && (newestTs === null || compareTs(pageNewest, newestTs) > 0)) {
+      newestTs = pageNewest;
+    }
+
+    const paging = response.messages?.paging;
+    totalPages = paging?.pages ?? page;
+    if (!paging || page >= totalPages) break;
+    page += 1;
+  }
+
+  // Refuse to advance the cursor if we exited the loop because of the safety
+  // cap rather than because Slack said there were no more pages — otherwise
+  // the unfetched tail is unrecoverable on the next poll. Throwing is loud
+  // enough that the operator sees it and can re-run with a tighter `since`.
+  if (totalPages > MAX_PAGES) {
+    throw new Error(
+      `pollMentions: search.messages returned ${totalPages} pages, exceeds MAX_PAGES=${MAX_PAGES}; ` +
+        'cursor not advanced. Re-run with a more recent `since` to recover the tail.',
+    );
+  }
+
+  // Preserve the prior watermark when the poll returns zero items, otherwise
+  // the next poll would backfill from the beginning. Matches #33 github's
+  // empty-page rule. Cursors are always ISO-8601 so the public
+  // `since?: Date` / `newCursor: string | null` contract round-trips through
+  // `new Date(cursor)` without per-platform parsing.
+  const newCursor = newestTs ? slackTsToIso(newestTs) : (since?.toISOString() ?? null);
+  markPollCompleted({ db, integration: INTEGRATION, cursor: newCursor, now: now() });
+  return { fetched, newCursor };
+}
+
+function compareTs(a: string, b: string): number {
+  const aN = Number.parseFloat(a);
+  const bN = Number.parseFloat(b);
+  if (!Number.isFinite(aN) || !Number.isFinite(bN)) return a.localeCompare(b);
+  return aN === bN ? 0 : aN > bN ? 1 : -1;
+}
+
+function slackTsToIso(ts: string): string {
+  // Slack ts is "<unix-seconds>.<microseconds>". The `since?: Date` round-
+  // trip only needs millisecond precision, so we floor to ms.
+  const seconds = Number.parseFloat(ts);
+  if (!Number.isFinite(seconds)) {
+    throw new Error(`slackTsToIso: cannot parse ts ${ts}`);
+  }
+  return new Date(Math.round(seconds * 1_000)).toISOString();
+}
+
+function formatSlackDate({ date }: { date: Date }): string {
+  // Slack's `after:` modifier accepts YYYY-MM-DD; the date format is the
+  // workspace timezone but our pad-by-1-day hedge handles the ambiguity.
+  const yyyy = date.getUTCFullYear().toString().padStart(4, '0');
+  const mm = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+  const dd = date.getUTCDate().toString().padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export type { AnySlackMessage };

--- a/packages/integrations/slack/src/test/db.ts
+++ b/packages/integrations/slack/src/test/db.ts
@@ -1,0 +1,13 @@
+/**
+ * In-memory SQLite handle for slack package tests.
+ *
+ * Mirrors the pattern used in `packages/db/src/db.test.ts` and
+ * `packages/mcp-server/src/server.test.ts` — a fresh `:memory:` database with
+ * migrations applied, isolated per test.
+ */
+
+import { type CreateDbHandle, createDb } from '@slopweaver/db';
+
+export function openMemoryDb(): CreateDbHandle {
+  return createDb({ path: ':memory:' });
+}

--- a/packages/integrations/slack/src/test/redact-slack.test.ts
+++ b/packages/integrations/slack/src/test/redact-slack.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Sentinel-driven test of the Slack PII redactors.
+ *
+ * Builds a representative recording (covering `auth.test`, `users.info`,
+ * `search.messages`, `conversations.list`, `conversations.history`) where
+ * every PII field is set to a unique sentinel string. Runs the redactors
+ * against it and asserts no sentinel survives.
+ *
+ * If a future contributor adds a Slack response field with PII and forgets
+ * to extend `redact-slack.ts`, this test fails before the cassette can be
+ * recorded, let alone committed.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { PollyRecording } from '@slopweaver/integrations-core/test-setup/polly';
+import { slackRedactors } from './redact-slack.ts';
+
+const SENTINELS = [
+  '__SENTINEL_MESSAGE_TEXT__',
+  '__SENTINEL_REAL_NAME__',
+  '__SENTINEL_DISPLAY_NAME__',
+  '__SENTINEL_DISPLAY_NORM__',
+  '__SENTINEL_FIRST_NAME__',
+  '__SENTINEL_LAST_NAME__',
+  '__SENTINEL_EMAIL__',
+  '__SENTINEL_PHONE__',
+  '__SENTINEL_TITLE__',
+  '__SENTINEL_TZ__',
+  '__SENTINEL_TZ_LABEL__',
+  '__SENTINEL_STATUS_TEXT__',
+  '__SENTINEL_IMAGE_URL__',
+  '__SENTINEL_CHANNEL_NAME__',
+  '__SENTINEL_CHANNEL_NAME_NORM__',
+  '__SENTINEL_PURPOSE__',
+  '__SENTINEL_TOPIC__',
+  '__SENTINEL_QUERY__',
+  '__SENTINEL_AVATAR_HASH__',
+  '__SENTINEL_USER_HANDLE__',
+  '__SENTINEL_TEAM_NAME__',
+  '__SENTINEL_USERNAME__',
+  '__SENTINEL_FILE_ID__',
+  '__SENTINEL_TAB_ID__',
+  '__SENTINEL_SHARED_TS__',
+];
+
+function buildRecording(): PollyRecording {
+  return {
+    request: {
+      url: 'https://slack.com/api/search.messages',
+      headers: [{ name: 'authorization', value: 'Bearer xoxp-…' }],
+      cookies: [],
+      postData: { text: 'query=__SENTINEL_QUERY__&count=100&page=1' },
+    },
+    response: {
+      headers: [],
+      cookies: [],
+      content: {
+        text: JSON.stringify({
+          ok: true,
+          // auth.test url + ambiguous user/team strings
+          url: 'https://slopweaver.slack.com/',
+          team: '__SENTINEL_TEAM_NAME__',
+          user: '__SENTINEL_USER_HANDLE__',
+          team_id: 'T0',
+          user_id: 'U0',
+          // users.info shape
+          user_obj_keep_user_id_intact: 'U0',
+          full_user: {
+            id: 'U0',
+            name: 'login-handle',
+            real_name: '__SENTINEL_REAL_NAME__',
+            tz: '__SENTINEL_TZ__',
+            tz_label: '__SENTINEL_TZ_LABEL__',
+            avatar_hash: '__SENTINEL_AVATAR_HASH__',
+            profile: {
+              real_name: '__SENTINEL_REAL_NAME__',
+              real_name_normalized: '__SENTINEL_REAL_NAME__',
+              display_name: '__SENTINEL_DISPLAY_NAME__',
+              display_name_normalized: '__SENTINEL_DISPLAY_NORM__',
+              first_name: '__SENTINEL_FIRST_NAME__',
+              last_name: '__SENTINEL_LAST_NAME__',
+              email: '__SENTINEL_EMAIL__',
+              phone: '__SENTINEL_PHONE__',
+              title: '__SENTINEL_TITLE__',
+              status_text: '__SENTINEL_STATUS_TEXT__',
+              image_72: '__SENTINEL_IMAGE_URL__',
+              image_512: '__SENTINEL_IMAGE_URL__',
+              avatar_hash: '__SENTINEL_AVATAR_HASH__',
+              // The 'team' field on a user profile is a team_id (Slack ID format)
+              // — must NOT be scrubbed because tests assert on team_ids.
+              team: 'T0',
+            },
+          },
+          // search.messages
+          messages: {
+            matches: [
+              {
+                ts: '1.0',
+                user: 'U0',
+                username: '__SENTINEL_USERNAME__',
+                text: '__SENTINEL_MESSAGE_TEXT__',
+                channel: { id: 'C0', name: '__SENTINEL_CHANNEL_NAME__' },
+                permalink: 'https://slopweaverworkspace.slack.com/archives/C0/p1000',
+              },
+            ],
+            paging: { count: 1, total: 1, page: 1, pages: 1 },
+          },
+          // conversations.list
+          channels: [
+            {
+              id: 'C0',
+              is_im: false,
+              name: '__SENTINEL_CHANNEL_NAME__',
+              name_normalized: '__SENTINEL_CHANNEL_NAME_NORM__',
+              purpose: { value: '__SENTINEL_PURPOSE__', creator: 'U0' },
+              topic: { value: '__SENTINEL_TOPIC__', creator: 'U0' },
+              // The `properties` subtree on a channel can contain references
+              // to workspace-internal canvases, meeting-notes, tabs, file IDs.
+              // Slack adds keys here over time. We drop the whole subtree
+              // rather than enumerate.
+              properties: {
+                meeting_notes: { file_id: '__SENTINEL_FILE_ID__', is_locked: true },
+                tabs: [
+                  {
+                    id: '__SENTINEL_TAB_ID__',
+                    type: 'canvas',
+                    data: {
+                      file_id: '__SENTINEL_FILE_ID__',
+                      shared_ts: '__SENTINEL_SHARED_TS__',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      },
+    },
+  };
+}
+
+describe('slack redactors', () => {
+  it('strips every sentinel from a representative recording', () => {
+    const recording = buildRecording();
+    for (const redactor of slackRedactors) {
+      redactor(recording);
+    }
+    const serialized =
+      (recording.request?.postData?.text ?? '') + (recording.response?.content?.text ?? '');
+    for (const sentinel of SENTINELS) {
+      expect(serialized).not.toContain(sentinel);
+    }
+  });
+
+  it('preserves IDs and structural fields', () => {
+    const recording = buildRecording();
+    for (const redactor of slackRedactors) {
+      redactor(recording);
+    }
+    const text = recording.response?.content?.text ?? '';
+    expect(text).toContain('"id":"U0"');
+    expect(text).toContain('"id":"C0"');
+    expect(text).toContain('"ok":true');
+    expect(text).toContain('"is_im":false');
+    expect(text).toContain('"ts":"1.0"');
+    expect(text).toContain('"team_id":"T0"');
+    expect(text).toContain('"user_id":"U0"');
+    // `team` inside profile is a team_id — pseudonymous, must survive.
+    expect(text).toContain('"team":"T0"');
+  });
+
+  it('replaces workspace .slack.com URL with example.slack.com', () => {
+    const recording = buildRecording();
+    for (const redactor of slackRedactors) {
+      redactor(recording);
+    }
+    const text = recording.response?.content?.text ?? '';
+    expect(text).not.toContain('slopweaver.slack.com');
+    expect(text).not.toContain('slopweaverworkspace.slack.com');
+    expect(text).toContain('example.slack.com');
+    // Permalink path structure preserved
+    expect(text).toContain('example.slack.com/archives/C0/p1000');
+  });
+
+  it('replaces query and q form params with [redacted-query]', () => {
+    const recording = buildRecording();
+    for (const redactor of slackRedactors) {
+      redactor(recording);
+    }
+    const body = recording.request?.postData?.text ?? '';
+    expect(body).not.toContain('__SENTINEL_QUERY__');
+    expect(body).toMatch(/query=%5Bredacted-query%5D/);
+  });
+});

--- a/packages/integrations/slack/src/test/redact-slack.ts
+++ b/packages/integrations/slack/src/test/redact-slack.ts
@@ -1,0 +1,185 @@
+/**
+ * Slack-specific PII redactors plugged into the core Polly setup.
+ *
+ * Strategy: keep IDs (pseudonymous, required for assertions), scrub everything
+ * a determined adversary could correlate back to a real workspace or its
+ * members. Applied at `beforePersist`, after the core's default
+ * header/cookie/token-string redaction.
+ *
+ * Fields scrubbed:
+ *   - message text (across `messages.matches[].text`, `messages[].text`,
+ *     and any nested `attachments[].text` / `blocks[].elements[].text`)
+ *   - user profile (`real_name`, `display_name`, `display_name_normalized`,
+ *     `real_name_normalized`, `first_name`, `last_name`, `email`, `phone`,
+ *     `title`, `image_*`, `bot_id`, `tz_label`)
+ *   - channel name (`name`, `name_normalized`, `purpose.value`, `topic.value`)
+ *   - workspace URL (`auth.test.url` → `https://example.slack.com/`)
+ *
+ * Fields preserved (pseudonymous):
+ *   - All IDs: user_id (`U…`), channel_id (`C…`/`D…`/`G…`), team_id (`T…`),
+ *     message ts (epoch), enterprise_id, app_id, bot_id-as-id-only.
+ *   - Structural flags (`ok`, `is_im`, `is_member`, `is_bot`, `deleted`).
+ *
+ * Each redactor mutates the recording in place. The accompanying
+ * `redact-slack.test.ts` exercises every redactor against a sentinel-laden
+ * fixture and asserts no sentinel survives.
+ */
+
+import type { ExtraRedactor, PollyRecording } from '@slopweaver/integrations-core/test-setup/polly';
+
+const SCRUB_PROFILE_KEYS = new Set([
+  'real_name',
+  'display_name',
+  'display_name_normalized',
+  'real_name_normalized',
+  'first_name',
+  'last_name',
+  'email',
+  'phone',
+  'title',
+  'tz',
+  'tz_label',
+  'status_text',
+  'status_emoji',
+  'status_emoji_display_info',
+  'avatar_hash',
+  'color',
+  'who_can_share_contact_card',
+  'username',
+]);
+
+// Any URL whose host ends in `.slack.com` reveals the workspace's vanity
+// domain. Replace the host portion with `example.slack.com` and preserve
+// the path (channel IDs are pseudonymous and tests assert on the structure).
+const SLACK_HOST_REGEX = /https?:\/\/[a-z0-9-]+\.slack\.com/gi;
+
+const SCRUB_IMAGE_KEY_REGEX = /^image_/;
+const SCRUB_CHANNEL_KEYS = new Set(['name', 'name_normalized']);
+const SCRUB_NESTED_TEXT_PARENTS = new Set(['purpose', 'topic']);
+// `properties` on a Slack channel is an unstable, feature-flag-shaped subtree
+// that holds references to workspace-internal canvases, meeting notes, file
+// IDs, tab IDs, and other document metadata. We don't assert on any of it, so
+// drop the entire subtree wholesale rather than enumerate every field Slack
+// might add later.
+const DROP_SUBTREE_KEYS = new Set(['properties']);
+// `user` and `team` are tricky: they're used both as IDs (uppercase alnum,
+// pseudonymous, must keep for assertions) and as handles / display names
+// (PII, must scrub). The regex below matches Slack's ID format. Only scrub
+// when the value doesn't look like an ID.
+const SLACK_ID_REGEX = /^[UTCDGW][A-Z0-9]+$/;
+const SCRUB_AMBIGUOUS_KEYS = new Set(['user', 'team']);
+
+const REDACTED = '[redacted]';
+const REDACTED_TEXT = '[redacted-message-text]';
+const REDACTED_URL = 'https://example.slack.com/';
+
+/**
+ * Walk a JSON tree and apply Slack-specific scrubbers in place.
+ *
+ * The traversal is structural — it knows about Slack's response shapes well
+ * enough to scrub at the right places without nuking IDs. A pure-text-blast
+ * approach would either over-redact (lose `ok` / IDs) or under-redact (miss
+ * nested attachments / blocks).
+ */
+function scrubSlackTree(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => scrubSlackTree(entry));
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(obj)) {
+      if (DROP_SUBTREE_KEYS.has(key)) {
+        out[key] = '[redacted]';
+        continue;
+      }
+      if (key === 'text' && typeof v === 'string' && v.length > 0) {
+        out[key] = REDACTED_TEXT;
+        continue;
+      }
+      // Scrub any string value containing a *.slack.com URL (covers `url`,
+      // `permalink`, and any other URL-shaped field). The replacement keeps
+      // the URL structure (path, query) intact so tests can still assert on
+      // it; only the workspace-identifying host is rewritten.
+      if (typeof v === 'string' && SLACK_HOST_REGEX.test(v)) {
+        SLACK_HOST_REGEX.lastIndex = 0;
+        out[key] = v.replace(SLACK_HOST_REGEX, 'https://example.slack.com');
+        SLACK_HOST_REGEX.lastIndex = 0;
+        continue;
+      }
+      if (SCRUB_PROFILE_KEYS.has(key) && typeof v === 'string') {
+        out[key] = REDACTED;
+        continue;
+      }
+      if (SCRUB_AMBIGUOUS_KEYS.has(key) && typeof v === 'string') {
+        out[key] = SLACK_ID_REGEX.test(v) ? v : REDACTED;
+        continue;
+      }
+      if (SCRUB_IMAGE_KEY_REGEX.test(key) && typeof v === 'string') {
+        out[key] = REDACTED;
+        continue;
+      }
+      if (SCRUB_CHANNEL_KEYS.has(key) && typeof v === 'string') {
+        out[key] = REDACTED;
+        continue;
+      }
+      if (SCRUB_NESTED_TEXT_PARENTS.has(key) && v && typeof v === 'object') {
+        const inner = v as Record<string, unknown>;
+        out[key] = {
+          ...inner,
+          ...(typeof inner['value'] === 'string' && inner['value'].length > 0
+            ? { value: REDACTED }
+            : {}),
+        };
+        continue;
+      }
+      out[key] = scrubSlackTree(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+const redactSlackResponse: ExtraRedactor = (recording: PollyRecording): void => {
+  const text = recording.response?.content?.text;
+  if (typeof text !== 'string' || text.length === 0) return;
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return;
+  }
+  const scrubbed = scrubSlackTree(parsed);
+  if (recording.response?.content) {
+    recording.response.content.text = JSON.stringify(scrubbed);
+  }
+};
+
+const redactSlackRequestBody: ExtraRedactor = (recording: PollyRecording): void => {
+  // search.messages and conversations.* requests are POST'd as form-urlencoded
+  // bodies. Token values are already scrubbed by core's REDACT_VALUE_REGEX,
+  // but `query=<@U…>` strings are also worth normalising — they reveal who
+  // the recording user is. Replace any `query` param value entirely.
+  const body = recording.request?.postData?.text;
+  if (typeof body !== 'string' || body.length === 0) return;
+  if (!body.includes('=')) return;
+  try {
+    const params = new URLSearchParams(body);
+    let changed = false;
+    for (const key of ['query', 'q']) {
+      if (params.has(key)) {
+        params.set(key, '[redacted-query]');
+        changed = true;
+      }
+    }
+    if (changed && recording.request?.postData) {
+      recording.request.postData.text = params.toString();
+    }
+  } catch {
+    // body wasn't urlencoded — leave it alone
+  }
+};
+
+export const slackRedactors: ExtraRedactor[] = [redactSlackResponse, redactSlackRequestBody];

--- a/packages/integrations/slack/src/test/setup-polly.ts
+++ b/packages/integrations/slack/src/test/setup-polly.ts
@@ -1,0 +1,13 @@
+/**
+ * Polly cassette setup for @slopweaver/integrations-slack tests.
+ *
+ * Wires the shared cassette plumbing from `@slopweaver/integrations-core`,
+ * extended with Slack-specific PII redactors so cassettes recorded against a
+ * real workspace don't commit message text, real names, emails, channel
+ * names, or workspace URLs.
+ */
+
+import { definePollySetup } from '@slopweaver/integrations-core/test-setup/polly';
+import { slackRedactors } from './redact-slack.ts';
+
+definePollySetup({ extraRedactors: slackRedactors });

--- a/packages/integrations/slack/src/upsert.ts
+++ b/packages/integrations/slack/src/upsert.ts
@@ -1,0 +1,132 @@
+/**
+ * Slack-specific shim that translates a Slack message (from `search.messages`
+ * or `conversations.history`) into the generic `UpsertEvidenceArgs` shape
+ * `@slopweaver/integrations-core` exposes.
+ *
+ * `external_id` is kind-prefixed (`mention_…` / `message_…`) so the same
+ * Slack `ts` observed via both `search.messages` (a mention) and
+ * `conversations.history` (the DM that contains the mention) lands as two
+ * rows in `evidence_log` — same wire-level convention #33's github package
+ * uses for `pr_` / `issue_` / `mention_`.
+ *
+ * The function returns the message's `ts` on success so the caller can
+ * compute a cursor for `markPollCompleted`. Returns `null` when the message
+ * was skipped (missing `ts`, missing channel, or malformed `ts`).
+ */
+
+import type { ConversationsHistoryResponse, SearchMessagesResponse } from '@slack/web-api';
+import type { SlopweaverDatabase } from '@slopweaver/db';
+import { upsertEvidence } from '@slopweaver/integrations-core';
+
+type SearchMatch = NonNullable<NonNullable<SearchMessagesResponse['messages']>['matches']>[number];
+type HistoryMessage = NonNullable<ConversationsHistoryResponse['messages']>[number];
+export type AnySlackMessage = SearchMatch | HistoryMessage;
+
+export type SlackMessageKind = 'mention' | 'message';
+
+export function upsertSlackMessage({
+  db,
+  message,
+  kind,
+  teamId,
+  workspaceUrl,
+  channelId,
+  now,
+}: {
+  db: SlopweaverDatabase;
+  message: AnySlackMessage;
+  kind: SlackMessageKind;
+  teamId: string;
+  workspaceUrl: string | null;
+  channelId?: string;
+  now: number;
+}): { ts: string | null } {
+  const ts = message.ts;
+  if (!ts) return { ts: null };
+
+  const resolvedChannelId = channelId ?? extractChannelId({ message });
+  if (!resolvedChannelId) return { ts: null };
+
+  const occurredAtMs = parseSlackTs({ ts });
+  if (occurredAtMs === null) return { ts: null };
+
+  const externalId = `${kind}_${ts}:${resolvedChannelId}`;
+  const text = message.text ?? '';
+  const title = text.length > 0 ? (text.split('\n', 1)[0]?.slice(0, 200) ?? null) : null;
+  const permalinkFromMatch =
+    'permalink' in message && typeof message.permalink === 'string' ? message.permalink : undefined;
+  const citationUrl =
+    permalinkFromMatch ?? buildPermalink({ workspaceUrl, channelId: resolvedChannelId, ts });
+
+  upsertEvidence({
+    db,
+    integration: 'slack',
+    externalId,
+    kind,
+    title,
+    body: text || null,
+    citationUrl,
+    payloadJson: JSON.stringify({ ...message, _team_id: teamId }),
+    occurredAtMs,
+    now,
+  });
+
+  return { ts };
+}
+
+/**
+ * Returns the lexicographically greatest `ts` from a list of messages, which
+ * (because Slack `ts` is `<unix-seconds>.<microseconds>` zero-padded enough
+ * to compare correctly as a string in any practical window) is the newest.
+ * Returns `null` if no message has a `ts`.
+ */
+export function pickNewestTs(messages: AnySlackMessage[]): string | null {
+  let newest: string | null = null;
+  for (const message of messages) {
+    const ts = message.ts;
+    if (typeof ts !== 'string' || ts.length === 0) continue;
+    if (newest === null || compareSlackTs(ts, newest) > 0) {
+      newest = ts;
+    }
+  }
+  return newest;
+}
+
+function compareSlackTs(a: string, b: string): number {
+  const aN = Number.parseFloat(a);
+  const bN = Number.parseFloat(b);
+  if (!Number.isFinite(aN) || !Number.isFinite(bN)) return a.localeCompare(b);
+  return aN === bN ? 0 : aN > bN ? 1 : -1;
+}
+
+function extractChannelId({ message }: { message: AnySlackMessage }): string | null {
+  const channel = (message as SearchMatch).channel;
+  if (!channel) return null;
+  if (typeof channel === 'string') return channel;
+  return channel.id ?? null;
+}
+
+function buildPermalink({
+  workspaceUrl,
+  channelId,
+  ts,
+}: {
+  workspaceUrl: string | null;
+  channelId: string;
+  ts: string;
+}): string | null {
+  if (!workspaceUrl) return null;
+  // Slack permalinks are `<workspace>/archives/<channel>/p<ts-without-dot>`.
+  const tsCompact = ts.replace('.', '');
+  const base = workspaceUrl.endsWith('/') ? workspaceUrl.slice(0, -1) : workspaceUrl;
+  return `${base}/archives/${channelId}/p${tsCompact}`;
+}
+
+function parseSlackTs({ ts }: { ts: string }): number | null {
+  // Slack ts is "<unix-seconds>.<microseconds>" — convert to epoch ms.
+  // Returns null on malformed input so callers can skip the row instead of
+  // coercing to epoch 0 and corrupting freshness ordering.
+  const seconds = Number.parseFloat(ts);
+  if (!Number.isFinite(seconds)) return null;
+  return Math.round(seconds * 1_000);
+}

--- a/packages/integrations/slack/tsconfig.build.json
+++ b/packages/integrations/slack/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "src/test/**", "src/__recordings__/**"]
+}

--- a/packages/integrations/slack/tsconfig.json
+++ b/packages/integrations/slack/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/integrations/slack/vitest.config.ts
+++ b/packages/integrations/slack/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    setupFiles: ['./src/test/setup-polly.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,37 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@types/node@22.10.5)(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
+  packages/integrations/core:
+    dependencies:
+      '@pollyjs/adapter-node-http':
+        specifier: 6.0.6
+        version: 6.0.6(patch_hash=ff919378829e46d1101e51d13824e5ea36d4dd1851c447b2183fa46549fde840)
+      '@pollyjs/core':
+        specifier: 6.0.6
+        version: 6.0.6
+      '@pollyjs/persister-fs':
+        specifier: 6.0.6
+        version: 6.0.6
+      '@slopweaver/db':
+        specifier: workspace:*
+        version: link:../../db
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)
+      nock:
+        specifier: 13.5.6
+        version: 13.5.6
+      node-fetch:
+        specifier: 3.3.2
+        version: 3.3.2
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@22.10.5)(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
   packages/integrations/github:
     dependencies:
       '@octokit/plugin-throttling':
@@ -150,25 +181,35 @@ importers:
       '@slopweaver/db':
         specifier: workspace:*
         version: link:../../db
+      '@slopweaver/integrations-core':
+        specifier: workspace:*
+        version: link:../core
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)
     devDependencies:
-      '@pollyjs/adapter-node-http':
-        specifier: 6.0.6
-        version: 6.0.6(patch_hash=ff919378829e46d1101e51d13824e5ea36d4dd1851c447b2183fa46549fde840)
-      '@pollyjs/core':
-        specifier: 6.0.6
-        version: 6.0.6
-      '@pollyjs/persister-fs':
-        specifier: 6.0.6
-        version: 6.0.6
-      nock:
-        specifier: 13.5.6
-        version: 13.5.6
-      node-fetch:
-        specifier: 3.3.2
-        version: 3.3.2
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@22.10.5)(vite@8.0.10(@types/node@22.10.5)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/integrations/slack:
+    dependencies:
+      '@slack/web-api':
+        specifier: 7.15.1
+        version: 7.15.1
+      '@slopweaver/db':
+        specifier: workspace:*
+        version: link:../../db
+      '@slopweaver/integrations-core':
+        specifier: workspace:*
+        version: link:../core
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)
+    devDependencies:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1333,6 +1374,18 @@ packages:
     resolution: {integrity: sha512-suq9tRQ6bkpMukTG5K5z0sPWB7t0zExMzZCdmYm6xTSSIm/yCKNm7VCL36wVeyTsFr597/UhU1OAYdHGMDiHrw==}
     engines: {node: '>=10'}
 
+  '@slack/logger@4.0.1':
+    resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/types@2.21.0':
+    resolution: {integrity: sha512-ZLMsKnD5KLRPmhFEoGoBQUD5Pc2bH3xFc5ygHlioEc0WmLGyZGoGCtMff4rpejrFnptrhfxcKpWxW4r3g39R0A==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.15.1':
+    resolution: {integrity: sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1389,6 +1442,9 @@ packages:
 
   '@types/node@22.10.5':
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@types/set-cookie-parser@2.4.10':
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
@@ -1464,6 +1520,12 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1561,6 +1623,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
@@ -1634,6 +1700,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1772,6 +1842,10 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
@@ -1873,6 +1947,12 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
@@ -1973,6 +2053,19 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
@@ -2047,6 +2140,10 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -2104,6 +2201,9 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2118,6 +2218,10 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2459,6 +2563,10 @@ packages:
   oxc-resolver@11.19.1:
     resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2466,6 +2574,18 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2528,6 +2648,10 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -2580,6 +2704,10 @@ packages:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
@@ -3780,6 +3908,29 @@ snapshots:
 
   '@sindresorhus/fnv1a@2.0.1': {}
 
+  '@slack/logger@4.0.1':
+    dependencies:
+      '@types/node': 22.10.5
+
+  '@slack/types@2.21.0': {}
+
+  '@slack/web-api@7.15.1':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/types': 2.21.0
+      '@types/node': 22.10.5
+      '@types/retry': 0.12.0
+      axios: 1.16.0
+      eventemitter3: 5.0.4
+      form-data: 4.0.5
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+
   '@standard-schema/spec@1.1.0': {}
 
   '@turbo/darwin-64@2.9.7':
@@ -3825,6 +3976,8 @@ snapshots:
   '@types/node@22.10.5':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/retry@0.12.0': {}
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
@@ -3912,6 +4065,16 @@ snapshots:
   array-flatten@1.1.1: {}
 
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.16.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
 
   balanced-match@4.0.4: {}
 
@@ -4023,6 +4186,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
@@ -4072,6 +4239,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
@@ -4113,6 +4282,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -4305,6 +4481,10 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
+
   eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
@@ -4467,6 +4647,16 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
@@ -4539,6 +4729,10 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
@@ -4587,6 +4781,8 @@ snapshots:
     dependencies:
       hasown: 2.0.3
 
+  is-electron@2.2.2: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -4596,6 +4792,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-promise@4.0.0: {}
+
+  is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -4927,6 +5125,8 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  p-finally@1.0.0: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -4934,6 +5134,20 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   parseurl@1.3.3: {}
 
@@ -4986,6 +5200,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -5045,6 +5261,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retry@0.13.1: {}
 
   rolldown@1.0.0-rc.17:
     dependencies:


### PR DESCRIPTION
## What this PR does

Scaffolds `@slopweaver/integrations-slack` — the first package under `packages/integrations/`. Exports four entrypoints:

- `pollMentions({ db, token, since? })` — `auth.test` + `search.messages` against `<@U…>`; upserts `evidence_log` with `kind='mention'`.
- `pollDMs({ db, token, since? })` — `conversations.list?types=im` then `conversations.history` per IM channel; upserts `evidence_log` with `kind='message'`.
- `fetchIdentity({ db, token })` — `auth.test` + `users.info`; upserts `identity_graph` preserving `canonical_id` and `created_at_ms` across re-runs.
- `createSlackClient({ token, fetch?, sleep? })` — fetch wrapper that honours 429 `Retry-After` once before surfacing a `SlackApiError`.

## Why

`refs #2` (v1.0.0 roadmap). One of the three Terminal 3 scaffolding worktrees. Establishes the integration-package shape that github / linear / jira will mirror in follow-up PRs.

## How HTTP testing is wired

Adopts the Polly + nock cassette stack used in `slopweaver-private`:

- `@pollyjs/{core,adapter-node-http,persister-fs}@6.0.6` + `nock@13.5.6` (root `pnpm.overrides` pins nock for adapter compatibility).
- `patches/@pollyjs__adapter-node-http@6.0.6.patch` (copied verbatim from the private repo) fixes HTTPS request handling and content-encoding edge cases.
- `node-fetch@3.3.2` replaces `globalThis.fetch` in `src/test/setup-polly.ts` so requests go through Node's `http` module where Polly can intercept (Node 22's native undici-based fetch bypasses Polly's adapter otherwise).
- `setup-polly.ts` is loaded as a vitest `setupFile`; it scrubs auth headers and token-shaped JSON values before persisting cassettes.

The initial scaffold tests inject a fake `SlackClient` via DI rather than using cassettes, since no real Slack workspace is available to record against. The Polly infrastructure is wired and ready — see README for the `POLLY_MODE=record SLACK_BOT_TOKEN=…` re-record flow when a workspace is connected.

## Pre-requisite config changes

- `pnpm-workspace.yaml`: added `packages/integrations/*` so nested packages register as workspaces.
- `eslint.config.js`: added `{ type: 'package', pattern: 'packages/integrations/*' }` to `boundaries/elements` so imports inside the slack package satisfy `boundaries/element-types`.

## Out of scope

- OAuth installation flow / token storage
- Write operations (sending messages, reactions)
- Threads (`thread_ts`)
- RTM / Socket Mode / Events API webhooks
- Slash commands
- Wiring this package into `mcp-server` tools
- Reconciliation of github vs slack package shape (deferred until both exist)

## Test plan

- [x] `pnpm format:check` ✅
- [x] `pnpm lint` ✅
- [x] `pnpm compile` ✅
- [x] `pnpm test` — 16 new tests pass; full repo suite stays green ✅
- [x] `pnpm knip` ✅
- [ ] Re-record cassettes against a real Slack bot token (follow-up PR once a workspace is connected)

## Notes for the reviewer

- Tests use injected fake `SlackClient` rather than Polly cassettes for now — the Polly infrastructure is ready for first-record but not yet exercised end-to-end. Worth deciding whether to keep cassettes per-developer or commit them (root `.gitignore` excludes `*.har` as a safety net; README flags the trade-off).
- `client.ts` and the Slack permalink derivation in `mentions.ts` are tested directly; the `auth.test` + `users.info` two-step in `fetchIdentity` reflects the bot-token reality (`users.identity` requires a user-token scope).
- One worktree = one branch = one PR — this is one of three Terminal 3 worktrees in flight; `pnpm-workspace.yaml` and `eslint.config.js` edits may conflict with sibling PRs touching the same files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Slack integration package exposing client creation and APIs to poll mentions, DMs, and fetch identity.

* **Tests**
  * Added comprehensive tests, HTTP recording/replay support, in-memory test DB helpers, and a Vitest test setup.

* **Documentation**
  * Reworked Slack integration README with API, testing, and development guidance.

* **Chores**
  * Updated workspace, lint boundaries, build/test configs, package manager settings, and added a runtime/patch for HTTP adapter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->