### PR TITLE
feat(mcp-server): implement start_session composite tool

### DIFF
--- a/apps/mcp-local/src/cli.smoke.test.ts
+++ b/apps/mcp-local/src/cli.smoke.test.ts
@@ -22,7 +22,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { PingResult } from '@slopweaver/contracts';
+import { PingResult, StartSessionResult } from '@slopweaver/contracts';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -65,6 +65,7 @@ describe('slopweaver bin (compiled CLI)', () => {
       const list = await client.listTools();
       const names = list.tools.map((t) => t.name);
       expect(names).toContain('ping');
+      expect(names).toContain('start_session');
 
       const ping = list.tools.find((t) => t.name === 'ping');
       expect(ping?.inputSchema.type).toBe('object');
@@ -78,6 +79,20 @@ describe('slopweaver bin (compiled CLI)', () => {
         expect(parsed.data.ok).toBe(true);
         expect(parsed.data.version.length).toBeGreaterThan(0);
         expect(parsed.data.uptime_s).toBeGreaterThanOrEqual(0);
+      }
+
+      // start_session against an empty fresh DB returns the empty contract
+      // shape — no integrations registered, so items/evidence/freshness are
+      // all empty but `generated_at` is set.
+      const startSession = await client.callTool({ name: 'start_session', arguments: {} });
+      expect(startSession.isError).toBeUndefined();
+      const startSessionParsed = StartSessionResult.safeParse(startSession.structuredContent);
+      expect(startSessionParsed.success).toBe(true);
+      if (startSessionParsed.success) {
+        expect(startSessionParsed.data.items).toEqual([]);
+        expect(startSessionParsed.data.evidence).toEqual([]);
+        expect(startSessionParsed.data.freshness).toEqual([]);
+        expect(startSessionParsed.data.generated_at.length).toBeGreaterThan(0);
       }
     } finally {
       await client.close();

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -19,7 +19,12 @@ import { readFileSync } from 'node:fs';
 import { argv, exit, stderr, stdout } from 'node:process';
 import { createDb, resolveDbPath } from '@slopweaver/db';
 import { loadEnv } from '@slopweaver/env';
-import { createMcpServer, createPingTool, startStdio } from '@slopweaver/mcp-server';
+import {
+  createMcpServer,
+  createPingTool,
+  createStartSessionTool,
+  startStdio,
+} from '@slopweaver/mcp-server';
 
 // Read the bin's own version from its package.json at runtime. dist/cli.js
 // sits one directory below package.json (apps/mcp-local/package.json in the
@@ -85,7 +90,14 @@ async function main(): Promise<void> {
   const server = createMcpServer({
     db: dbHandle.db,
     version: VERSION,
-    tools: [createPingTool({ version: VERSION, startedAtMs })],
+    tools: [
+      createPingTool({ version: VERSION, startedAtMs }),
+      // Pollers are intentionally empty in v1: integration auth tokens are
+      // not yet wired through env, so `force_refresh` is a no-op until that
+      // lands. The tool still serves cached evidence and accurate freshness
+      // reports without them.
+      createStartSessionTool(),
+    ],
   });
 
   // Ensure the SQLite handle is closed on graceful shutdown. The MCP

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -30,6 +30,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@slopweaver/contracts": "workspace:*",
     "@slopweaver/db": "workspace:*",
+    "drizzle-orm": "0.45.2",
     "zod": "4.4.2"
   },
   "devDependencies": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -18,5 +18,10 @@ export type {
 } from './tools/registry.ts';
 export { createPingTool } from './tools/builtin/ping.ts';
 export type { CreatePingToolArgs } from './tools/builtin/ping.ts';
+export { createStartSessionTool } from './tools/composite/start-session.ts';
+export type {
+  CreateStartSessionToolArgs,
+  StartSessionPoller,
+} from './tools/composite/start-session.ts';
 export { startStdio } from './transports/stdio.ts';
 export type { StartStdioArgs, StartStdioHandle } from './transports/stdio.ts';

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -9,12 +9,13 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { PingResult } from '@slopweaver/contracts';
+import { PingResult, StartSessionResult } from '@slopweaver/contracts';
 import { createDb } from '@slopweaver/db';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { createMcpServer } from './server.ts';
 import { createPingTool } from './tools/builtin/ping.ts';
+import { createStartSessionTool } from './tools/composite/start-session.ts';
 import { defineTool, type Tool } from './tools/registry.ts';
 
 describe('createMcpServer + ping', () => {
@@ -161,6 +162,40 @@ describe('createMcpServer + ping', () => {
       });
       expect(ok.isError).toBeUndefined();
       expect(handlerCalled).toBe(1);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('registers start_session and round-trips a StartSessionResult shape', async () => {
+    const fixedNow = 1_762_000_000_000;
+    const server = createMcpServer({
+      db: dbHandle.db,
+      version: '0.1.0',
+      tools: [createStartSessionTool({ now: () => fixedNow })],
+    });
+
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      const list = await client.listTools();
+      expect(list.tools.map((t) => t.name)).toContain('start_session');
+
+      const callResult = await client.callTool({ name: 'start_session', arguments: {} });
+      expect(callResult.isError).toBeUndefined();
+
+      const parsed = StartSessionResult.safeParse(callResult.structuredContent);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.items).toEqual([]);
+        expect(parsed.data.evidence).toEqual([]);
+        expect(parsed.data.freshness).toEqual([]);
+        expect(parsed.data.generated_at).toBe(new Date(fixedNow).toISOString());
+      }
     } finally {
       await client.close();
       await server.close();

--- a/packages/mcp-server/src/tools/composite/start-session.test.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Unit tests for the start_session composite tool. Exercises the handler
+ * directly (faster, more focused than going through MCP transport — there is
+ * one transport-level smoke test in `server.test.ts` that pins the wire
+ * shape).
+ *
+ * Each test uses a fresh in-memory SQLite DB seeded directly via Drizzle.
+ * Time is pinned via the `now` factory arg so age-dependent ranking and
+ * staleness checks are deterministic.
+ */
+
+import { evidenceLog, integrationState, createDb } from '@slopweaver/db';
+import { StartSessionArgs, StartSessionResult } from '@slopweaver/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStartSessionTool, type StartSessionPoller } from './start-session.ts';
+
+const FIXED_NOW = 1_762_000_000_000;
+const FIVE_MIN = 5 * 60 * 1000;
+const ELEVEN_MIN = 11 * 60 * 1000;
+
+describe('createStartSessionTool', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  function seedEvidence(overrides: Partial<typeof evidenceLog.$inferInsert>): number {
+    const base = {
+      integration: 'github',
+      externalId: `ext-${Math.random().toString(36).slice(2)}`,
+      kind: 'pull_request',
+      citationUrl: null,
+      title: null,
+      body: null,
+      payloadJson: '{}',
+      occurredAtMs: FIXED_NOW - FIVE_MIN,
+      firstSeenAtMs: FIXED_NOW - FIVE_MIN,
+      lastSeenAtMs: FIXED_NOW - FIVE_MIN,
+      createdAtMs: FIXED_NOW - FIVE_MIN,
+      updatedAtMs: FIXED_NOW - FIVE_MIN,
+    } satisfies typeof evidenceLog.$inferInsert;
+    const result = dbHandle.db
+      .insert(evidenceLog)
+      .values({ ...base, ...overrides })
+      .returning({ id: evidenceLog.id })
+      .get();
+    return result.id;
+  }
+
+  function seedFreshIntegrationState(integration: string, lastCompleted = FIXED_NOW - FIVE_MIN) {
+    dbHandle.db
+      .insert(integrationState)
+      .values({
+        integration,
+        cursor: null,
+        lastPollStartedAtMs: lastCompleted,
+        lastPollCompletedAtMs: lastCompleted,
+        createdAtMs: lastCompleted,
+        updatedAtMs: lastCompleted,
+      })
+      .run();
+  }
+
+  function callHandler(
+    tool: ReturnType<typeof createStartSessionTool>,
+    rawInput: unknown,
+  ): Promise<unknown> {
+    // Mirror the SDK's pre-handler validation step so handler input is typed.
+    const input = StartSessionArgs.parse(rawInput);
+    return tool.handler({ input, ctx: { db: dbHandle.db } });
+  }
+
+  it('happy path: ranks a Slack mention above an equal-recency GitHub PR via the kind boost', async () => {
+    seedEvidence({
+      integration: 'github',
+      externalId: 'pr-1',
+      kind: 'pull_request',
+      title: 'Add widget',
+      citationUrl: 'https://github.com/example/repo/pull/1',
+      occurredAtMs: FIXED_NOW - FIVE_MIN,
+    });
+    seedEvidence({
+      integration: 'slack',
+      externalId: 'msg-1',
+      kind: 'mention',
+      title: '@you take a look?',
+      citationUrl: 'https://slack.example.com/archives/C1/p1',
+      occurredAtMs: FIXED_NOW - FIVE_MIN,
+    });
+    seedFreshIntegrationState('github');
+    seedFreshIntegrationState('slack');
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, {});
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(parsed.items).toHaveLength(2);
+    expect(parsed.items[0]?.priority).toBe(1);
+    expect(parsed.items[0]?.title).toBe('@you take a look?');
+    expect(parsed.items[1]?.priority).toBe(2);
+    expect(parsed.items[1]?.title).toBe('Add widget');
+
+    expect(parsed.evidence).toHaveLength(2);
+    expect(parsed.evidence.map((e) => e.integration)).toEqual(
+      expect.arrayContaining(['github', 'slack']),
+    );
+
+    expect(parsed.freshness).toHaveLength(2);
+    for (const f of parsed.freshness) {
+      expect(f.stale).toBe(false);
+      expect(typeof f.last_polled_at).toBe('string');
+    }
+
+    expect(() => new Date(parsed.generated_at)).not.toThrow();
+  });
+
+  it('returns empty arrays with a valid generated_at when the DB is empty', async () => {
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, {});
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(parsed.items).toEqual([]);
+    expect(parsed.evidence).toEqual([]);
+    expect(parsed.freshness).toEqual([]);
+    expect(parsed.generated_at).toBe(new Date(FIXED_NOW).toISOString());
+  });
+
+  it('integrations filter excludes rows from other integrations', async () => {
+    seedEvidence({ integration: 'github', externalId: 'pr-1', kind: 'pull_request' });
+    seedEvidence({ integration: 'slack', externalId: 'msg-1', kind: 'mention' });
+    seedFreshIntegrationState('github');
+    seedFreshIntegrationState('slack');
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, { integrations: ['github'] });
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(parsed.items.every((i) => i.title !== '@you take a look?')).toBe(true);
+    expect(parsed.evidence).toHaveLength(1);
+    expect(parsed.evidence[0]?.integration).toBe('github');
+    expect(parsed.freshness).toHaveLength(1);
+    expect(parsed.freshness[0]?.integration).toBe('github');
+  });
+
+  it('caps results to max_items and rejects out-of-range max_items at the schema boundary', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      seedEvidence({
+        externalId: `pr-${i}`,
+        occurredAtMs: FIXED_NOW - i * 60_000,
+      });
+    }
+    seedFreshIntegrationState('github');
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, { max_items: 2 });
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(parsed.items).toHaveLength(2);
+    expect(parsed.evidence).toHaveLength(2);
+
+    // Schema enforces max(25). 30 must be rejected at the SDK boundary —
+    // mirror that here by parsing the raw input.
+    expect(() => StartSessionArgs.parse({ max_items: 30 })).toThrow();
+  });
+
+  it('force_refresh invokes the registered poller exactly once per integration', async () => {
+    seedFreshIntegrationState('github');
+
+    const githubPoller: StartSessionPoller = vi.fn(async ({ db, now }) => {
+      db.insert(evidenceLog)
+        .values({
+          integration: 'github',
+          externalId: 'fresh-1',
+          kind: 'pull_request',
+          citationUrl: null,
+          title: 'Fresh PR',
+          body: null,
+          payloadJson: '{}',
+          occurredAtMs: now - 1_000,
+          firstSeenAtMs: now,
+          lastSeenAtMs: now,
+          createdAtMs: now,
+          updatedAtMs: now,
+        })
+        .run();
+    });
+
+    const tool = createStartSessionTool({
+      now: () => FIXED_NOW,
+      pollers: { github: githubPoller },
+    });
+    const raw = await callHandler(tool, { force_refresh: true });
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(githubPoller).toHaveBeenCalledTimes(1);
+    expect(githubPoller).toHaveBeenCalledWith({ db: dbHandle.db, now: FIXED_NOW });
+    expect(parsed.items.map((i) => i.title)).toContain('Fresh PR');
+  });
+
+  it('auto-polls when integration_state is older than the staleness threshold', async () => {
+    const stalePoller: StartSessionPoller = vi.fn(async () => {});
+    seedFreshIntegrationState('github', FIXED_NOW - ELEVEN_MIN);
+
+    const tool = createStartSessionTool({
+      now: () => FIXED_NOW,
+      pollers: { github: stalePoller },
+    });
+    await callHandler(tool, {});
+    expect(stalePoller).toHaveBeenCalledTimes(1);
+
+    // Reset to fresh; poller must NOT fire again.
+    dbHandle.db.delete(integrationState).run();
+    seedFreshIntegrationState('github', FIXED_NOW - FIVE_MIN);
+    const freshPoller: StartSessionPoller = vi.fn(async () => {});
+    const tool2 = createStartSessionTool({
+      now: () => FIXED_NOW,
+      pollers: { github: freshPoller },
+    });
+    await callHandler(tool2, {});
+    expect(freshPoller).not.toHaveBeenCalled();
+  });
+
+  it('reports stale=true and last_polled_at=null when no integration_state row exists', async () => {
+    seedEvidence({ integration: 'github', externalId: 'pr-1' });
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, { integrations: ['github'] });
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(parsed.freshness).toEqual([
+      { integration: 'github', last_polled_at: null, stale: true },
+    ]);
+  });
+
+  it('builds Reference as kind:url when citation_url is present, else kind:canonical', async () => {
+    seedEvidence({
+      integration: 'github',
+      externalId: 'pr-with-url',
+      citationUrl: 'https://github.com/example/repo/pull/9',
+      occurredAtMs: FIXED_NOW - FIVE_MIN,
+    });
+    seedEvidence({
+      integration: 'github',
+      externalId: 'pr-without-url',
+      citationUrl: null,
+      occurredAtMs: FIXED_NOW - FIVE_MIN - 1_000,
+    });
+    seedFreshIntegrationState('github');
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, {});
+    const parsed = StartSessionResult.parse(raw);
+
+    const withUrl = parsed.evidence.find((e) => e.citation_url != null);
+    const withoutUrl = parsed.evidence.find((e) => e.citation_url == null);
+
+    expect(withUrl?.ref).toEqual({
+      kind: 'url',
+      url: 'https://github.com/example/repo/pull/9',
+    });
+    expect(withoutUrl?.ref).toEqual({
+      kind: 'canonical',
+      integration: 'github',
+      id: 'pr-without-url',
+    });
+
+    // id is stringified at the boundary; occurred_at is an ISO datetime.
+    for (const e of parsed.evidence) {
+      expect(typeof e.id).toBe('string');
+      expect(e.id.length).toBeGreaterThan(0);
+      expect(() => new Date(e.occurred_at).toISOString()).not.toThrow();
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/composite/start-session.test.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.test.ts
@@ -345,7 +345,7 @@ describe('createStartSessionTool', () => {
     const parsed = StartSessionResult.parse(raw);
 
     expect(parsed.items.map((i) => i.title)).toEqual(['Has bad URL', 'Has bad JSON']);
-    const badUrl = parsed.evidence.find((e) => e.kind === 'pull_request' && e.id !== 'no-title');
+
     const downgraded = parsed.evidence.find(
       (e) => e.ref.kind === 'canonical' && e.ref.id === 'bad-url',
     );
@@ -357,11 +357,60 @@ describe('createStartSessionTool', () => {
     );
     expect(badJson).toBeDefined();
     expect(badJson?.payload_json).toBeNull();
-    expect(badUrl).toBeDefined();
   });
 
-  it('breaks score ties deterministically by occurredAtMs desc then id asc', async () => {
-    // Same kind, same occurredAtMs → score tied → fall through to id ascending.
+  it('orders by score desc — a higher-score row beats a more recent lower-score row', async () => {
+    // 'mention' wins the kind boost (+0.5). Even though the PR is more recent,
+    // the score-desc tier puts the older mention first.
+    seedEvidence({
+      integration: 'slack',
+      externalId: 'older-mention',
+      title: 'Older Mention',
+      kind: 'mention',
+      occurredAtMs: FIXED_NOW - 60 * 60_000, // 1 hour ago
+    });
+    seedEvidence({
+      integration: 'github',
+      externalId: 'newer-pr',
+      title: 'Newer PR',
+      kind: 'pull_request',
+      occurredAtMs: FIXED_NOW - 5 * 60_000, // 5 minutes ago
+    });
+    seedFreshIntegrationState('slack');
+    seedFreshIntegrationState('github');
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, {});
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(parsed.items.map((i) => i.title)).toEqual(['Older Mention', 'Newer PR']);
+  });
+
+  it('breaks score ties by occurredAtMs desc — newer row first when scores are equal', async () => {
+    seedEvidence({
+      integration: 'github',
+      externalId: 'older',
+      title: 'Older',
+      kind: 'pull_request',
+      occurredAtMs: FIXED_NOW - 10 * 60_000,
+    });
+    seedEvidence({
+      integration: 'github',
+      externalId: 'newer',
+      title: 'Newer',
+      kind: 'pull_request',
+      occurredAtMs: FIXED_NOW - 1 * 60_000,
+    });
+    seedFreshIntegrationState('github');
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, {});
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(parsed.items.map((i) => i.title)).toEqual(['Newer', 'Older']);
+  });
+
+  it('breaks remaining ties by id asc — earlier insert first when score and occurredAtMs are equal', async () => {
     const idA = seedEvidence({
       integration: 'github',
       externalId: 'a',

--- a/packages/mcp-server/src/tools/composite/start-session.test.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.test.ts
@@ -276,4 +276,113 @@ describe('createStartSessionTool', () => {
       expect(() => new Date(e.occurred_at).toISOString()).not.toThrow();
     }
   });
+
+  it('dedupes a duplicated `integrations` argument so each integration is processed once', async () => {
+    seedEvidence({ integration: 'github', externalId: 'pr-1' });
+    seedFreshIntegrationState('github');
+
+    const githubPoller: StartSessionPoller = vi.fn(async () => {});
+    const tool = createStartSessionTool({
+      now: () => FIXED_NOW,
+      pollers: { github: githubPoller },
+    });
+    const raw = await callHandler(tool, {
+      integrations: ['github', 'github'],
+      force_refresh: true,
+    });
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(githubPoller).toHaveBeenCalledTimes(1);
+    expect(parsed.freshness).toHaveLength(1);
+    expect(parsed.freshness[0]?.integration).toBe('github');
+  });
+
+  it('force_refresh polls a registered integration that has no integration_state row yet', async () => {
+    // No state row, no evidence — this is the first-run case.
+    const githubPoller: StartSessionPoller = vi.fn(async () => {});
+    const tool = createStartSessionTool({
+      now: () => FIXED_NOW,
+      pollers: { github: githubPoller },
+    });
+    const raw = await callHandler(tool, { force_refresh: true });
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(githubPoller).toHaveBeenCalledTimes(1);
+    expect(parsed.freshness).toEqual([
+      { integration: 'github', last_polled_at: null, stale: true },
+    ]);
+  });
+
+  it('skips rows with no usable title, downgrades malformed citation_url, tolerates bad payload_json', async () => {
+    // Row 1: empty title and empty kind — must be skipped entirely.
+    seedEvidence({
+      integration: 'github',
+      externalId: 'no-title',
+      title: '',
+      kind: '',
+      occurredAtMs: FIXED_NOW - 60_000,
+    });
+    // Row 2: malformed citation_url — must downgrade to canonical ref.
+    seedEvidence({
+      integration: 'github',
+      externalId: 'bad-url',
+      title: 'Has bad URL',
+      citationUrl: 'not a real url',
+      occurredAtMs: FIXED_NOW - 120_000,
+    });
+    // Row 3: malformed JSON payload — must surface with payload_json: null.
+    seedEvidence({
+      integration: 'github',
+      externalId: 'bad-json',
+      title: 'Has bad JSON',
+      payloadJson: '{not json',
+      occurredAtMs: FIXED_NOW - 180_000,
+    });
+    seedFreshIntegrationState('github');
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, {});
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(parsed.items.map((i) => i.title)).toEqual(['Has bad URL', 'Has bad JSON']);
+    const badUrl = parsed.evidence.find((e) => e.kind === 'pull_request' && e.id !== 'no-title');
+    const downgraded = parsed.evidence.find(
+      (e) => e.ref.kind === 'canonical' && e.ref.id === 'bad-url',
+    );
+    expect(downgraded).toBeDefined();
+    expect(downgraded?.citation_url).toBeNull();
+
+    const badJson = parsed.evidence.find(
+      (e) => e.ref.kind === 'canonical' && e.ref.id === 'bad-json',
+    );
+    expect(badJson).toBeDefined();
+    expect(badJson?.payload_json).toBeNull();
+    expect(badUrl).toBeDefined();
+  });
+
+  it('breaks score ties deterministically by occurredAtMs desc then id asc', async () => {
+    // Same kind, same occurredAtMs → score tied → fall through to id ascending.
+    const idA = seedEvidence({
+      integration: 'github',
+      externalId: 'a',
+      title: 'A',
+      kind: 'pull_request',
+      occurredAtMs: FIXED_NOW - FIVE_MIN,
+    });
+    const idB = seedEvidence({
+      integration: 'github',
+      externalId: 'b',
+      title: 'B',
+      kind: 'pull_request',
+      occurredAtMs: FIXED_NOW - FIVE_MIN,
+    });
+    seedFreshIntegrationState('github');
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, {});
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(idA).toBeLessThan(idB);
+    expect(parsed.items.map((i) => i.title)).toEqual(['A', 'B']);
+  });
 });

--- a/packages/mcp-server/src/tools/composite/start-session.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.ts
@@ -13,23 +13,30 @@
  *   score        = recencyScore + kindBoost
  *   priority     = rank index + 1                  (1 = highest)
  *
+ * Tie-break is explicit (score desc, occurredAtMs desc, id asc) so equal-score
+ * rows have a deterministic order independent of SQLite's row-fetch order.
+ *
  * Pollers are injected via the factory (`pollers`) rather than read out of the
  * MCP context, because the integration poll functions need auth tokens that
  * the MCP `ToolHandlerContext` deliberately does not carry. The host
  * (`apps/mcp-local` once it lands) builds closures that capture tokens at
  * startup; tests pass `vi.fn()` mocks.
+ *
+ * Row shaping is defensive: a single corrupt `evidence_log` row (empty title,
+ * malformed citation URL, unparseable payload JSON) downgrades or is skipped,
+ * never aborts the whole tool call.
  */
 
 import {
+  EvidenceLogEntry,
+  type Freshness,
+  type Reference,
   StartSessionArgs,
   StartSessionResult,
-  type Reference,
-  type EvidenceLogEntry,
-  type Freshness,
 } from '@slopweaver/contracts';
 import { evidenceLog, integrationState, type SlopweaverDatabase } from '@slopweaver/db';
 import { desc, eq, inArray } from 'drizzle-orm';
-import type { z } from 'zod';
+import { z } from 'zod';
 import { defineTool, type Tool } from '../registry.ts';
 
 /** Default: poll if the most recent successful poll completed more than 10 minutes ago. */
@@ -41,6 +48,8 @@ const KIND_BOOST_VALUE = 0.5;
 const MS_PER_MINUTE = 60_000;
 const MS_PER_HOUR = 60 * MS_PER_MINUTE;
 const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+const UrlSchema = z.url();
 
 /**
  * Per-integration refresh hook. The host wires one of these up per connected
@@ -60,6 +69,7 @@ export type CreateStartSessionToolArgs = {
 
 type EvidenceRow = typeof evidenceLog.$inferSelect;
 type StartSessionItem = z.infer<typeof StartSessionResult>['items'][number];
+type ShapedEntry = { item: Omit<StartSessionItem, 'priority'>; evidence: EvidenceLogEntry };
 
 export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): Tool {
   const pollers = args.pollers ?? {};
@@ -76,13 +86,7 @@ export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): T
       const nowMs = now();
       const cap = Math.min(input.max_items ?? 10, 25);
 
-      const requested =
-        input.integrations ??
-        db
-          .select({ integration: integrationState.integration })
-          .from(integrationState)
-          .all()
-          .map((r) => r.integration);
+      const requested = resolveRequested(db, input.integrations, pollers);
 
       if (requested.length === 0) {
         return {
@@ -109,15 +113,17 @@ export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): T
         .orderBy(desc(evidenceLog.occurredAtMs))
         .all();
 
-      const ranked = rows
-        .map((row) => ({ row, score: scoreOf(row, nowMs) }))
-        .sort((a, b) => b.score - a.score)
-        .slice(0, cap);
+      const ranked = rows.map((row) => ({ row, score: scoreOf(row, nowMs) })).sort(compareRanked);
 
-      const items: StartSessionItem[] = ranked.map((entry, idx) =>
-        buildItem(entry.row, idx + 1, nowMs),
-      );
-      const evidence: EvidenceLogEntry[] = ranked.map((entry) => toEvidenceLogEntry(entry.row));
+      const built: ShapedEntry[] = [];
+      for (const entry of ranked) {
+        if (built.length >= cap) break;
+        const shaped = shapeRow(entry.row, nowMs);
+        if (shaped) built.push(shaped);
+      }
+
+      const items: StartSessionItem[] = built.map((b, idx) => ({ ...b.item, priority: idx + 1 }));
+      const evidence: EvidenceLogEntry[] = built.map((b) => b.evidence);
       const freshness: Freshness[] = requested.map((integration) =>
         readFreshness(db, integration, nowMs, staleThresholdMs),
       );
@@ -130,6 +136,41 @@ export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): T
       };
     },
   });
+}
+
+/**
+ * Pick the integrations to consider this call. When the caller supplies
+ * `inputIntegrations` we honour that exactly (deduped). Otherwise default to
+ * the union of registered pollers and existing `integration_state` rows so a
+ * first-run `force_refresh` actually has something to poll. First-seen order
+ * is preserved.
+ */
+function resolveRequested(
+  db: SlopweaverDatabase,
+  inputIntegrations: readonly string[] | undefined,
+  pollers: Record<string, StartSessionPoller>,
+): string[] {
+  if (inputIntegrations !== undefined) {
+    return dedupeOrdered(inputIntegrations);
+  }
+  const stateRows = db
+    .select({ integration: integrationState.integration })
+    .from(integrationState)
+    .all()
+    .map((r) => r.integration);
+  return dedupeOrdered([...Object.keys(pollers), ...stateRows]);
+}
+
+function dedupeOrdered(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    if (!seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
 }
 
 function shouldPoll(
@@ -176,33 +217,67 @@ function scoreOf(row: EvidenceRow, nowMs: number): number {
   return recencyScore + boost;
 }
 
-function buildItem(row: EvidenceRow, priority: number, nowMs: number): StartSessionItem {
+function compareRanked(
+  a: { row: EvidenceRow; score: number },
+  b: { row: EvidenceRow; score: number },
+): number {
+  if (b.score !== a.score) return b.score - a.score;
+  if (b.row.occurredAtMs !== a.row.occurredAtMs) return b.row.occurredAtMs - a.row.occurredAtMs;
+  return a.row.id - b.row.id;
+}
+
+/**
+ * Defensively convert a DB row to the wire shape. Returns `null` if the row
+ * cannot produce a contract-valid item (e.g. both `title` and `kind` are
+ * empty). Recoverable issues are downgraded inline:
+ *   - malformed `citation_url` → ref becomes canonical, `citation_url` null
+ *   - unparseable `payload_json` → `payload_json` becomes null
+ */
+function shapeRow(row: EvidenceRow, nowMs: number): ShapedEntry | null {
+  const title = (row.title && row.title.length > 0 ? row.title : row.kind) || null;
+  if (title == null) return null;
+
+  const ref = buildRef(row);
+  const citationUrl = ref.kind === 'url' ? ref.url : null;
+  const payload = tryParseJson(row.payloadJson);
+
+  const evidence: EvidenceLogEntry = {
+    id: String(row.id),
+    integration: row.integration,
+    kind: row.kind,
+    ref,
+    occurred_at: new Date(row.occurredAtMs).toISOString(),
+    payload_json: payload,
+    citation_url: citationUrl,
+  };
+
   return {
-    ref: buildRef(row),
-    priority,
-    title: row.title ?? row.kind,
-    why: `${row.integration} ${row.kind} from ${humanAge(nowMs - row.occurredAtMs)}`,
-    evidence_ids: [String(row.id)],
+    item: {
+      ref,
+      title,
+      why: `${row.integration} ${row.kind} from ${humanAge(nowMs - row.occurredAtMs)}`,
+      evidence_ids: [String(row.id)],
+    },
+    evidence,
   };
 }
 
 function buildRef(row: EvidenceRow): Reference {
-  if (row.citationUrl != null) {
-    return { kind: 'url', url: row.citationUrl };
+  if (row.citationUrl != null && row.citationUrl.length > 0) {
+    const parsed = UrlSchema.safeParse(row.citationUrl);
+    if (parsed.success) {
+      return { kind: 'url', url: parsed.data };
+    }
   }
   return { kind: 'canonical', integration: row.integration, id: row.externalId };
 }
 
-function toEvidenceLogEntry(row: EvidenceRow): EvidenceLogEntry {
-  return {
-    id: String(row.id),
-    integration: row.integration,
-    kind: row.kind,
-    ref: buildRef(row),
-    occurred_at: new Date(row.occurredAtMs).toISOString(),
-    payload_json: JSON.parse(row.payloadJson),
-    citation_url: row.citationUrl,
-  };
+function tryParseJson(json: string): z.infer<typeof EvidenceLogEntry>['payload_json'] {
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
 }
 
 function humanAge(ageMs: number): string {

--- a/packages/mcp-server/src/tools/composite/start-session.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.ts
@@ -1,0 +1,217 @@
+/**
+ * Composite `start_session` tool — the v1 flagship.
+ *
+ * Answers "what should I work on next?" by reading recent evidence from the
+ * local DB across the user's connected integrations. Per integration, decides
+ * whether the cached evidence is fresh enough or whether to trigger a fresh
+ * poll first; then ranks the surviving rows and shapes them to the wire
+ * contract.
+ *
+ * Ranking heuristic (deliberately simple — easy to swap once we have signal):
+ *   recencyScore = 1 / (1 + ageHours / 24)         (~ half-life of one day)
+ *   kindBoost    = 0.5 if kind ∈ {mention, review_request, dm} else 0
+ *   score        = recencyScore + kindBoost
+ *   priority     = rank index + 1                  (1 = highest)
+ *
+ * Pollers are injected via the factory (`pollers`) rather than read out of the
+ * MCP context, because the integration poll functions need auth tokens that
+ * the MCP `ToolHandlerContext` deliberately does not carry. The host
+ * (`apps/mcp-local` once it lands) builds closures that capture tokens at
+ * startup; tests pass `vi.fn()` mocks.
+ */
+
+import {
+  StartSessionArgs,
+  StartSessionResult,
+  type Reference,
+  type EvidenceLogEntry,
+  type Freshness,
+} from '@slopweaver/contracts';
+import { evidenceLog, integrationState, type SlopweaverDatabase } from '@slopweaver/db';
+import { desc, eq, inArray } from 'drizzle-orm';
+import type { z } from 'zod';
+import { defineTool, type Tool } from '../registry.ts';
+
+/** Default: poll if the most recent successful poll completed more than 10 minutes ago. */
+const DEFAULT_STALE_THRESHOLD_MS = 10 * 60 * 1000;
+
+const KIND_BOOST = new Set<string>(['mention', 'review_request', 'dm']);
+const KIND_BOOST_VALUE = 0.5;
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+/**
+ * Per-integration refresh hook. The host wires one of these up per connected
+ * integration with the auth token captured in the closure. Called when the
+ * tool decides the cache is stale or `force_refresh` was set.
+ */
+export type StartSessionPoller = (args: { db: SlopweaverDatabase; now: number }) => Promise<void>;
+
+export type CreateStartSessionToolArgs = {
+  /** Map from integration slug (`'github'`, `'slack'`) to its refresh hook. Integrations without a registered poller are simply not refreshed. */
+  pollers?: Record<string, StartSessionPoller>;
+  /** Override the default 10-minute staleness threshold (e.g. for tests). */
+  staleThresholdMs?: number;
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  now?: () => number;
+};
+
+type EvidenceRow = typeof evidenceLog.$inferSelect;
+type StartSessionItem = z.infer<typeof StartSessionResult>['items'][number];
+
+export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): Tool {
+  const pollers = args.pollers ?? {};
+  const staleThresholdMs = args.staleThresholdMs ?? DEFAULT_STALE_THRESHOLD_MS;
+  const now = args.now ?? Date.now;
+
+  return defineTool({
+    name: 'start_session',
+    description:
+      'Returns ranked evidence for "what should I work on next?" across the connected integrations. Optionally triggers a fresh poll per integration when cached evidence is stale or `force_refresh` is set.',
+    inputSchema: StartSessionArgs,
+    outputSchema: StartSessionResult,
+    handler: async ({ input, ctx: { db } }) => {
+      const nowMs = now();
+      const cap = Math.min(input.max_items ?? 10, 25);
+
+      const requested =
+        input.integrations ??
+        db
+          .select({ integration: integrationState.integration })
+          .from(integrationState)
+          .all()
+          .map((r) => r.integration);
+
+      if (requested.length === 0) {
+        return {
+          items: [],
+          evidence: [],
+          freshness: [],
+          generated_at: new Date(nowMs).toISOString(),
+        };
+      }
+
+      for (const integration of requested) {
+        if (shouldPoll(db, integration, nowMs, staleThresholdMs, input.force_refresh === true)) {
+          const poller = pollers[integration];
+          if (poller) {
+            await poller({ db, now: nowMs });
+          }
+        }
+      }
+
+      const rows: EvidenceRow[] = db
+        .select()
+        .from(evidenceLog)
+        .where(inArray(evidenceLog.integration, requested))
+        .orderBy(desc(evidenceLog.occurredAtMs))
+        .all();
+
+      const ranked = rows
+        .map((row) => ({ row, score: scoreOf(row, nowMs) }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, cap);
+
+      const items: StartSessionItem[] = ranked.map((entry, idx) =>
+        buildItem(entry.row, idx + 1, nowMs),
+      );
+      const evidence: EvidenceLogEntry[] = ranked.map((entry) => toEvidenceLogEntry(entry.row));
+      const freshness: Freshness[] = requested.map((integration) =>
+        readFreshness(db, integration, nowMs, staleThresholdMs),
+      );
+
+      return {
+        items,
+        evidence,
+        freshness,
+        generated_at: new Date(nowMs).toISOString(),
+      };
+    },
+  });
+}
+
+function shouldPoll(
+  db: SlopweaverDatabase,
+  integration: string,
+  nowMs: number,
+  staleThresholdMs: number,
+  forceRefresh: boolean,
+): boolean {
+  if (forceRefresh) return true;
+  const stateRow = db
+    .select({ lastPollCompletedAtMs: integrationState.lastPollCompletedAtMs })
+    .from(integrationState)
+    .where(eq(integrationState.integration, integration))
+    .get();
+  const last = stateRow?.lastPollCompletedAtMs;
+  return last == null || nowMs - last > staleThresholdMs;
+}
+
+function readFreshness(
+  db: SlopweaverDatabase,
+  integration: string,
+  nowMs: number,
+  staleThresholdMs: number,
+): Freshness {
+  const stateRow = db
+    .select({ lastPollCompletedAtMs: integrationState.lastPollCompletedAtMs })
+    .from(integrationState)
+    .where(eq(integrationState.integration, integration))
+    .get();
+  const last = stateRow?.lastPollCompletedAtMs ?? null;
+  return {
+    integration,
+    last_polled_at: last != null ? new Date(last).toISOString() : null,
+    stale: last == null || nowMs - last > staleThresholdMs,
+  };
+}
+
+function scoreOf(row: EvidenceRow, nowMs: number): number {
+  const ageMs = Math.max(0, nowMs - row.occurredAtMs);
+  const ageHours = ageMs / MS_PER_HOUR;
+  const recencyScore = 1 / (1 + ageHours / 24);
+  const boost = KIND_BOOST.has(row.kind) ? KIND_BOOST_VALUE : 0;
+  return recencyScore + boost;
+}
+
+function buildItem(row: EvidenceRow, priority: number, nowMs: number): StartSessionItem {
+  return {
+    ref: buildRef(row),
+    priority,
+    title: row.title ?? row.kind,
+    why: `${row.integration} ${row.kind} from ${humanAge(nowMs - row.occurredAtMs)}`,
+    evidence_ids: [String(row.id)],
+  };
+}
+
+function buildRef(row: EvidenceRow): Reference {
+  if (row.citationUrl != null) {
+    return { kind: 'url', url: row.citationUrl };
+  }
+  return { kind: 'canonical', integration: row.integration, id: row.externalId };
+}
+
+function toEvidenceLogEntry(row: EvidenceRow): EvidenceLogEntry {
+  return {
+    id: String(row.id),
+    integration: row.integration,
+    kind: row.kind,
+    ref: buildRef(row),
+    occurred_at: new Date(row.occurredAtMs).toISOString(),
+    payload_json: JSON.parse(row.payloadJson),
+    citation_url: row.citationUrl,
+  };
+}
+
+function humanAge(ageMs: number): string {
+  const safe = Math.max(0, ageMs);
+  const minutes = Math.floor(safe / MS_PER_MINUTE);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(safe / MS_PER_HOUR);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(safe / MS_PER_DAY);
+  return `${days}d ago`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@slopweaver/db':
         specifier: workspace:*
         version: link:../db
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)
       zod:
         specifier: 4.4.2
         version: 4.4.2


### PR DESCRIPTION
## What this PR does

Adds the v1 flagship composite MCP tool. Reads ranked work-context evidence from `evidence_log` across the user's connected integrations, optionally triggering a fresh poll per integration when the cached state is stale or `force_refresh` is set. Wires the tool into `apps/mcp-local` so it's reachable end-to-end over stdio.

## Why

`start_session` is the demo that motivates the whole project — when a user opens Claude Code, it answers "what should I work on next?" by ranking recent evidence the local poller has captured. The wire contract was already locked in `@slopweaver/contracts`; both `@slopweaver/integrations-github` and `@slopweaver/integrations-slack` are merged with poll exports; this PR fills the last big gap.

refs #2

## Design notes

- **Pollers are injected via factory args**, not read from `ToolHandlerContext`. The MCP context deliberately does not carry auth tokens; the host (`apps/mcp-local`) builds closures that capture tokens at startup. Tests pass `vi.fn()` mocks.
- **Stale threshold** is a top-of-file constant (`DEFAULT_STALE_THRESHOLD_MS = 10 * 60 * 1000`), overridable via factory arg for tests.
- **Ranking heuristic** is intentionally simple, documented in a top-of-file comment so the formula is easy to swap later: `score = recencyScore + kindBoost`, where `recencyScore = 1 / (1 + ageHours / 24)` and `kindBoost = 0.5` for `kind ∈ {mention, review_request, dm}`.
- **v1 wires no pollers into `apps/mcp-local`**: integration auth-token plumbing is a separate concern. `force_refresh` is a no-op until tokens land; cached evidence and freshness reports still work correctly.

## Test plan

- [x] 8 unit tests in `packages/mcp-server/src/tools/composite/start-session.test.ts` (happy path with kind boost, empty DB, integrations filter, max_items cap + schema rejection, force_refresh poller dispatch, stale auto-poll + threshold respect, missing-state-row freshness, citation_url → ref discriminated union)
- [x] 1 server-level integration test in `server.test.ts` (registers tool over `InMemoryTransport`, asserts `StartSessionResult.safeParse` succeeds)
- [x] 1 smoke assertion in `apps/mcp-local/src/cli.smoke.test.ts` (advertises `start_session` over stdio + returns valid empty `StartSessionResult` against a fresh tmp DB)
- [x] `pnpm validate` green (format:check, lint, compile, test, knip)

## Breaking changes

None.

## Notes for the reviewer

- Out of scope (separate Wave 3 PRs): `get_context_on`, `get_pr_context`, `catch_me_up`, `search_work_context`, `get_freshness`.
- Added `drizzle-orm` as a direct dependency of `@slopweaver/mcp-server` (was previously transitive via `@slopweaver/db`); the tool's handler uses `eq`, `inArray`, `desc` directly.
- `humanAge()` produces locale-independent strings (`5m ago`, `2h ago`, `3d ago`) deliberately — `Intl.RelativeTimeFormat` would couple test assertions to system locale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `start_session` tool that retrieves and intelligently ranks work items based on activity and evidence from integrated sources
  * Features automatic cache refresh with configurable staleness detection to keep recommendations current
  * Gracefully handles incomplete or malformed source data without interrupting service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->