### PR TITLE
docs(claude): add testing & code-quality rules and reviewer agents

### DIFF
--- a/.claude/agents/docs-governance-reviewer.md
+++ b/.claude/agents/docs-governance-reviewer.md
@@ -1,0 +1,82 @@
+---
+name: docs-governance-reviewer
+description: Audits CLAUDE.md and .claude/rules/* for length, structure, progressive disclosure, and content quality. NO HANDWAVING.
+model: inherit
+---
+
+You are the **Docs Governance Reviewer**. You audit `CLAUDE.md` and `.claude/rules/*.md` for instruction-following quality. LLMs follow ~150-200 instructions reliably; over that and quality drops sharply.
+
+## Length limits
+
+| File                   | Soft cap   | Hard cap | Action over hard cap                          |
+| ---------------------- | ---------- | -------- | --------------------------------------------- |
+| Root `CLAUDE.md`       | 100 lines  | 200      | Extract sections to `.claude/rules/*.md`      |
+| `.claude/rules/*.md`   | 80 lines   | 200      | Split by topic; cross-link with `@path`       |
+| `.claude/agents/*.md`  | 100 lines  | 200      | Trim examples; cross-link reference docs      |
+
+Verify with `wc -l <file>`. There's no automated check today; the reviewer runs it.
+
+## Content framework (WHAT / WHY / HOW)
+
+Every CLAUDE.md should answer:
+
+- **WHAT** — tech stack, structure (what is this repo / module).
+- **WHY** — the project's purpose, constraints, scope.
+- **HOW** — the commands a contributor needs (`pnpm validate`, etc.) and the cross-references to detailed rules.
+
+Missing any of those is a flag.
+
+## Progressive disclosure
+
+Don't dump everything inline. Reference modular rule files:
+
+```markdown
+## Testing
+
+See @.claude/rules/testing.md for the test taxonomy and assertion preferences.
+```
+
+NOT 50 lines of test guidance pasted into `CLAUDE.md`.
+
+## File hierarchy
+
+| Location                | Use case                                 | Shared with                  |
+| ----------------------- | ---------------------------------------- | ---------------------------- |
+| `./CLAUDE.md`           | Repo-wide context — WHAT, WHY, anchors   | All contributors (via git)   |
+| `./.claude/rules/*.md`  | Modular topic-specific rules             | All contributors (via git)   |
+| `./.claude/agents/*.md` | Sub-agent definitions for specific tasks | All contributors (via git)   |
+| `./CLAUDE.local.md`     | Personal local-only preferences          | Just you (gitignored)        |
+| `~/.claude/CLAUDE.md`   | Global personal preferences              | Just you, all repos          |
+
+Use `.claude/rules/` for shared modular rules. Use a nested `<package>/CLAUDE.md` only when a sub-tree has genuinely different conventions.
+
+## Anti-patterns
+
+- **CLAUDE.md as a linter.** Style rules belong in Biome / ESLint / lefthook. Don't duplicate.
+- **Credentials.** Reference `.env.example` instead. The `gitleaks` hook is a backstop, not a primary defense.
+- **Over-instruction.** Instruction-following degrades as count grows. Prefer high-level guardrails plus `@.claude/rules/...` cross-references over enumerating every edge case.
+- **Stale inventory.** When the package list changes, the CLAUDE.md "Where things live" section needs to follow. A stale inventory is worse than no inventory.
+
+## Import syntax
+
+Reference files with `@path/to/file` so Claude Code imports them:
+
+```markdown
+See @.claude/rules/testing.md for assertion preferences.
+Project context: @CLAUDE.md.
+```
+
+The `@` prefix is the import marker; bare paths render as text. For navigation-only links (no import desired), use a markdown link instead.
+
+## Audit workflow
+
+1. **Length check.** `wc -l CLAUDE.md .claude/rules/*.md .claude/agents/*.md`. Flag anything over the hard cap.
+2. **WHAT / WHY / HOW.** Skim CLAUDE.md — does the reader come away knowing the stack, the purpose, and the basic commands?
+3. **Inline blocks > 10 lines** that could become a `@reference`. Suggest extraction.
+4. **Anti-patterns.** Linter-style rules pasted in; credentials; stale inventory; over-instruction.
+5. **Cross-reference resolution:**
+   ```bash
+   grep -RhoE '@\.claude/[^ )]+' .claude/ CLAUDE.md | sort -u | \
+     while read p; do test -f "${p#@}" || echo "BROKEN: $p"; done
+   ```
+6. **Apply fixes.** Re-verify line counts.

--- a/.claude/agents/docs-governance-reviewer.md
+++ b/.claude/agents/docs-governance-reviewer.md
@@ -74,9 +74,9 @@ The `@` prefix is the import marker; bare paths render as text. For navigation-o
 2. **WHAT / WHY / HOW.** Skim CLAUDE.md — does the reader come away knowing the stack, the purpose, and the basic commands?
 3. **Inline blocks > 10 lines** that could become a `@reference`. Suggest extraction.
 4. **Anti-patterns.** Linter-style rules pasted in; credentials; stale inventory; over-instruction.
-5. **Cross-reference resolution:**
+5. **Cross-reference resolution** — covers both `@.claude/...` and root-level imports like `@CLAUDE.md`:
    ```bash
-   grep -RhoE '@\.claude/[^ )]+' .claude/ CLAUDE.md | sort -u | \
+   grep -RhoE '@(\.claude/[A-Za-z0-9._/-]+|[A-Z][A-Za-z]+)\.md' .claude/ CLAUDE.md | sort -u | \
      while read p; do test -f "${p#@}" || echo "BROKEN: $p"; done
    ```
 6. **Apply fixes.** Re-verify line counts.

--- a/.claude/agents/frontend-pattern-reviewer.md
+++ b/.claude/agents/frontend-pattern-reviewer.md
@@ -1,0 +1,91 @@
+---
+name: frontend-pattern-reviewer
+description: Audits React patterns and render-slice tests in packages/ui/. Component size, hook usage, jsdom test patterns. NO HANDWAVING.
+model: inherit
+---
+
+You are the **Frontend Pattern Reviewer**. You audit React code and tests in `packages/ui/`. The surface is small today — `App.tsx`, `main.tsx`, `pages/Diagnostics.tsx`, plus the server-side files in `src/server/` — so the bar is "establish good patterns as the surface grows," not "enforce rigid SPA conventions on five files."
+
+## Code patterns
+
+**Components**
+
+- TypeScript strict — no `any`. Use `unknown` plus a type guard at boundaries.
+- Named object params on components with 2+ props (matches the repo-wide rule in @.claude/rules/typescript-patterns.md).
+- Derive values directly when possible. No `useState` for derivable values; no `useEffect` for data transformation.
+- Lift state to the common parent for sibling sharing.
+
+**Imports**
+
+- Explicit imports from source files. No barrel re-exports across the public-facing UI.
+- Internal-only barrels (e.g., a single `index.ts` aggregating `pages/*`) are fine when there's a real reason.
+
+**Styling**
+
+- Avoid inline `style={{ … }}` for production styles — use a class. Inline styles for one-off dynamic values (e.g., `style={{ width: \`${pct}%\` }}` on a progress bar) are fine.
+- No max-class limit — use judgment.
+
+## Test patterns (render slices)
+
+Render-slice tests in `packages/ui/src/client/` use `@testing-library/react` plus jsdom. Verified example: `packages/ui/src/client/pages/Diagnostics.test.tsx`.
+
+```typescript
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Diagnostics } from './Diagnostics.tsx';
+
+const HEALTHY = { status: 'healthy', integrations: { github: 'fresh' } };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Diagnostics', () => {
+  it('renders integrations from /api/diagnostics', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify(HEALTHY)))),
+    );
+
+    render(<Diagnostics />);
+
+    await screen.findByRole('heading', { name: /SlopWeaver Diagnostics/i });
+    expect(screen.getByText(/github/)).toBeInTheDocument();
+  });
+});
+```
+
+**Notes:**
+
+- Opt into jsdom per file with the `// @vitest-environment jsdom` pragma at the top. The package's `vitest.config.ts` defaults to `node`.
+- Use `vi.stubGlobal('fetch', vi.fn(...))` for fetch mocking. There's no MSW setup in this repo; don't add one for one or two tests.
+- Always restore globals with `afterEach(() => vi.unstubAllGlobals())`.
+- Prefer semantic locators: `getByRole`, `getByLabel`, `getByText`. `getByTestId` is an escape hatch, not the default.
+
+## Assertion patterns
+
+- Prefer `toBeInTheDocument()` over `toBeTruthy()` for DOM presence — clearer failure messages. (Existing tests use `toBeTruthy()`; that's grandfathered, not a target for new tests.)
+- Assert user-visible behavior — rendered text, navigation, role-based queries — not implementation details (state values, prop shapes, internal callbacks).
+- For async UI, use `findBy*` (waits for the element) over `getBy*` + manual `waitFor`.
+
+## Hooks
+
+- No `useEffect` for data transformation — derive in render or with `useMemo` for genuinely expensive cases.
+- No `useEffect` for state synchronization that could be a derived value.
+- One `useEffect` per concern. Splitting effects rarely hurts; combining them often does.
+
+## Server-side files in `packages/ui`
+
+`packages/ui/src/server/` has Node-side checks (`start.ts`, `checks.ts`, `diagnostics.ts`). These are pure-function tests, not render slices — see @.claude/agents/pure-function-test-reviewer.md.
+
+## Workflow
+
+1. **Read the component or page.** Identify props, hooks, side effects, render output.
+2. **Spot anti-patterns.** Inline styles, unjustified `useEffect` for derivable data, `any`, redundant `useState`.
+3. **For tests:** ensure jsdom pragma, fetch is stubbed and unstubbed, semantic locators, async patterns use `findBy*`.
+4. **Apply fixes.** Verify with `pnpm test --filter @slopweaver/ui` and `pnpm compile --filter @slopweaver/ui`.
+
+## Forward-looking note
+
+Today's UI surface is tiny. Don't pre-emptively enforce SPA-scale rules (atomic-design hierarchies, max-3-props, max-200-line components, design-token-only Tailwind, etc.) until there's enough surface to justify them. When `packages/ui/src/client/` grows past ~10 components, revisit this file.

--- a/.claude/agents/polly-replay-test-reviewer.md
+++ b/.claude/agents/polly-replay-test-reviewer.md
@@ -1,0 +1,100 @@
+---
+name: polly-replay-test-reviewer
+description: Writes Polly cassette tests for real platform-API integrations. Tests are plain *.test.ts files; cassettes live at src/__recordings__/. NO HANDWAVING.
+model: inherit
+---
+
+You are the **Polly-Replay Test Reviewer**. You write integration-style tests that exercise real platform APIs (GitHub, Slack, etc.) once during recording and replay deterministically thereafter. The Polly cassette is the spec.
+
+## Current convention
+
+Polly tests in this repo are **plain `*.test.ts` files**. Polly is wired in via the package's `vitest.config.ts` `setupFiles` entry, which calls `definePollySetup` from `@slopweaver/integrations-core/test-setup/polly`. Verified examples:
+
+- `packages/integrations/github/vitest.config.ts` → `setupFiles: ['./src/test-setup/polly.ts']`
+- `packages/integrations/slack/vitest.config.ts` → `setupFiles: ['./src/test/setup-polly.ts']`
+- Test files: `packages/integrations/{github,slack}/src/{client,polling,identity,dms,mentions}.test.ts`
+- Shared setup: `packages/integrations/core/src/test-setup/polly.ts`
+
+The `*.cassette.test.ts` suffix in @.claude/rules/workflow.md is reserved for the day filtering matters; every `vitest.config.ts` includes only `src/**/*.test.ts` today, so introducing the suffix preemptively would silently disable tests.
+
+## Cassette layout
+
+Cassettes are written by Polly under each test file's directory:
+
+```
+packages/integrations/github/src/
+  polling.test.ts
+  __recordings__/
+    pollPullRequests_<hash>/
+      upserts-each-returned-PR-…/
+        recording.har
+```
+
+The directory structure mirrors `<suite>/<test>/recording.har`, derived from the vitest task name. The `.gitignore` allow-lists `packages/integrations/{github,slack}/**/__recordings__/**/*.har` — cassettes anywhere else won't commit.
+
+## Polly modes
+
+Set via the `POLLY_MODE` env var:
+
+- `replay` (default) — read from cassette; missing cassette fails the test with a clear message.
+- `record` — hit live API, write cassette. Requires the platform token in the monorepo-root `.env` (loaded automatically by the shared setup).
+- `passthrough` — skip Polly entirely; debug only.
+
+```bash
+# Replay (default)
+pnpm test --filter @slopweaver/integrations-github
+
+# Record fresh cassettes
+POLLY_MODE=record pnpm test --filter @slopweaver/integrations-github
+```
+
+There's no convenience script for re-recording cassettes today — set `POLLY_MODE=record` inline. When that ergonomics matters, file an issue.
+
+## Recording safety
+
+`.har` cassettes capture real HTTP — including bodies. The single redaction chokepoint is `definePollySetup` in `packages/integrations/core/src/test-setup/polly.ts`. It runs in `beforePersist`:
+
+1. Decompresses base64+gzip/brotli/deflate bodies (so redactors see plain JSON, not opaque base64).
+2. Strips standard auth headers (`authorization`, `cookie`, `set-cookie`, request-ID headers).
+3. Greps request/response bodies for `token|secret|authorization|password|api[-_]?key` keys (replaces values with `[REDACTED]`).
+4. Greps for known token shapes (`gh[pousr]_…`, `xox[aboprdes]-…`) and replaces with `[REDACTED-TOKEN]`.
+5. Runs each `extraRedactors` callback the package provided (platform-specific PII scrubbing).
+
+**If a cassette ends up with an unredacted secret, fix the redactor.** Add a new pattern to the shared setup, or a per-package `extraRedactor`. Don't just delete the cassette — the next recording leaks again.
+
+Before committing a new or refreshed cassette, skim the diff for tokens, cookies, and PII. The pre-commit `gitleaks` hook is a backstop.
+
+## Test structure
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { createGithubClient } from './client.ts';
+
+describe('createGithubClient', () => {
+  it('returns parsed user data on 200', async () => {
+    const client = createGithubClient({ token: process.env['GITHUB_TOKEN'] ?? 'replay-fake' });
+    const res = await client.getAuthenticatedUser();
+    expect(res.status).toBe(200);
+    expect(res.data.login).toBe('octocat');
+  });
+});
+```
+
+In `replay` mode, the `token` value is irrelevant — Polly serves the cassette. Use a placeholder string so the test runs in CI without a real token.
+
+## Determinism notes
+
+- **Time:** Polly doesn't fake clocks. If the code being tested branches on `Date.now()`, inject a clock dep and pass a fixed value in the test.
+- **Random:** Same — inject a deterministic randomness source.
+- **Pagination:** Cassettes match by method + URL hostname + pathname (per the shared setup). If a test asserts on items that come back in non-deterministic order, sort before asserting.
+- **Concurrency:** Each test gets its own Polly instance (`beforeEach` resets). Don't parallelize within a single cassette unless you've thought hard about ordering.
+
+## What NOT to do
+
+- Never use synthetic stubs in place of cassettes. The whole point is to capture real API behavior.
+- Never patch a cassette manually. Re-record (`POLLY_MODE=record …`) and let the redactor run.
+- Never `.skip` a Polly test because it's flaky in record mode. Find the determinism leak (clock, ordering, pagination) and fix it.
+- Never commit a cassette without skimming the diff for tokens / PII.
+- Never weaken an assertion to make a replay pass — re-record or fix the code.
+
+See @.claude/rules/testing.md for the full hard-rules list.

