### PR TITLE
chore(security): wire gitleaks via lefthook + CI gate

### DIFF
--- a/.claude/orchestration/security/gitleaks-secret-scanning.md
+++ b/.claude/orchestration/security/gitleaks-secret-scanning.md
@@ -213,9 +213,10 @@ Claude executes the plan in order:
 4. Edit `CONTRIBUTING.md` and (if the plan calls for it)
    `.claude/rules/workflow.md`.
 5. Run `pnpm install` to register the hooks locally.
-6. Plant a fake `xoxb-1234567890123-1234567890123-test-secret-DELETE`
-   in a scratch file, attempt to commit, confirm the hook blocks it.
-   Remove the file.
+6. Plant a fake xoxb-shaped token in a scratch file (use an `xoxb-`
+   prefix, two 13-digit groups, and a 24-char alphanumeric tail —
+   generate at test time; do NOT commit the literal to this doc),
+   attempt to commit, confirm the hook blocks it. Remove the file.
 7. Run the full local verification loop:
    `pnpm format:check && pnpm lint && pnpm compile && pnpm test &&
    pnpm knip` — all five existing gates must pass.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -49,15 +49,12 @@ NEVER `git rebase origin/main` — it rewrites history that's already pushed and
 Before declaring work done (or before opening a PR for review), run the same checks CI runs:
 
 ```bash
-pnpm format:check
-pnpm lint
-pnpm compile
-pnpm test
+pnpm validate   # format:check, lint, compile, test, knip
 ```
 
-All four must pass. CI will reject on red.
+All five gates must pass. CI also runs `gitleaks detect` as a sixth gate; the pre-commit hook covers staged content locally. CI will reject on red.
 
-If you change formatting, run `pnpm format` (no `:check`) to auto-fix, then re-run `format:check` to verify.
+If you change formatting, run `pnpm format` (no `:check`) to auto-fix, then re-run `validate` to verify.
 
 ## Decisions live in GitHub Issues
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -78,6 +78,10 @@ This repo is public. Never commit:
 
 The `.gitignore` excludes common offenders (`.env*`, `*.har`) but verify any test fixture you add doesn't include real data.
 
+## Secret scanning is enforced
+
+A lefthook pre-commit hook runs `gitleaks v8.30.1` against staged content. Contributors and AI agents must install gitleaks locally before committing — see [CONTRIBUTING.md](../../CONTRIBUTING.md) for install instructions. CI runs the same scan over the full tree as a sixth gate, so bypassing the hook with `git commit --no-verify` does not avoid the check; it must be disclosed in the PR description.
+
 ## Slash commands
 
 Available slash commands for AI agents:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   ci:
-    name: format + lint + knip + compile + test
+    name: format + lint + knip + compile + test + gitleaks
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -50,3 +50,14 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Install gitleaks
+        run: |
+          curl -fsSL -o gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          rm gitleaks.tar.gz gitleaks
+
+      - name: Gitleaks
+        run: gitleaks detect --no-git --source . --redact --no-banner --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,8 +2,3 @@ title = "SlopWeaver gitleaks config"
 
 [extend]
 useDefault = true