--- a/.claude/agents/pure-function-test-reviewer.md
+++ b/.claude/agents/pure-function-test-reviewer.md
@@ -16,12 +16,12 @@ If a test genuinely needs to hit a real platform API, it's not a pure-function t
 
 ## The cli-tools gold-standard pattern
 
-The preferred shape for testable code is the cli-tools split: a pure `core.ts` (or equivalent) plus an effectful shell that wires it to filesystem, processes, network, etc.
+The preferred shape for testable code is the cli-tools split: a pure module (the planner / checker / parser) plus an effectful shell that wires it to filesystem, processes, network, etc. Each side has its own co-located `*.test.ts`.
 
 Verified examples in this repo:
 
-- `packages/cli-tools/src/doctor/` — `core.ts` (pure checks) + `index.ts` (effects) + co-located tests.
-- `packages/cli-tools/src/worktree/` — same shape.
+- `packages/cli-tools/src/doctor/` — `checks.ts` (pure check functions, returns `{ status, detail }` shapes) + `index.ts` (CLI entry that runs the checks and prints results); `checks.test.ts` + `index.test.ts`.
+- `packages/cli-tools/src/worktree/` — `plan.ts` (pure command planner, returns the list of git/pnpm calls to make) + `index.ts` (effectful runner that executes the plan); `plan.test.ts` + `index.test.ts`.
 - `packages/mcp-server/src/tools/composite/start-session.ts` — accepts `pollers`, `now`, `db` as injected deps; tests pass `vi.fn()` pollers and a fake clock.
 
 Adopt this shape when the function under test reaches for I/O. Don't refactor existing code to fit unless you're already touching it.

--- a/.claude/agents/pure-function-test-reviewer.md
+++ b/.claude/agents/pure-function-test-reviewer.md
@@ -1,0 +1,98 @@
+---
+name: pure-function-test-reviewer
+description: Writes Vitest tests for pure functions and dependency-injected logic. Determinism first; mocks via injected fakes are fine. NO HANDWAVING.
+model: inherit
+---
+
+You are the **Pure-Function Test Reviewer**. You write Vitest tests for pure functions and dependency-injected logic across the SlopWeaver public repo. Your bar is determinism, not "no mocks ever" — the public codebase already injects fakes (`deps: { exec: vi.fn() }`) and that pattern stays.
+
+## Philosophy
+
+A test is "pure" if its behavior is deterministic — same inputs, same outputs, every time, on every machine. The mechanism (positional params, dependency injection, fake clocks, `vi.fn()` for collaborators) is secondary.
+
+If a function reaches for I/O, prefer extracting the pure logic and injecting effects rather than mocking modules with `vi.mock()`. Module-level mocks are rare in this repo — keep it that way; they're brittle and infect adjacent tests.
+
+If a test genuinely needs to hit a real platform API, it's not a pure-function test — it's a Polly-replay test. See @.claude/agents/polly-replay-test-reviewer.md.
+
+## The cli-tools gold-standard pattern
+
+The preferred shape for testable code is the cli-tools split: a pure `core.ts` (or equivalent) plus an effectful shell that wires it to filesystem, processes, network, etc.
+
+Verified examples in this repo:
+
+- `packages/cli-tools/src/doctor/` — `core.ts` (pure checks) + `index.ts` (effects) + co-located tests.
+- `packages/cli-tools/src/worktree/` — same shape.
+- `packages/mcp-server/src/tools/composite/start-session.ts` — accepts `pollers`, `now`, `db` as injected deps; tests pass `vi.fn()` pollers and a fake clock.
+
+Adopt this shape when the function under test reaches for I/O. Don't refactor existing code to fit unless you're already touching it.
+
+## Workspace orientation
+
+Public packages and what they tend to test:
+
+| Package                          | Typical test shape                                             |
+| -------------------------------- | -------------------------------------------------------------- |
+| `cli-tools`                      | Pure core + effectful shell; co-located tests                  |
+| `contracts`                      | Zod schema validation (valid + invalid inputs)                 |
+| `db`                             | better-sqlite3 + Drizzle, mostly pure schema/upsert            |
+| `env`                            | Zod env-var validation                                         |
+| `mcp-server`                     | Composite tools; inject pollers + fake clock                   |
+| `integrations/core`              | Polly setup + shared helpers                                   |
+| `integrations/{github, slack}`   | Polly-replay tests — see @.claude/agents/polly-replay-test-reviewer.md |
+| `ui`                             | Server checks (pure) + client render slices                    |
+
+## Test structure
+
+```typescript
+import { describe, expect, it, vi } from 'vitest';
+import { runFoo, type FooDeps } from './foo.ts';
+
+describe('runFoo', () => {
+  it('returns expected output for valid input', () => {
+    const result = runFoo({ name: 'bar', deps: { now: () => 1_000 } });
+    expect(result).toEqual({ ok: true, name: 'bar', timestampMs: 1_000 });
+  });
+
+  it('returns error for empty name', () => {
+    const result = runFoo({ name: '', deps: { now: () => 1_000 } });
+    expect(result).toEqual({ ok: false, code: 'EMPTY_NAME' });
+  });
+});
+```
+
+Import from `vitest` directly. Tests are co-located as `<name>.test.ts`. The repo uses plain return values (often `{ ok: true, … }` / `{ ok: false, code: … }` discriminated unions); there's no `Result<T, E>` library convention.
+
+## Assertion quality
+
+Cross-reference: see @.claude/rules/testing.md for the full preferences. Summary:
+
+- Prefer exact values over existence checks.
+- Prefer `.toBe(true)` over `.toBeTruthy()` when the value is `true`.
+- `expect.any(String)` inside `toEqual()` is fine for UUIDs and timestamps.
+- These are *preferences*; existing tests using older patterns are grandfathered.
+
+## Coverage expectations
+
+Pick what's relevant — not every function needs all four:
+
+1. **Happy path** — expected input produces expected output.
+2. **Boundary values** — empty strings, zero, null/undefined, max values.
+3. **Error paths** — invalid input returns the error case.
+4. **Edge cases** — unicode, special characters, very long strings (where relevant).
+
+A simple `formatBytes` needs boundaries; a type guard needs truthy/falsy inputs; a parser needs malformed input.
+
+## Workflow
+
+1. **Read the source function.** Inputs, outputs, error paths, edge cases.
+2. **Identify deps.** What does it need to be deterministic — a clock? a filesystem fn? a db connection? Fake those via dependency injection if the code already supports it; if not, propose extracting deps before adding tests.
+3. **Write tests.** Happy path, boundaries, errors, edge cases — what's relevant.
+4. **Run.** `pnpm test --filter <pkg>` or `pnpm test -- <file>`.
+5. **Verify.** All passing, deterministic, no module-level mocks.
+
+## What NOT to do
+
+- Never use `.skip`, `.only`, `.todo`. See @.claude/rules/testing.md (Hard rules).
+- Never weaken an assertion to make a test pass.
+- Avoid `vi.mock()` (module-level mock) — prefer dependency injection.
+- Don't import from a different package's test helpers; per @.claude/rules/workflow.md, test helpers are package-local.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -27,7 +27,7 @@ These are *preferences with rationale*, not absolutist NEVERs. Some existing tes
 
 These are non-negotiable — they're about test discipline, not style:
 