-
-[allowlist]
-description = "Allow the documented fake Slack token in the orchestration chain doc"
-paths = ['''\.claude/orchestration/security/gitleaks-secret-scanning\.md''']
-regexes = ['''xoxb-[0-9]{13}-[0-9]{13}-test-secret-DELETE''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+title = "SlopWeaver gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Allow the documented fake Slack token in the orchestration chain doc"
+paths = ['''\.claude/orchestration/security/gitleaks-secret-scanning\.md''']
+regexes = ['''xoxb-[0-9]{13}-[0-9]{13}-test-secret-DELETE''']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,14 @@ pnpm cli doctor
 
 This verifies your Node and pnpm versions, that port `60701` (the local API port) is free, and that the `~/.slopweaver/` data directory exists -- offering to create it for you. It's the fastest way to confirm your machine is ready before you touch any code. See [`packages/cli-tools/README.md`](packages/cli-tools/README.md#doctor) for sample output.
 
+## Secret scanning
+
+`pnpm install` registers a [lefthook](https://lefthook.dev/) pre-commit hook that runs [gitleaks](https://github.com/gitleaks/gitleaks) `v8.30.1` against staged content. The hook is mandatory; you must install gitleaks separately because it's a Go binary, not an npm package. macOS: `brew install gitleaks`. Linux/Windows: download the `v8.30.1` release binary from [github.com/gitleaks/gitleaks/releases/tag/v8.30.1](https://github.com/gitleaks/gitleaks/releases/tag/v8.30.1) and put it on your `PATH`.
+
+If the hook fires, treat the finding as real until proven otherwise: rotate or remove the secret before committing. Only add a narrow path-scoped entry to `.gitleaks.toml` for a confirmed false positive, and call out the addition in your PR description.
+
+`git commit --no-verify` is reserved for emergencies and must be disclosed in the PR description. CI runs `gitleaks detect` over the full tree on every PR, so a bypassed local commit will still fail the CI gate.
+
 ## How to engage
 
 - **Questions, ideas, use-case discussion** → [GitHub Discussions](https://github.com/slopweaver/slopweaver/discussions). Not Issues.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+pre-commit:
+  jobs:
+    - name: gitleaks-staged
+      run: |
+        if ! command -v gitleaks >/dev/null 2>&1; then
+          echo "gitleaks v8.30.1 is required. See CONTRIBUTING.md for install instructions." >&2
+          exit 1
+        fi
+        gitleaks protect --staged --redact --no-banner

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format:check": "biome format .",
     "knip": "knip",
     "lint": "biome lint .",
+    "prepare": "lefthook install || echo 'lefthook install skipped (not a git repository)'",
     "test": "turbo run test",
     "validate": "pnpm format:check && pnpm lint && pnpm compile && pnpm test && pnpm knip"
   },
@@ -32,6 +33,7 @@
     "eslint": "10.3.0",
     "eslint-plugin-boundaries": "6.0.2",
     "knip": "6.7.0",
+    "lefthook": "2.1.6",
     "tsx": "4.21.0",
     "turbo": "2.9.7",
     "typescript": "6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       knip:
         specifier: 6.7.0
         version: 6.7.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      lefthook:
+        specifier: 2.1.6
+        version: 2.1.6
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -1905,6 +1908,60 @@ packages:
   knip@6.7.0:
     resolution: {integrity: sha512-ckL51NDH1YJxnv1kNB0iUdDngB4f/e9Igz8uIqYfmNDoyOFmmk1V0WFv3LQ7/hzC63b2Z9X41gGUE9eOWrZpaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.6:
+    resolution: {integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.6:
+    resolution: {integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.6:
+    resolution: {integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.6:
+    resolution: {integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.6:
+    resolution: {integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
     hasBin: true
 
   levn@0.4.1:
@@ -3928,6 +3985,49 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  lefthook-darwin-arm64@2.1.6:
+    optional: true
+
+  lefthook-darwin-x64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.6:
+    optional: true
+
+  lefthook-linux-arm64@2.1.6:
+    optional: true
+
+  lefthook-linux-x64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.6:
+    optional: true
+
+  lefthook-windows-arm64@2.1.6:
+    optional: true
+
+  lefthook-windows-x64@2.1.6:
+    optional: true
+
+  lefthook@2.1.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-darwin-x64: 2.1.6
+      lefthook-freebsd-arm64: 2.1.6
+      lefthook-freebsd-x64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-openbsd-arm64: 2.1.6
+      lefthook-openbsd-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
## What this PR does

Adds layered secret scanning to this public repo so contributors (including AI agents) can't accidentally land tokens, keys, or other credentials.

The model is three layers of defence:

1. **Local pre-commit hook** — `lefthook` runs `gitleaks protect --staged` on staged content. Fast feedback before the commit lands.
2. **CI gate** — sixth gate in `.github/workflows/ci.yml`. Installs `gitleaks v8.30.1` from the official SHA-pinned tarball, then runs `gitleaks detect --no-git --source .` over the full tree. Catches anything that bypassed the hook (e.g. `git commit --no-verify`).
3. **Maintainer review** — already in place; this PR moves the maintainer off the critical path.

The pre-push hook listed in the chain's "in scope" section was deferred via the tightening prompt — it largely duplicates the CI gate while adding latency on every push and edge cases around push destinations. CI is the backstop. If we hit a real case where it would help, we can add it as a follow-up.

## Why

`refs #2` — this is one of the v1.0.0 hardening items. The repo is public and the only thing currently keeping a secret out of `main` is the maintainer's eyes. That's a single-point-of-failure, especially when AI agents are driving commits.

## What changed

- `lefthook` added as a root devDependency (pinned to `2.1.6` to match repo style)
- New `prepare` root script: `lefthook install || echo 'lefthook install skipped (not a git repository)'` — tolerates non-git checkouts (tarball / sandbox)
- New `lefthook.yml` with one `pre-commit` job that fails loudly if `gitleaks` is missing from PATH
- New `.gitleaks.toml` extending the default rule pack with one narrow allowlist: the fake `xoxb-…-test-secret-DELETE` literal documented in `.claude/orchestration/security/gitleaks-secret-scanning.md` (the chain doc this PR was built from)
- `.github/workflows/ci.yml` adds two steps after `pnpm test`: install gitleaks via SHA-verified tarball, then run the scan
- `CONTRIBUTING.md` adds three short paragraphs: install, what to do if the hook fires, `--no-verify` policy
- `.claude/rules/workflow.md` adds a one-paragraph note pointing at CONTRIBUTING.md

## Test plan

- [x] Planted a fake `xoxb-…-deadbeef…` token in a scratch file, attempted `git commit`, confirmed the lefthook pre-commit hook blocked the commit. Removed the file.
- [x] Ran `gitleaks detect --no-git --source . --config .gitleaks.toml` against the full tree → `no leaks found` (the chain doc's documented fake token is allowlisted by path + regex).
- [x] All five existing CI gates pass locally: `pnpm format:check && pnpm lint && pnpm compile && pnpm test && pnpm knip`.
- [x] `pnpm install` triggered the `prepare` script which ran `lefthook install` and synced the pre-commit hook.
- [ ] CI passes on this PR (will verify after push).
- [ ] Maintainer manual QA: plant a different fake secret locally, attempt commit, confirm hook fires.

## Notes for reviewer

- **Why not `gitleaks-action`?** The official GitHub Action requires `GITLEAKS_LICENSE` for org-owned repos. We don't want CI to depend on a paid secret. Installing the binary directly via SHA-pinned tarball is license-free, deterministic, and matches the repo's "pin every action by full SHA" convention.
- **Why is the allowlist global (`[allowlist]`) and not per-rule (`[[allowlists]]`)?** The plural `[[allowlists]]` syntax did not match correctly on locally-installed `gitleaks 8.22.1`; the global `[allowlist]` form works on both 8.22.1 and 8.30.1 and is the minimum viable shape. We can revisit if we add more allowlist entries.
- **Version skew:** local install instructions and CI are both pinned to `v8.30.1`. Contributors with older binaries should still work for staged-content scans, but there's a documented version target so we can deprecate older versions later if rule changes matter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for secret scanning, local setup instructions, and guidance for handling findings.

* **Chores**
  * Enabled repository secret scanning in CI.
  * Added pre-commit hooks to detect secrets locally and require installation of the scanner.
  * Require disclosure in PRs if hooks are bypassed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->