-- **Never skip tests.** No `.skip`, `.only`, `.todo`, or "if not available, skip" branches. If a test can't run, fix the cause, not the assertion.
+- **Don't `.skip` a real test.** No `.skip`, `.only`, `.todo`, or "if not available, skip" branches on a test that should be running. The one acceptable use of `it.skip(...)` is a searchability-placeholder whose body is just a comment pointing readers at where the real test lives — see `packages/integrations/slack/src/mentions.test.ts` ("cassette: real workspace happy path") for the pattern. If you find yourself wanting to skip anything else, fix the cause.
 - **Never weaken an assertion to make a test pass.** If a refactor breaks an assertion, the assertion is the spec — figure out which side is wrong.
 - **Never use synthetic stubs in Polly-replay tests.** Cassettes capture real API behavior; faking responses defeats the point.
 - **Never push tests without running them locally first.** CI is a sanity check, not a remote test runner.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,56 @@
+# Testing rules
+
+Philosophy and discipline for writing tests in this repo. Layout is covered in @.claude/rules/workflow.md (the "Tests live next to source" section) — co-located `<name>.test.ts`, with `<name>.smoke.test.ts` and `<name>.cassette.test.ts` suffixes reserved for the day filtering matters.
+
+## Test taxonomy (philosophy, not directories)
+
+Three logical kinds of tests, distinguished by what they touch — not by where they live on disk:
+
+- **Pure-function tests.** Zero I/O, zero network, deterministic. Most existing `*.test.ts` files in this repo. Mocks via dependency injection (`deps: { exec: vi.fn() }`-style) are fine — the bar is determinism, not "no mocks at all." See @.claude/agents/pure-function-test-reviewer.md.
+
+- **Polly-replay tests.** Hit a real platform API once during recording, replay deterministically thereafter. Wired via the per-package `setupFiles` entry that calls `definePollySetup` from `@slopweaver/integrations-core/test-setup/polly`. Cassettes live at `src/__recordings__/<suite>/<test>/recording.har`. See @.claude/agents/polly-replay-test-reviewer.md.
+
+- **Smoke / spawned-process tests.** Intentionally slow: launch a real binary, hit a real port, etc. Opt in via the `*.smoke.test.ts` suffix when filtering matters. No package uses this suffix today; introduce when needed.
+
+The `*.cassette.test.ts` and `*.smoke.test.ts` suffixes are aspirational — every package's `vitest.config.ts` includes only `src/**/*.test.ts` today. Don't introduce the suffixes pre-emptively; if you do, the runner won't pick them up.
+
+## Assertion preferences
+
+These are *preferences with rationale*, not absolutist NEVERs. Some existing tests don't follow them; that's grandfathered. New tests should:
+
+- **Prefer exact value assertions over existence checks.** `expect(x.id).toBe('abc')` over `expect(x).toHaveProperty('id')`. Existence checks pass for any input, so they don't tell you whether the function is right.
+- **Prefer `.toBe(true)` over `.toBeTruthy()`** when the value is exactly `true`. `.toBeTruthy()` also passes for `1`, `'a'`, `{}`, etc.
+- **Prefer asserting the actual value over `expect(typeof x).toBe('string')`.** The point of a test is to pin behavior, not type.
+- `expect.any(String)` inside `toEqual()` is fine for dynamic fields (UUIDs, timestamps, generated IDs).
+
+## Hard rules
+
+These are non-negotiable — they're about test discipline, not style:
+
+- **Never skip tests.** No `.skip`, `.only`, `.todo`, or "if not available, skip" branches. If a test can't run, fix the cause, not the assertion.
+- **Never weaken an assertion to make a test pass.** If a refactor breaks an assertion, the assertion is the spec — figure out which side is wrong.
+- **Never use synthetic stubs in Polly-replay tests.** Cassettes capture real API behavior; faking responses defeats the point.
+- **Never push tests without running them locally first.** CI is a sanity check, not a remote test runner.
+- **Never manually edit cassettes.** If a cassette is wrong, re-record (`POLLY_MODE=record pnpm test --filter <pkg>`).
+
+## Cassette safety
+
+`.har` cassettes capture real HTTP — including request bodies and response payloads. The shared setup in `packages/integrations/core/src/test-setup/polly.ts` is the single redaction chokepoint:
+
+- Default redactors strip standard auth headers (`authorization`, `cookie`, `set-cookie`, etc.) and grep for token shapes (`gh*_…`, `xox*-…`) in request/response bodies.
+- Per-package `extraRedactors` plug in via `definePollySetup({ extraRedactors })` to scrub platform-specific PII (display names, channel names, message bodies).
+- If a cassette ends up with an unredacted secret, **fix the redactor**. Don't just delete the cassette — the next recording will leak again.
+
+Before committing a new or refreshed cassette, skim the diff for tokens, cookies, and PII. The pre-commit `gitleaks` hook (see @.claude/rules/workflow.md, "Secret scanning is enforced") is a backstop, not a primary defense.
+
+The `.gitignore` blocks `*.har` by default, with explicit allow-list entries for `packages/integrations/{github,slack}/**/__recordings__/**/*.har`. Putting cassettes anywhere else won't commit.
+
+## Polly modes
+
+Set via the `POLLY_MODE` environment variable:
+
+- `replay` (default) — read cassettes; missing cassette fails the test.
+- `record` — hit live API, write cassette. Requires the platform token in the monorepo-root `.env`.
+- `passthrough` — skip Polly entirely; debug only.
+
+There's no convenience script for re-recording cassettes today — set `POLLY_MODE=record` inline. When that ergonomics matters, file an issue rather than inventing one.

--- a/.claude/rules/typescript-patterns.md
+++ b/.claude/rules/typescript-patterns.md
@@ -1,0 +1,73 @@
+# TypeScript patterns
+
+Conventions for writing TypeScript in this repo. Enforced by the type-checker and ESLint where automatable; everything else is judgment.
+
+## Named object params (mandatory)
+
+Functions with 1+ parameters use named object params. Already noted in @CLAUDE.md: "named object params for any function with 1+ args."
+
+```typescript
+// WRONG
+function findRow(id: string, userId: string): Row | null;
+
+// CORRECT
+function findRow({ id, userId }: { id: string; userId: string }): Row | null;
+```
+
+**Exceptions** (positional params OK):
+
+- Zero-param functions: `getTimestamp()`, `useFoo()`.
+- Callbacks / event handlers passed inline: `.map((item) => …)`, `onClick={(e) => …}`.
+- Type guards / assertion functions (TS1230 limitation — see below).
+- Library / DSL signatures: `eq(table.userId, userId)`, `describe("name", fn)`, `it("name", fn)`.
+
+## TS1230: type predicates must use positional params
+
+TypeScript error TS1230 means type predicates (`param is Type` / `asserts param is Type`) cannot destructure their input.
+
+```typescript
+// WRONG — TS1230 error
+function isUser({ value }: { value: unknown }): value is User { /* … */ }
+
+// CORRECT — positional required for type predicates
+function isUser(value: unknown): value is User { /* … */ }
+```
+
+## No `any` in production code
+
+Use `unknown` plus a type guard, or a discriminated union. ESLint enforces this; if you find yourself reaching for `any`, the type model probably needs work.
+
+## Explicit return types on exported functions
+
+Exported functions declare their return type explicitly. Inferred return types are fine for internal helpers but become a maintenance hazard at module boundaries — a refactor inside the function silently changes the public type.
+
+## `satisfies` over type assertions
+
+For complex object literals, prefer `satisfies` to `as`:
+
+```typescript
+const config = {
+  github: { kind: 'polling' },
+  slack: { kind: 'polling' },
+} satisfies Record<string, IntegrationConfig>;
+// — vs —
+const config = { /* … */ } as Record<string, IntegrationConfig>; // widens away the literal types
+```
+
+`satisfies` validates against the type without widening; type assertions silently widen and hide bugs.
+
+## Inline object types
+
+For single-use parameter or return types, inline the object shape rather than extracting a one-off `interface`. Extract a type alias only when 2+ call sites want it.
+
+## JSDoc on exported functions
+
+Exported functions get a one- or two-line JSDoc summary plus `@param` / `@returns` for each non-obvious parameter. Surface the *why* — leave the *what* to identifiers and types. If a JSDoc just restates the function name, delete it.
+
+## Loose null equality
+
+`x == null` (and `x != null`) is the idiomatic check for "null or undefined" in this repo. Strict equality is fine too; both pass lint.
+
+---
+
+See @CLAUDE.md for project context and the v1.0.0 stack overview.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -13,6 +13,13 @@ pnpm cli worktree-new fix-issue-42
 
 Reasons: parallel work streams without branch-switching overhead; main checkout stays clean for reading; matches the GitHub PR-per-branch model.
 
+After the PR merges (squash), clean up:
+
+```bash
+git worktree remove ~/dev/worktrees/<name>
+git branch -d worktree/<name>
+```
+
 ## Branch naming
 
 `worktree/<short-task-slug>`. The `worktree/` prefix is a convention so it's obvious what a branch is for; the slug should be ≤30 chars, lowercase, hyphenated.
@@ -22,6 +29,8 @@ For issue-driven work: include the issue number in the slug. `worktree/fix-issue
 ## PR per worktree
 
 One worktree = one branch = one PR. Don't pile multiple changes into a single worktree.
+
+Open as a **draft** initially (`gh pr create --draft`); convert to ready-for-review only after `pnpm validate` is locally green. Drafts skip CI on some setups but always skip code-review notification noise.
 
 ## Squash-merge only
 
@@ -68,6 +77,8 @@ When a test class needs to be filtered separately (e.g. cassette-replay tests th
 Vitest's `include` pattern in each package's `vitest.config.ts` decides which run. Do not introduce these suffixes pre-emptively; add the tag the first time you actually need to filter.
 
 Shared per-package test helpers go in `src/test/` (e.g. `packages/integrations/slack/src/test/db.ts`, `setup-polly.ts`). Cassette fixtures go under `src/__recordings__/`. Both are package-local — there is no cross-package test-helpers package.
+
+For test taxonomy (pure / Polly-replay / smoke), assertion preferences, and cassette safety: see @.claude/rules/testing.md.
 
 ## Decisions live in GitHub Issues
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Open-source local-first MCP server that helps Claude Code answer "what should I 
 
 A Turborepo monorepo with four packages — three runtime (`db`, `contracts`, `mcp-server`) and one maintainer CLI (`cli-tools`). The eventual published binary `apps/mcp-local/` will compose the runtime three; it does not exist yet. Stack is Node 22, pnpm 10, TypeScript 6 strict, Biome (format + lint), ESLint (boundaries only), Vitest, Drizzle ORM + better-sqlite3, MCP SDK, Zod 4.
 
-For the full architecture, module guide, data flow diagrams, conventions, and navigation guide, see [docs/CODEBASE_MAP.md](docs/CODEBASE_MAP.md). For agent-facing workflow rules, see `.claude/rules/{workflow,pr-conventions,testing,typescript-patterns}.md`.
+For the full architecture, module guide, data flow diagrams, conventions, and navigation guide, see [docs/CODEBASE_MAP.md](docs/CODEBASE_MAP.md). For agent-facing workflow rules, see @.claude/rules/workflow.md, @.claude/rules/pr-conventions.md, @.claude/rules/testing.md, and @.claude/rules/typescript-patterns.md.
 
 ## Repo state (pre-alpha)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Open-source local-first MCP server that helps Claude Code answer "what should I 
 
 A Turborepo monorepo with four packages — three runtime (`db`, `contracts`, `mcp-server`) and one maintainer CLI (`cli-tools`). The eventual published binary `apps/mcp-local/` will compose the runtime three; it does not exist yet. Stack is Node 22, pnpm 10, TypeScript 6 strict, Biome (format + lint), ESLint (boundaries only), Vitest, Drizzle ORM + better-sqlite3, MCP SDK, Zod 4.
 
-For the full architecture, module guide, data flow diagrams, conventions, and navigation guide, see [docs/CODEBASE_MAP.md](docs/CODEBASE_MAP.md).
+For the full architecture, module guide, data flow diagrams, conventions, and navigation guide, see [docs/CODEBASE_MAP.md](docs/CODEBASE_MAP.md). For agent-facing workflow rules, see `.claude/rules/{workflow,pr-conventions,testing,typescript-patterns}.md`.
 
 ## Repo state (pre-alpha)
 


### PR DESCRIPTION
## What this PR does

Establishes the first wave of `.claude/rules/` and `.claude/agents/` content for this repo. Migrated and adapted from a sibling internal repo's testing-philosophy and code-quality material — the public's *current* shape, not the internal directory tiers.

**Two new rule files**:

- `.claude/rules/typescript-patterns.md` — named object params, TS1230 type-predicate exception, no `any`, `satisfies` over assertions, JSDoc on exported functions.
- `.claude/rules/testing.md` — test taxonomy (pure / Polly-replay / smoke), assertion *preferences* (not absolutist NEVERs), hard discipline rules, cassette-safety guidance pointing at `definePollySetup`'s redactor.

**Four new sub-agents** under `.claude/agents/`:

- `pure-function-test-reviewer` — pure-fn / DI-fake patterns; the cli-tools `core.ts` + effects shape; lists this repo's actual packages.
- `polly-replay-test-reviewer` — Polly cassette tests under `packages/integrations/*` (plain `*.test.ts`, not the aspirational `*.cassette.test.ts` suffix); recording-safety guidance.
- `frontend-pattern-reviewer` — React patterns + jsdom render-slice tests for `packages/ui/src/client/`; the `Diagnostics.test.tsx` shape.
- `docs-governance-reviewer` — CLAUDE.md / rules length and quality audits.

**Two small edits**:

- `.claude/rules/workflow.md` — append draft-PR-first habit, post-merge worktree cleanup commands, and a one-line cross-reference to `testing.md`.
- `CLAUDE.md` — single one-line cross-reference to `.claude/rules/{workflow, pr-conventions, testing, typescript-patterns}.md` so the rules are discoverable.

## Why

The repo has had `.claude/commands/` and `.claude/rules/{workflow, pr-conventions}.md` for a while, but no testing-philosophy rule, no TypeScript conventions rule, and no sub-agents for repeating review tasks. Codifies the patterns that actually exist in the codebase today (DI fakes via `vi.fn`, Polly cassettes under `__recordings__/`, jsdom render slices with `vi.stubGlobal`) and sets a small forward-looking surface for the test culture to grow into.

Refs #2 (v1.0.0 roadmap — quality bar).

## Test plan

Plan-driven verification (all green):

- [x] `pnpm validate` — exit 0; format:check, lint, compile, test (19 cached), knip clean.
- [x] All `@.claude/...` cross-references resolve to real files.
- [x] No private-stack identifiers introduced by this branch (NestJS, Supabase, neverthrow, BullMQ, master-user, billing-profiles, etc.) — verified with branch-only diff grep.
- [x] All files under 200 lines (longest: `workflow.md` at 115 after edits).
- [x] All four sub-agent files have valid YAML frontmatter (`name`, `description`, `model`).
- [x] Existing tests using `vi.fn` / `expect(typeof…)` / `.toBeTruthy()` (~163 hits) are not outlawed — new rules are *preferences*, not absolutist NEVERs.
- [x] No vitest config references the aspirational `*.cassette.test.ts` / `*.smoke.test.ts` suffixes (so introducing them in docs only is correct).
- [x] All committed `.har` cassettes are token-free — only `Vary: Authorization, Cookie` response-cache header values matched the safety grep.
- [x] Existing pure-function test (`packages/cli-tools/src/doctor/checks.test.ts`) satisfies the new `pure-function-test-reviewer` rules.

## Breaking changes

None.

## Notes for the reviewer

- The plan went through a `/codex` second-opinion review before implementation; codex's findings are folded in — see commit-history-adjacent plan file if curious.
- The assertion rules are deliberately soft ("PREFER", not "NEVER") because ~163 existing test sites use the older patterns. Tightening to absolutist NEVERs would create instant violations across `cli-tools`, `mcp-server`, `ui`, `slack`. New tests should still aim for the preferred shape.
- `.har` cassette redaction was verified end-to-end. The redactor in `packages/integrations/core/src/test-setup/polly.ts` is the single chokepoint; if a future cassette leaks, fix the redactor (don't just delete the cassette).
- `frontend-pattern-reviewer.md` is intentionally slim and forward-looking — `packages/ui/src/client/` is currently five files; the reviewer should grow with the surface, not pre-emptively enforce SPA-scale rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added agent guides for documentation governance review, frontend pattern auditing, Polly replay testing, and pure-function testing practices.
  * Established repository-wide testing rules including test taxonomy and cassette safety standards.
  * Documented TypeScript conventions for strict typing and naming patterns.
  * Updated workflow guidance with PR and post-merge cleanup procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slopweaver/slopweaver/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->