### PR TITLE
feat(neverthrow): migrate packages to Result/ResultAsync pattern

### DIFF
--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -89,7 +89,7 @@ export async function pollMentions(args: PollMentionsArgs): Promise<PollResult> 
 }
 ```
 
-Enforced by `pnpm check:service-boundaries` (custom CLI check, wired
+Enforced by `pnpm cli check-service-boundaries` (custom CLI check, wired
 into `pnpm validate` as the first gate). The scanner covers these
 directories (all `.ts` files except tests, recordings, and `src/test/`):
 
@@ -252,6 +252,6 @@ in ESLint 9+; the plugin is therefore incompatible with the ESLint 10
 this repo uses. Tracked in #41.
 
 Until upstream catches up or a custom rule is written, the
-`pnpm check:service-boundaries` scanner is the runtime enforcement —
+`pnpm cli check-service-boundaries` scanner is the runtime enforcement —
 it catches new throws at service boundaries, which is the highest-risk
 regression class.

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -179,12 +179,25 @@ result.match(
 );
 ```
 
-…or the equivalent `if (isErr)` early-return shape — both forms appear
-in the repo. The CLI's outer `.catch()` (e.g. cac's `.action()` callback
-catching from a thrown `EnvValidationError`) also serves as a backstop
-for the typed-throw carve-out below; the `asMessage()` helper at the
-boundary extracts `.message` from BaseError-shaped values so they print
-cleanly either way.
+…or — and this is what current CLI entrypoints actually use — the
+equivalent `if (isErr)` early-return shape:
+
+```ts
+const result = await runCommand(args);
+if (result.isErr()) {
+  stderr.write(formatError(result.error) + '\n');
+  exit(1);
+  return;
+}
+stdout.write(format(result.value));
+```
+
+Either form is fine — pick whichever reads cleanly at the call site.
+The CLI's outer `.catch()` (e.g. cac's `.action()` callback catching
+from a thrown `EnvValidationError`) also serves as a backstop for the
+typed-throw carve-out below; the `asMessage()` helper at the boundary
+extracts `.message` from BaseError-shaped values so they print cleanly
+either way.
 
 **MCP tool handlers** (`packages/mcp-server/src/tools/...`) use a
 boundary helper inside the dispatcher to convert `Err` into an

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -201,3 +201,47 @@ Tests for unhappy paths assert on `error.code` (the discriminant), not
 
 If a rule above conflicts with what a piece of code is trying to do,
 file a `decision-record` issue rather than working around it.
+
+## Carve-outs (throws that are allowed)
+
+The "no throws at service boundaries" rule has three intentional
+exemptions. Code in any of these places may throw without being a bug:
+
+- **Browser-side data fetchers** (`packages/ui/src/client/api/**`) — React
+  consumers catch via `<ErrorBoundary>`, React Query's `onError`, or
+  SWR's `error` field; all three expect throw-based async. Threading
+  `Result` into the JSX layer would buy nothing and force every render
+  site to `.match()`. The scanner does not cover `packages/ui/src`.
+
+- **CLI entry points** (`apps/*/src/cli.ts`, `packages/cli-tools/src/cli.ts`)
+  — these are the boundary where Result is unwrapped via `.match()` and
+  printed. The preferred shape is still `.match()` (or `if (result.isErr())
+  { console.error(…); process.exit(…) }`), but throws are tolerated when:
+  - The throw is from a synchronous parse helper that the caller of the
+    parse helper wraps in a single `try/catch` (e.g. `cac.parse()`-style).
+  - The throw value is itself a typed error already (e.g. `throw envResult.error`
+    where the catcher checks `instanceof EnvValidationError`) — the CLI
+    boundary's `asMessage()` helper extracts `.message` from BaseError-shaped
+    objects so this prints cleanly.
+
+- **Recovery / classification `try/catch` blocks** — `try/catch` that
+  exists to *classify* an outcome (e.g. swallowing a known recoverable
+  error so the broader operation can proceed) is fine. The scanner only
+  flags `throw` statements, so a catch that doesn't re-throw isn't
+  affected. If a catch *does* re-throw, prefer returning `Result` with
+  a typed classification.
+
+## eslint-plugin-neverthrow status
+
+The upstream `eslint-plugin-neverthrow` runtime `must-use-result` rule
+(which would flag forgotten Result unwraps like `if (result)` /
+`result && x` / awaited-but-not-matched `ResultAsync`) is **not enabled**
+in `eslint.config.js`. v1.1.4 (last published 2022) reads
+`context.parserServices`, which moved to `context.sourceCode.parserServices`
+in ESLint 9+; the plugin is therefore incompatible with the ESLint 10
+this repo uses. Tracked in #41.
+
+Until upstream catches up or a custom rule is written, the
+`pnpm check:service-boundaries` scanner is the runtime enforcement —
+it catches new throws at service boundaries, which is the highest-risk
+regression class.

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -1,0 +1,203 @@
+# Error handling
+
+How errors flow through SlopWeaver's TypeScript code.
+
+This is the public-repo companion to the equivalent pattern in
+`slopweaver-private`. The motivation: every error becomes part of a typed
+union, so callers handle failure modes exhaustively (`.match()`,
+`switch`) instead of relying on `try/catch` review hygiene. Decision
+record: [#41](https://github.com/slopweaver/slopweaver/issues/41).
+
+## The pattern in one minute
+
+1. **Functions that can fail return `Result<T, E>` or `ResultAsync<T, E>`** from
+   [`@slopweaver/errors`](../../packages/errors/README.md), where `E` is a
+   discriminated union of error interfaces extending `BaseError`.
+2. **External SDK / API calls go through `safeApiCall`** (in
+   `@slopweaver/errors`). It's the only place exceptions from external
+   calls become Results.
+3. **Database operations go through `safeQuery`** (in `@slopweaver/db`).
+   Same idea, scoped to better-sqlite3.
+4. **At the user-facing boundary (CLI commands, MCP tool dispatch),
+   `.match()` the Result** to print + exit, or to format an MCP error
+   response.
+
+That's it. The rest of this doc is the conventions that make those four
+rules consistent across packages.
+
+## Error type shape
+
+Every domain error interface extends `BaseError`. The `code` field is
+the discriminant, in `SCREAMING_SNAKE_CASE`. Codes are unique within a
+package's error union.
+
+```ts
+import type { BaseError } from '@slopweaver/errors';
+
+export interface SlackTokenInvalidError extends BaseError {
+  readonly code: 'SLACK_TOKEN_INVALID';
+  readonly tokenPrefix: string;
+}
+
+export interface SlackPaginationCapError extends BaseError {
+  readonly code: 'SLACK_PAGINATION_CAP_EXCEEDED';
+  readonly totalPages: number;
+  readonly maxPages: number;
+}
+
+export type SlackError = SlackTokenInvalidError | SlackPaginationCapError; // | …
+```
+
+Each package exports both the union type AND a factory namespace, so
+constructing errors is uniform:
+
+```ts
+export const SlackErrors = {
+  tokenInvalid: (tokenPrefix: string): SlackTokenInvalidError => ({
+    code: 'SLACK_TOKEN_INVALID',
+    message: `Slack token must start with xoxp- or xoxb-, got "${tokenPrefix}"`,
+    tokenPrefix,
+  }),
+  paginationCapExceeded: (totalPages: number, maxPages: number): SlackPaginationCapError => ({
+    code: 'SLACK_PAGINATION_CAP_EXCEEDED',
+    message: `Slack search returned ${totalPages} pages, exceeds MAX_PAGES=${maxPages}; cursor not advanced.`,
+    totalPages,
+    maxPages,
+  }),
+} as const;
+```
+
+Callers always go through factories — they never construct error
+literals inline. This keeps messages consistent and gives you one place
+to add fields later.
+
+## Service layer: no throws
+
+A "service" here is any function that performs side effects (network,
+DB, FS) on behalf of the caller. Service files do not throw. They
+return `Result` / `ResultAsync`.
+
+```ts
+// ✅ good
+export function pollMentions(args: PollMentionsArgs): ResultAsync<PollResult, SlackError | DatabaseError> {
+  // …
+}
+
+// ❌ bad — throws across a service boundary
+export async function pollMentions(args: PollMentionsArgs): Promise<PollResult> {
+  if (totalPages > MAX_PAGES) throw new Error(`pollMentions: …`);
+}
+```
+
+Enforced by `pnpm check:neverthrow-service-boundaries` (custom CLI
+check) for these globs:
+
+- `packages/integrations/{core,github,slack}/src/!(test/**)*.ts`
+- `packages/mcp-server/src/tools/**/*.ts`
+- `packages/cli-tools/src/orchestration/{core,runtime}.ts`
+- `apps/mcp-local/src/connect/*.ts`
+
+Plus `eslint-plugin-neverthrow`'s `must-use-result` rule, which flags
+unconsumed `Result` values anywhere in the tree.
+
+## Legitimate recovery catches
+
+The "no throws at service boundaries" rule is **not** "no `try/catch`
+anywhere." Catches that locally downgrade or recover from a fault are
+legitimate and stay. Examples currently in the tree:
+
+- `packages/mcp-server/src/tools/composite/start-session.ts:275` —
+  per-platform poll failures get logged and the overall session
+  proceeds.
+- `packages/ui/src/server/start.ts:152` — static-asset request handler
+  catches per-request errors so one bad request doesn't kill the
+  server.
+
+The CLI check's allowlist names these explicitly. If you need a new
+recovery catch, add a comment on the `try` line explaining why, and
+either keep it inside an allowlisted file or extend the allowlist.
+
+## Boundary translation back to throws
+
+Errors are unwrapped only at the user-facing edge.
+
+**CLI entrypoints** (`apps/mcp-local/src/cli.ts`,
+`packages/cli-tools/src/cli.ts`) `.match()` the top-level result:
+
+```ts
+const result = await runCommand(args);
+result.match(
+  (success) => { stdout.write(format(success)); },
+  (error) => { stderr.write(formatError(error) + '\n'); exit(1); },
+);
+```
+
+**MCP tool handlers** (`packages/mcp-server/src/tools/...`) use a
+boundary helper inside the dispatcher to convert `Err` into an
+`isError: true`-style structured response. Don't widen every tool's
+output schema to a success/error union — the dispatcher does the
+translation in one place.
+
+## External calls
+
+For any SDK / HTTP call, use `safeApiCall` from `@slopweaver/errors`:
+
+```ts
+import { safeApiCall } from '@slopweaver/errors';
+import { RequestError } from '@octokit/request-error';
+
+const result = await safeApiCall({
+  execute: () => octokit.rest.users.getAuthenticated(),
+  provider: 'github',
+  extractError: ({ error }) =>
+    error instanceof RequestError ? { status: error.status, code: 'GITHUB_API_ERROR' } : {},
+});
+```
+
+For database calls, use `safeQuery` from `@slopweaver/db`. Same shape,
+sqlite-aware extractor.
+
+If the raw `ApiCallError` / `DatabaseError` shape isn't right for your
+domain, `.mapErr()` to a domain error:
+
+```ts
+return safeApiCall({ execute, provider: 'slack' }).mapErr((apiErr) =>
+  apiErr.code === 'not_allowed_token_type'
+    ? SlackErrors.tokenInvalid(token.slice(0, 4))
+    : SlackErrors.upstreamFailure(apiErr.message),
+);
+```
+
+## Test discipline
+
+Use strong assertions on `Result` values:
+
+```ts
+// ✅ good
+expect(result.isErr()).toBe(true);
+if (result.isErr()) {
+  expect(result.error.code).toBe('SLACK_TOKEN_INVALID');
+}
+
+// ❌ bad — .toBeTruthy() passes for any non-falsy value, hiding real bugs
+expect(result.isErr()).toBeTruthy();
+```
+
+Tests for unhappy paths assert on `error.code` (the discriminant), not
+`error.message` (the human-readable string is allowed to drift).
+
+## Why these conventions
+
+- **Code, not `_tag`.** Mirrors `slopweaver-private`'s convention so
+  patterns travel cleanly between repos.
+- **Factories, not inline literals.** One place to change a message; one
+  place to add a field; nothing to grep for.
+- **Boundary wrappers (`safeApiCall`/`safeQuery`), not ad-hoc `try/catch`.**
+  The classification logic (extracting status codes, sqlite error names,
+  vendor error envelopes) lives in one place per surface.
+- **No throws at service boundaries.** Forces callers to acknowledge
+  failure modes in the type system; review burden moves from "did I
+  catch?" to "did I handle every code in the union?".
+
+If a rule above conflicts with what a piece of code is trying to do,
+file a `decision-record` issue rather than working around it.

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -71,6 +71,38 @@ Callers always go through factories — they never construct error
 literals inline. This keeps messages consistent and gives you one place
 to add fields later.
 
+## Error definition location
+
+Every error interface extends `BaseError` and lives in one of two
+places:
+
+1. **Generic / shared errors → `@slopweaver/errors`:**
+   - `BaseError` (the interface every error extends)
+   - `ApiCallError` (raw output of `safeApiCall`)
+   - `DatabaseError` (raw output of `safeQuery`)
+   - Constructors and helpers re-exported from neverthrow: `ok`, `err`,
+     `okAsync`, `errAsync`, `Result`, `ResultAsync`, `fromThrowable`
+
+2. **Domain-specific errors → per-package `errors.ts`:**
+   - Each package that can fail owns one `errors.ts`. Define the error
+     interfaces, a factory namespace (e.g. `SlackErrors.tokenInvalid({…})`),
+     and any domain-specific safe-call wrapper (`safeSlackCall`,
+     `safeGithubCall`).
+   - Examples:
+     - `packages/integrations/slack/src/errors.ts` — 5 codes
+     - `packages/integrations/github/src/errors.ts` — 2 codes
+     - `packages/cli-tools/src/orchestration/errors.ts` — 12 codes
+
+**Why:** Errors live with the domain that creates them. New packages
+(e.g. a future Linear integration) define their errors locally without
+touching shared infrastructure. The base shapes in `@slopweaver/errors`
+keep the discriminant convention enforced across all of them.
+
+**Lint enforcement:** `ok`, `err`, `okAsync`, `errAsync`, `Result`,
+`ResultAsync`, `fromThrowable` may not be imported directly from
+`neverthrow` — `eslint.config.js` redirects to `@slopweaver/errors`
+(except inside `packages/errors/**`, where the re-export barrel lives).
+
 ## Service layer: no throws
 
 A "service" here is any function that performs side effects (network,
@@ -123,16 +155,21 @@ legitimate and stay. Examples currently in the tree:
   catches per-request errors so one bad request doesn't kill the
   server.
 
-The CLI check's allowlist names these explicitly. If you need a new
-recovery catch, add a comment on the `try` line explaining why, and
-either keep it inside an allowlisted file or extend the allowlist.
+The scanner doesn't flag these because it only inspects `throw`
+statements, not catches — a `try/catch` that swallows or maps an error
+without re-throwing is invisible to it. If you need a new recovery
+catch, add a comment on the `try` line explaining why the local recovery
+is correct (so reviewers know it's intentional, not an oversight). If
+you find yourself wanting to *re-throw* from a service-boundary file,
+return a typed `Result` with a classification field instead.
 
 ## Boundary translation back to throws
 
 Errors are unwrapped only at the user-facing edge.
 
 **CLI entrypoints** (`apps/mcp-local/src/cli.ts`,
-`packages/cli-tools/src/cli.ts`) `.match()` the top-level result:
+`packages/cli-tools/src/cli.ts`) translate the Result to a process exit
+code at the top of each command action. Either `.match()`:
 
 ```ts
 const result = await runCommand(args);
@@ -141,6 +178,13 @@ result.match(
   (error) => { stderr.write(formatError(error) + '\n'); exit(1); },
 );
 ```
+
+…or the equivalent `if (isErr)` early-return shape — both forms appear
+in the repo. The CLI's outer `.catch()` (e.g. cac's `.action()` callback
+catching from a thrown `EnvValidationError`) also serves as a backstop
+for the typed-throw carve-out below; the `asMessage()` helper at the
+boundary extracts `.message` from BaseError-shaped values so they print
+cleanly either way.
 
 **MCP tool handlers** (`packages/mcp-server/src/tools/...`) use a
 boundary helper inside the dispatcher to convert `Err` into an

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -89,16 +89,26 @@ export async function pollMentions(args: PollMentionsArgs): Promise<PollResult> 
 }
 ```
 
-Enforced by `pnpm check:neverthrow-service-boundaries` (custom CLI
-check) for these globs:
+Enforced by `pnpm check:service-boundaries` (custom CLI check, wired
+into `pnpm validate` as the first gate). The scanner covers these
+directories (all `.ts` files except tests, recordings, and `src/test/`):
 
-- `packages/integrations/{core,github,slack}/src/!(test/**)*.ts`
-- `packages/mcp-server/src/tools/**/*.ts`
+- `packages/db/src/**`
+- `packages/cli-tools/src/lib/**`
+- `packages/integrations/{core,github,slack}/src/**`
+- `packages/mcp-server/src/tools/**`
+- `apps/mcp-local/src/connect/**`
+
+Plus these explicit single-file boundaries:
+
 - `packages/cli-tools/src/orchestration/{core,runtime}.ts`
-- `apps/mcp-local/src/connect/*.ts`
+- `packages/cli-tools/src/worktree/index.ts`
+- `packages/env/src/index.ts`
+- `packages/mcp-server/src/server.ts`
 
-Plus `eslint-plugin-neverthrow`'s `must-use-result` rule, which flags
-unconsumed `Result` values anywhere in the tree.
+See the "Carve-outs (throws that are allowed)" and
+"eslint-plugin-neverthrow status" sections below for what's
+intentionally *not* covered.
 
 ## Legitimate recovery catches
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -101,7 +101,7 @@ The `.gitignore` excludes common offenders (`.env*`, `*.har`) but verify any tes
 
 ## Secret scanning is enforced
 
-A lefthook pre-commit hook runs `gitleaks v8.30.1` against staged content. Contributors and AI agents must install gitleaks locally before committing — see [CONTRIBUTING.md](../../CONTRIBUTING.md) for install instructions. CI runs the same scan over the full tree as a sixth gate, so bypassing the hook with `git commit --no-verify` does not avoid the check; it must be disclosed in the PR description.
+A lefthook pre-commit hook runs `gitleaks v8.30.1` against staged content. Contributors and AI agents must install gitleaks locally before committing — see [CONTRIBUTING.md](../../CONTRIBUTING.md) for install instructions. CI runs the same scan over the full tree as a seventh gate, so bypassing the hook with `git commit --no-verify` does not avoid the check; it must be disclosed in the PR description.
 
 ## Slash commands
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -49,10 +49,10 @@ NEVER `git rebase origin/main` — it rewrites history that's already pushed and
 Before declaring work done (or before opening a PR for review), run the same checks CI runs:
 
 ```bash
-pnpm validate   # format:check, lint, compile, test, knip
+pnpm validate   # check:service-boundaries, format:check, lint, compile, test, knip
 ```
 
-All five gates must pass. CI also runs `gitleaks detect` as a sixth gate; the pre-commit hook covers staged content locally. CI will reject on red.
+All six gates must pass. The first gate — `check:service-boundaries` — scans configured service-boundary files for `throw` statements (see `.claude/rules/error-handling.md`); it's the cheapest gate and runs first so regressions surface before the slower passes. CI also runs `gitleaks detect` as a seventh gate; the pre-commit hook covers staged content locally. CI will reject on red.
 
 If you change formatting, run `pnpm format` (no `:check`) to auto-fix, then re-run `validate` to verify.
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -49,10 +49,10 @@ NEVER `git rebase origin/main` — it rewrites history that's already pushed and
 Before declaring work done (or before opening a PR for review), run the same checks CI runs:
 
 ```bash
-pnpm validate   # check:service-boundaries, format:check, lint, compile, test, knip
+pnpm validate   # cli check-service-boundaries, format:check, lint, compile, test, knip
 ```
 
-All six gates must pass. The first gate — `check:service-boundaries` — scans configured service-boundary files for `throw` statements (see `.claude/rules/error-handling.md`); it's the cheapest gate and runs first so regressions surface before the slower passes. CI also runs `gitleaks detect` as a seventh gate; the pre-commit hook covers staged content locally. CI will reject on red.
+All six gates must pass. The first gate — `pnpm cli check-service-boundaries` — scans configured service-boundary files for `throw` statements (see `.claude/rules/error-handling.md`); it's the cheapest gate and runs first so regressions surface before the slower passes. CI also runs `gitleaks detect` as a seventh gate; the pre-commit hook covers staged content locally. CI will reject on red.
 
 If you change formatting, run `pnpm format` (no `:check`) to auto-fix, then re-run `validate` to verify.
 

--- a/apps/mcp-local/package.json
+++ b/apps/mcp-local/package.json
@@ -28,6 +28,7 @@
     "@inquirer/prompts": "8.4.2",
     "@slopweaver/db": "workspace:*",
     "@slopweaver/env": "workspace:*",
+    "@slopweaver/errors": "workspace:*",
     "@slopweaver/integrations-github": "workspace:*",
     "@slopweaver/integrations-slack": "workspace:*",
     "@slopweaver/mcp-server": "workspace:*",

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -209,8 +209,11 @@ async function runConnect({ integration }: { integration: string }): Promise<num
       db: dbHandle.db,
       promptForToken,
       validateToken: async (token: string): Promise<{ team: string | null }> => {
-        const slack = createSlackClient({ token });
-        const auth = await slack.auth.test();
+        const slackResult = createSlackClient({ token });
+        if (slackResult.isErr()) {
+          throw new Error(slackResult.error.message);
+        }
+        const auth = await slackResult.value.auth.test();
         return { team: auth.team ?? null };
       },
       stdout,

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -25,7 +25,7 @@ import { password } from '@inquirer/prompts';
 import { cac } from 'cac';
 import { createDb, resolveDataDir, resolveDbPath } from '@slopweaver/db';
 import { loadEnv } from '@slopweaver/env';
-import { createGithubClient } from '@slopweaver/integrations-github';
+import { createGithubClient, safeGithubCall } from '@slopweaver/integrations-github';
 import { errAsync } from '@slopweaver/errors';
 import { createSlackClient, safeSlackCall } from '@slopweaver/integrations-slack';
 import {
@@ -210,10 +210,12 @@ async function runConnect({ integration }: { integration: string }): Promise<num
       return await runConnectGithub({
         db: dbHandle.db,
         promptForToken,
-        validateToken: async (token: string): Promise<{ login: string }> => {
+        validateToken: (token: string) => {
           const octokit = createGithubClient({ token });
-          const { data } = await octokit.rest.users.getAuthenticated();
-          return { login: data.login };
+          return safeGithubCall({
+            execute: () => octokit.rest.users.getAuthenticated(),
+            endpoint: 'users.getAuthenticated',
+          }).map((res) => ({ login: res.data.login }));
         },
         stdout,
         stderr,

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -78,9 +78,12 @@ function resolveWebUiPort(): number {
 
 async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void> {
   // Validate the environment before opening the SQLite file or starting the
-  // server. Aggregated `EnvValidationError` propagates out and the process
-  // exits non-zero — single fail-fast boundary for bad env.
-  loadEnv();
+  // server. The `EnvValidationError` is unwrapped at this CLI boundary so the
+  // outer .catch() in the cac action prints + exits non-zero.
+  const envResult = loadEnv();
+  if (envResult.isErr()) {
+    throw envResult.error;
+  }
 
   const startedAtMs = Date.now();
   const dbHandle = createDb({ path: resolveDbPath() });
@@ -178,7 +181,10 @@ async function runConnect({ integration }: { integration: string }): Promise<num
   // Mirror runMcpServer's env contract — bad NODE_ENV / LOG_LEVEL must reject
   // here too, otherwise the connect path would silently honour invalid values
   // that the stdio path rejects.
-  loadEnv();
+  const envResult = loadEnv();
+  if (envResult.isErr()) {
+    throw envResult.error;
+  }
 
   const dbHandle = createDb({ path: resolveDbPath() });
   try {

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -26,7 +26,8 @@ import { cac } from 'cac';
 import { createDb, resolveDataDir, resolveDbPath } from '@slopweaver/db';
 import { loadEnv } from '@slopweaver/env';
 import { createGithubClient } from '@slopweaver/integrations-github';
-import { createSlackClient } from '@slopweaver/integrations-slack';
+import { errAsync } from '@slopweaver/errors';
+import { createSlackClient, safeSlackCall } from '@slopweaver/integrations-slack';
 import {
   createMcpServer,
   createPingTool,
@@ -222,13 +223,16 @@ async function runConnect({ integration }: { integration: string }): Promise<num
     return await runConnectSlack({
       db: dbHandle.db,
       promptForToken,
-      validateToken: async (token: string): Promise<{ team: string | null }> => {
+      validateToken: (token: string) => {
         const slackResult = createSlackClient({ token });
         if (slackResult.isErr()) {
-          throw new Error(slackResult.error.message);
+          return errAsync(slackResult.error);
         }
-        const auth = await slackResult.value.auth.test();
-        return { team: auth.team ?? null };
+        const slack = slackResult.value;
+        return safeSlackCall({
+          execute: () => slack.auth.test(),
+          endpoint: 'auth.test',
+        }).map((auth) => ({ team: auth.team ?? null }));
       },
       stdout,
       stderr,

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -85,9 +85,18 @@ async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void
     throw envResult.error;
   }
 
+  const dbPathResult = resolveDbPath();
+  if (dbPathResult.isErr()) {
+    throw dbPathResult.error;
+  }
+  const dataDirResult = resolveDataDir();
+  if (dataDirResult.isErr()) {
+    throw dataDirResult.error;
+  }
+
   const startedAtMs = Date.now();
-  const dbHandle = createDb({ path: resolveDbPath() });
-  const dataDir = resolveDataDir();
+  const dbHandle = createDb({ path: dbPathResult.value });
+  const dataDir = dataDirResult.value;
 
   const server = createMcpServer({
     db: dbHandle.db,
@@ -186,7 +195,12 @@ async function runConnect({ integration }: { integration: string }): Promise<num
     throw envResult.error;
   }
 
-  const dbHandle = createDb({ path: resolveDbPath() });
+  const dbPathResult = resolveDbPath();
+  if (dbPathResult.isErr()) {
+    throw dbPathResult.error;
+  }
+
+  const dbHandle = createDb({ path: dbPathResult.value });
   try {
     const promptForToken = async ({ message }: { message: string }): Promise<string> =>
       password({ message, mask: true });
@@ -225,7 +239,16 @@ async function runConnect({ integration }: { integration: string }): Promise<num
 }
 
 function asMessage({ error }: { error: unknown }): string {
-  return error instanceof Error ? error.message : String(error);
+  // Native Error instances expose `.message` directly. Result-pattern errors
+  // (BaseError-shaped plain objects from @slopweaver/errors) also carry a
+  // string `message` field — extract it explicitly so they print cleanly at
+  // this CLI boundary instead of stringifying to `[object Object]`.
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === 'string') return message;
+  }
+  return String(error);
 }
 
 const cli = cac('slopweaver');

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -210,7 +210,7 @@ async function runConnect({ integration }: { integration: string }): Promise<num
       return await runConnectGithub({
         db: dbHandle.db,
         promptForToken,
-        validateToken: (token: string) => {
+        validateToken: ({ token }: { token: string }) => {
           const octokit = createGithubClient({ token });
           return safeGithubCall({
             execute: () => octokit.rest.users.getAuthenticated(),
@@ -225,7 +225,7 @@ async function runConnect({ integration }: { integration: string }): Promise<num
     return await runConnectSlack({
       db: dbHandle.db,
       promptForToken,
-      validateToken: (token: string) => {
+      validateToken: ({ token }: { token: string }) => {
         const slackResult = createSlackClient({ token });
         if (slackResult.isErr()) {
           return errAsync(slackResult.error);

--- a/apps/mcp-local/src/connect/github.test.ts
+++ b/apps/mcp-local/src/connect/github.test.ts
@@ -54,10 +54,11 @@ describe('runConnectGithub', () => {
     expect(code).toBe(0);
     expect(stdout.text()).toContain('Connected to GitHub as octocat');
     expect(stderr.text()).toBe('');
-    expect(loadIntegrationToken({ db: handle.db, integration: 'github' })).toEqual({
-      token: 'ghp_happy',
-      accountLabel: 'octocat',
-    });
+    const loaded = await loadIntegrationToken({ db: handle.db, integration: 'github' });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toEqual({ token: 'ghp_happy', accountLabel: 'octocat' });
+    }
   });
 
   it('invalid token: prints the error, exits 1, does NOT persist', async () => {
@@ -75,7 +76,11 @@ describe('runConnectGithub', () => {
     expect(stderr.text()).toContain('GitHub token rejected');
     expect(stderr.text()).toContain('Bad credentials');
     expect(stdout.text()).toBe('');
-    expect(loadIntegrationToken({ db: handle.db, integration: 'github' })).toBeNull();
+    const loaded = await loadIntegrationToken({ db: handle.db, integration: 'github' });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toBeNull();
+    }
   });
 
   it('repeat connect overwrites the previous value with one row total', async () => {
@@ -97,9 +102,10 @@ describe('runConnectGithub', () => {
       now: () => 1_746_000_000_500,
     });
 
-    expect(loadIntegrationToken({ db: handle.db, integration: 'github' })).toEqual({
-      token: 'ghp_second',
-      accountLabel: 'octocat-renamed',
-    });
+    const loaded = await loadIntegrationToken({ db: handle.db, integration: 'github' });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toEqual({ token: 'ghp_second', accountLabel: 'octocat-renamed' });
+    }
   });
 });

--- a/apps/mcp-local/src/connect/github.test.ts
+++ b/apps/mcp-local/src/connect/github.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { createDb, loadIntegrationToken } from '@slopweaver/db';
+import { errAsync, okAsync } from '@slopweaver/errors';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { runConnectGithub } from './github.ts';
 
@@ -42,9 +43,9 @@ describe('runConnectGithub', () => {
     const code = await runConnectGithub({
       db: handle.db,
       promptForToken: async () => 'ghp_happy',
-      validateToken: async (token) => {
+      validateToken: (token) => {
         expect(token).toBe('ghp_happy');
-        return { login: 'octocat' };
+        return okAsync({ login: 'octocat' });
       },
       stdout,
       stderr,
@@ -65,9 +66,11 @@ describe('runConnectGithub', () => {
     const code = await runConnectGithub({
       db: handle.db,
       promptForToken: async () => 'ghp_bogus',
-      validateToken: async () => {
-        throw new Error('Bad credentials');
-      },
+      validateToken: () =>
+        errAsync({
+          code: 'GITHUB_API_ERROR',
+          message: 'Bad credentials',
+        }),
       stdout,
       stderr,
     });
@@ -87,7 +90,7 @@ describe('runConnectGithub', () => {
     await runConnectGithub({
       db: handle.db,
       promptForToken: async () => 'ghp_first',
-      validateToken: async () => ({ login: 'octocat' }),
+      validateToken: () => okAsync({ login: 'octocat' }),
       stdout,
       stderr,
       now: () => 1_746_000_000_000,
@@ -96,7 +99,7 @@ describe('runConnectGithub', () => {
     await runConnectGithub({
       db: handle.db,
       promptForToken: async () => 'ghp_second',
-      validateToken: async () => ({ login: 'octocat-renamed' }),
+      validateToken: () => okAsync({ login: 'octocat-renamed' }),
       stdout,
       stderr,
       now: () => 1_746_000_000_500,

--- a/apps/mcp-local/src/connect/github.test.ts
+++ b/apps/mcp-local/src/connect/github.test.ts
@@ -43,7 +43,7 @@ describe('runConnectGithub', () => {
     const code = await runConnectGithub({
       db: handle.db,
       promptForToken: async () => 'ghp_happy',
-      validateToken: (token) => {
+      validateToken: ({ token }) => {
         expect(token).toBe('ghp_happy');
         return okAsync({ login: 'octocat' });
       },

--- a/apps/mcp-local/src/connect/github.ts
+++ b/apps/mcp-local/src/connect/github.ts
@@ -51,13 +51,17 @@ export async function runConnectGithub({
     return 1;
   }
 
-  saveIntegrationToken({
+  const saveResult = await saveIntegrationToken({
     db,
     integration: INTEGRATION,
     token,
     accountLabel: login,
     ...(now ? { now } : {}),
   });
+  if (saveResult.isErr()) {
+    stderr.write(`slopweaver: failed to save GitHub token: ${saveResult.error.message}\n`);
+    return 1;
+  }
 
   stdout.write(`Connected to GitHub as ${login}.\n`);
   return 0;

--- a/apps/mcp-local/src/connect/github.ts
+++ b/apps/mcp-local/src/connect/github.ts
@@ -21,7 +21,7 @@ const INTEGRATION = 'github';
 export type RunConnectGithubDeps = {
   db: SlopweaverDatabase;
   promptForToken: (opts: { message: string }) => Promise<string>;
-  validateToken: (token: string) => ResultAsync<{ login: string }, BaseError>;
+  validateToken: (args: { token: string }) => ResultAsync<{ login: string }, BaseError>;
   stdout: { write: (s: string) => void };
   stderr: { write: (s: string) => void };
   now?: () => number;
@@ -43,7 +43,7 @@ export async function runConnectGithub({
     message: 'GitHub fine-grained PAT (input hidden):',
   });
 
-  const validateResult = await validateToken(token);
+  const validateResult = await validateToken({ token });
   if (validateResult.isErr()) {
     stderr.write(`slopweaver: GitHub token rejected: ${validateResult.error.message}\n`);
     return 1;

--- a/apps/mcp-local/src/connect/github.ts
+++ b/apps/mcp-local/src/connect/github.ts
@@ -14,13 +14,14 @@
  */
 
 import { type SlopweaverDatabase, saveIntegrationToken } from '@slopweaver/db';
+import type { BaseError, ResultAsync } from '@slopweaver/errors';
 
 const INTEGRATION = 'github';
 
 export type RunConnectGithubDeps = {
   db: SlopweaverDatabase;
   promptForToken: (opts: { message: string }) => Promise<string>;
-  validateToken: (token: string) => Promise<{ login: string }>;
+  validateToken: (token: string) => ResultAsync<{ login: string }, BaseError>;
   stdout: { write: (s: string) => void };
   stderr: { write: (s: string) => void };
   now?: () => number;
@@ -42,14 +43,12 @@ export async function runConnectGithub({
     message: 'GitHub fine-grained PAT (input hidden):',
   });
 
-  let login: string;
-  try {
-    ({ login } = await validateToken(token));
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    stderr.write(`slopweaver: GitHub token rejected: ${message}\n`);
+  const validateResult = await validateToken(token);
+  if (validateResult.isErr()) {
+    stderr.write(`slopweaver: GitHub token rejected: ${validateResult.error.message}\n`);
     return 1;
   }
+  const { login } = validateResult.value;
 
   const saveResult = await saveIntegrationToken({
     db,

--- a/apps/mcp-local/src/connect/slack.test.ts
+++ b/apps/mcp-local/src/connect/slack.test.ts
@@ -38,7 +38,7 @@ describe('runConnectSlack', () => {
     const code = await runConnectSlack({
       db: handle.db,
       promptForToken: async () => 'xoxp-test',
-      validateToken: (token) => {
+      validateToken: ({ token }) => {
         expect(token).toBe('xoxp-test');
         return okAsync({ team: 'AcmeCorp' });
       },

--- a/apps/mcp-local/src/connect/slack.test.ts
+++ b/apps/mcp-local/src/connect/slack.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { createDb, loadIntegrationToken } from '@slopweaver/db';
+import { errAsync, okAsync } from '@slopweaver/errors';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { runConnectSlack } from './slack.ts';
 
@@ -37,9 +38,9 @@ describe('runConnectSlack', () => {
     const code = await runConnectSlack({
       db: handle.db,
       promptForToken: async () => 'xoxp-test',
-      validateToken: async (token) => {
+      validateToken: (token) => {
         expect(token).toBe('xoxp-test');
-        return { team: 'AcmeCorp' };
+        return okAsync({ team: 'AcmeCorp' });
       },
       stdout,
       stderr,
@@ -60,7 +61,7 @@ describe('runConnectSlack', () => {
     const code = await runConnectSlack({
       db: handle.db,
       promptForToken: async () => 'xoxp-test',
-      validateToken: async () => ({ team: null }),
+      validateToken: () => okAsync({ team: null }),
       stdout,
       stderr,
       now: () => 1_746_000_000_000,
@@ -81,9 +82,9 @@ describe('runConnectSlack', () => {
     const code = await runConnectSlack({
       db: handle.db,
       promptForToken: async () => 'xoxb-bot-token',
-      validateToken: async () => {
+      validateToken: () => {
         validateCalled = true;
-        return { team: 'AcmeCorp' };
+        return okAsync({ team: 'AcmeCorp' });
       },
       stdout,
       stderr,
@@ -105,7 +106,7 @@ describe('runConnectSlack', () => {
     const code = await runConnectSlack({
       db: handle.db,
       promptForToken: async () => 'xapp-app-level',
-      validateToken: async () => ({ team: 'AcmeCorp' }),
+      validateToken: () => okAsync({ team: 'AcmeCorp' }),
       stdout,
       stderr,
     });
@@ -123,9 +124,11 @@ describe('runConnectSlack', () => {
     const code = await runConnectSlack({
       db: handle.db,
       promptForToken: async () => 'xoxp-bogus',
-      validateToken: async () => {
-        throw new Error('invalid_auth');
-      },
+      validateToken: () =>
+        errAsync({
+          code: 'SLACK_API_ERROR',
+          message: 'invalid_auth',
+        }),
       stdout,
       stderr,
     });
@@ -145,7 +148,7 @@ describe('runConnectSlack', () => {
     await runConnectSlack({
       db: handle.db,
       promptForToken: async () => 'xoxp-first',
-      validateToken: async () => ({ team: 'AcmeCorp' }),
+      validateToken: () => okAsync({ team: 'AcmeCorp' }),
       stdout,
       stderr,
       now: () => 1_746_000_000_000,
@@ -154,7 +157,7 @@ describe('runConnectSlack', () => {
     await runConnectSlack({
       db: handle.db,
       promptForToken: async () => 'xoxp-second',
-      validateToken: async () => ({ team: 'AcmeCorp-Renamed' }),
+      validateToken: () => okAsync({ team: 'AcmeCorp-Renamed' }),
       stdout,
       stderr,
       now: () => 1_746_000_000_500,

--- a/apps/mcp-local/src/connect/slack.test.ts
+++ b/apps/mcp-local/src/connect/slack.test.ts
@@ -49,10 +49,11 @@ describe('runConnectSlack', () => {
     expect(code).toBe(0);
     expect(stdout.text()).toContain('Connected to Slack workspace "AcmeCorp"');
     expect(stderr.text()).toBe('');
-    expect(loadIntegrationToken({ db: handle.db, integration: 'slack' })).toEqual({
-      token: 'xoxp-test',
-      accountLabel: 'AcmeCorp',
-    });
+    const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toEqual({ token: 'xoxp-test', accountLabel: 'AcmeCorp' });
+    }
   });
 
   it('happy path with no team name: persists with null label and prints generic success', async () => {
@@ -67,10 +68,11 @@ describe('runConnectSlack', () => {
 
     expect(code).toBe(0);
     expect(stdout.text()).toContain('Connected to Slack.');
-    expect(loadIntegrationToken({ db: handle.db, integration: 'slack' })).toEqual({
-      token: 'xoxp-test',
-      accountLabel: null,
-    });
+    const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toEqual({ token: 'xoxp-test', accountLabel: null });
+    }
   });
 
   it('rejects xoxb- bot tokens before calling validateToken or persisting', async () => {
@@ -92,7 +94,11 @@ describe('runConnectSlack', () => {
     expect(stderr.text()).toContain('user token (xoxp-) is required');
     expect(stderr.text()).toContain('search.messages');
     expect(stdout.text()).toBe('');
-    expect(loadIntegrationToken({ db: handle.db, integration: 'slack' })).toBeNull();
+    const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toBeNull();
+    }
   });
 
   it('rejects unknown token prefixes (xapp-, xoxa-, garbage) with the same xoxp- guidance', async () => {
@@ -106,7 +112,11 @@ describe('runConnectSlack', () => {
 
     expect(code).toBe(1);
     expect(stderr.text()).toContain('user token (xoxp-) is required');
-    expect(loadIntegrationToken({ db: handle.db, integration: 'slack' })).toBeNull();
+    const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toBeNull();
+    }
   });
 
   it('invalid token: prints the error, exits 1, does NOT persist', async () => {
@@ -124,7 +134,11 @@ describe('runConnectSlack', () => {
     expect(stderr.text()).toContain('Slack token rejected');
     expect(stderr.text()).toContain('invalid_auth');
     expect(stdout.text()).toBe('');
-    expect(loadIntegrationToken({ db: handle.db, integration: 'slack' })).toBeNull();
+    const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toBeNull();
+    }
   });
 
   it('repeat connect overwrites the previous value with one row total', async () => {
@@ -146,9 +160,10 @@ describe('runConnectSlack', () => {
       now: () => 1_746_000_000_500,
     });
 
-    expect(loadIntegrationToken({ db: handle.db, integration: 'slack' })).toEqual({
-      token: 'xoxp-second',
-      accountLabel: 'AcmeCorp-Renamed',
-    });
+    const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toEqual({ token: 'xoxp-second', accountLabel: 'AcmeCorp-Renamed' });
+    }
   });
 });

--- a/apps/mcp-local/src/connect/slack.ts
+++ b/apps/mcp-local/src/connect/slack.ts
@@ -15,6 +15,7 @@
  */
 
 import { type SlopweaverDatabase, saveIntegrationToken } from '@slopweaver/db';
+import type { BaseError, ResultAsync } from '@slopweaver/errors';
 
 const INTEGRATION = 'slack';
 const USER_TOKEN_PREFIX = 'xoxp-';
@@ -22,7 +23,7 @@ const USER_TOKEN_PREFIX = 'xoxp-';
 export type RunConnectSlackDeps = {
   db: SlopweaverDatabase;
   promptForToken: (opts: { message: string }) => Promise<string>;
-  validateToken: (token: string) => Promise<{ team: string | null }>;
+  validateToken: (token: string) => ResultAsync<{ team: string | null }, BaseError>;
   stdout: { write: (s: string) => void };
   stderr: { write: (s: string) => void };
   now?: () => number;
@@ -47,14 +48,12 @@ export async function runConnectSlack({
     return 1;
   }
 
-  let team: string | null;
-  try {
-    ({ team } = await validateToken(token));
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    stderr.write(`slopweaver: Slack token rejected: ${message}\n`);
+  const validateResult = await validateToken(token);
+  if (validateResult.isErr()) {
+    stderr.write(`slopweaver: Slack token rejected: ${validateResult.error.message}\n`);
     return 1;
   }
+  const { team } = validateResult.value;
 
   const saveResult = await saveIntegrationToken({
     db,

--- a/apps/mcp-local/src/connect/slack.ts
+++ b/apps/mcp-local/src/connect/slack.ts
@@ -23,7 +23,7 @@ const USER_TOKEN_PREFIX = 'xoxp-';
 export type RunConnectSlackDeps = {
   db: SlopweaverDatabase;
   promptForToken: (opts: { message: string }) => Promise<string>;
-  validateToken: (token: string) => ResultAsync<{ team: string | null }, BaseError>;
+  validateToken: (args: { token: string }) => ResultAsync<{ team: string | null }, BaseError>;
   stdout: { write: (s: string) => void };
   stderr: { write: (s: string) => void };
   now?: () => number;
@@ -48,7 +48,7 @@ export async function runConnectSlack({
     return 1;
   }
 
-  const validateResult = await validateToken(token);
+  const validateResult = await validateToken({ token });
   if (validateResult.isErr()) {
     stderr.write(`slopweaver: Slack token rejected: ${validateResult.error.message}\n`);
     return 1;

--- a/apps/mcp-local/src/connect/slack.ts
+++ b/apps/mcp-local/src/connect/slack.ts
@@ -56,13 +56,17 @@ export async function runConnectSlack({
     return 1;
   }
 
-  saveIntegrationToken({
+  const saveResult = await saveIntegrationToken({
     db,
     integration: INTEGRATION,
     token,
     accountLabel: team,
     ...(now ? { now } : {}),
   });
+  if (saveResult.isErr()) {
+    stderr.write(`slopweaver: failed to save Slack token: ${saveResult.error.message}\n`);
+    return 1;
+  }
 
   if (team) {
     stdout.write(`Connected to Slack workspace "${team}".\n`);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import boundaries from 'eslint-plugin-boundaries';
 /**
  * Flat ESLint config for SlopWeaver.
  *
- * Two structural rules enforced here:
+ * Structural rules enforced here:
  *
  * 1. `eslint-plugin-boundaries` — apps/* may import packages/*; packages/*
  *    may import packages/*; packages/* may NOT import from apps/*. This is
@@ -13,6 +13,12 @@ import boundaries from 'eslint-plugin-boundaries';
  * 2. `no-restricted-imports` — no `@nestjs/*` imports inside packages/*.
  *    NestJS belongs only to apps/cloud/ (when that lands in v2). Packages
  *    must remain framework-agnostic.
+ *
+ * 3. `no-restricted-imports` (named) — `ok`, `err`, `okAsync`, `errAsync`,
+ *    `Result`, `ResultAsync`, `fromThrowable` may not be imported directly
+ *    from `neverthrow`. Use `@slopweaver/errors` (the canonical re-export
+ *    barrel) so a future wrap/extend of the Result type has a single entry
+ *    point. Exempt: `packages/errors/**` (the barrel itself).
  *
  * Note on must-use-result enforcement: the upstream `eslint-plugin-neverthrow`
  * (v1.1.4, last published 2022) is incompatible with ESLint 10 — it reads
@@ -45,6 +51,43 @@ export default [
           ],
         },
       ],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'neverthrow',
+              importNames: [
+                'ok',
+                'err',
+                'okAsync',
+                'errAsync',
+                'Result',
+                'ResultAsync',
+                'fromThrowable',
+              ],
+              message:
+                'Import Result helpers from @slopweaver/errors instead. The barrel re-exports neverthrow and is the canonical source.',
+            },
+          ],
+          patterns: [
+            {
+              group: ['@nestjs/*'],
+              message:
+                'NestJS imports are forbidden in packages/. Move framework-specific code to apps/cloud/.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['packages/errors/**/*'],
+    rules: {
+      // packages/errors is the barrel that wraps neverthrow; direct imports
+      // from `neverthrow` are required here. The @nestjs/* check still
+      // applies to packages/errors via the base config; this override only
+      // drops the neverthrow path restriction for the barrel itself.
       'no-restricted-imports': [
         'error',
         {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,15 @@ import boundaries from 'eslint-plugin-boundaries';
  * 2. `no-restricted-imports` — no `@nestjs/*` imports inside packages/*.
  *    NestJS belongs only to apps/cloud/ (when that lands in v2). Packages
  *    must remain framework-agnostic.
+ *
+ * Note on must-use-result enforcement: the upstream `eslint-plugin-neverthrow`
+ * (v1.1.4, last published 2022) is incompatible with ESLint 10 — it reads
+ * `context.parserServices`, which was moved to `context.sourceCode.parserServices`
+ * in ESLint 9+. The CLI service-boundary check at
+ * `packages/cli-tools/src/check-neverthrow-service-boundaries/` covers the
+ * highest-risk enforcement (no thrown errors at service boundaries); the
+ * runtime-level "every Result must be consumed" rule is deferred. Tracked
+ * in #41.
  */
 export default [
   {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
     "compile": "turbo run compile",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "check:service-boundaries": "tsx packages/cli-tools/src/cli.ts check-service-boundaries",
     "knip": "knip",
     "lint": "biome lint . && eslint .",
     "prepare": "lefthook install || echo 'lefthook install skipped (not a git repository)'",
     "test": "turbo run test",
-    "validate": "pnpm check:service-boundaries && pnpm format:check && pnpm lint && pnpm compile && pnpm test && pnpm knip"
+    "validate": "pnpm cli check-service-boundaries && pnpm format:check && pnpm lint && pnpm compile && pnpm test && pnpm knip"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.14",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "biome lint . && eslint .",
     "prepare": "lefthook install || echo 'lefthook install skipped (not a git repository)'",
     "test": "turbo run test",
-    "validate": "pnpm format:check && pnpm lint && pnpm compile && pnpm test && pnpm knip"
+    "validate": "pnpm check:service-boundaries && pnpm format:check && pnpm lint && pnpm compile && pnpm test && pnpm knip"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.14",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "knip": "knip",
-    "lint": "biome lint .",
+    "lint": "biome lint . && eslint .",
     "prepare": "lefthook install || echo 'lefthook install skipped (not a git repository)'",
     "test": "turbo run test",
     "validate": "pnpm format:check && pnpm lint && pnpm compile && pnpm test && pnpm knip"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "compile": "turbo run compile",
     "format": "biome format --write .",
     "format:check": "biome format .",
+    "check:service-boundaries": "tsx packages/cli-tools/src/cli.ts check-service-boundaries",
     "knip": "knip",
     "lint": "biome lint . && eslint .",
     "prepare": "lefthook install || echo 'lefthook install skipped (not a git repository)'",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "8.4.2",
+    "@slopweaver/errors": "workspace:*",
     "cac": "7.0.0",
     "picocolors": "1.1.1"
   },

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/core.test.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/core.test.ts
@@ -1,0 +1,119 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { findThrowSites, isCommentOnlyLine, listBoundaryFiles, scanFiles } from './core.ts';
+
+describe('isCommentOnlyLine', () => {
+  it('flags // line comments', () => {
+    expect(isCommentOnlyLine({ line: '// throw new Error("nope")' })).toBe(true);
+    expect(isCommentOnlyLine({ line: '  // throw new Error("nope")' })).toBe(true);
+  });
+
+  it('flags lines that are part of a block comment formatted by biome', () => {
+    expect(isCommentOnlyLine({ line: ' * throw something' })).toBe(true);
+    expect(isCommentOnlyLine({ line: '/** docblock' })).toBe(true);
+  });
+
+  it('does not flag normal code', () => {
+    expect(isCommentOnlyLine({ line: 'throw new Error("real")' })).toBe(false);
+    expect(isCommentOnlyLine({ line: '  throw new Error("indented")' })).toBe(false);
+  });
+});
+
+describe('findThrowSites', () => {
+  it('returns findings for top-level throws', () => {
+    const content = [
+      'export function f() {',
+      '  if (bad) throw new Error("boom");',
+      '  return 1;',
+      '}',
+    ].join('\n');
+
+    const findings = findThrowSites({ content, file: 'a.ts' });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toEqual({
+      file: 'a.ts',
+      line: 2,
+      text: '  if (bad) throw new Error("boom");',
+    });
+  });
+
+  it('returns findings for re-throws inside catch blocks', () => {
+    const content = ['try {', '  doIt();', '} catch (e) {', '  throw e;', '}'].join('\n');
+
+    const findings = findThrowSites({ content, file: 'a.ts' });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.line).toBe(4);
+  });
+
+  it('ignores `throw` inside line comments', () => {
+    const content = '// always throw on bad input\nreturn 1;';
+
+    expect(findThrowSites({ content, file: 'a.ts' })).toEqual([]);
+  });
+
+  it('ignores identifiers that contain "throw" as a substring', () => {
+    const content = 'const mythrow = 1;\nthrowsHelper();';
+
+    expect(findThrowSites({ content, file: 'a.ts' })).toEqual([]);
+  });
+
+  it('does not fire on a `} catch {` line', () => {
+    const content = '} catch (err) {\n  log(err);\n}';
+
+    expect(findThrowSites({ content, file: 'a.ts' })).toEqual([]);
+  });
+});
+
+describe('listBoundaryFiles + scanFiles', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'check-svc-bound-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('walks the configured directory and reports throws while skipping test files', () => {
+    const dir = 'packages/integrations/slack/src';
+    mkdirSync(join(root, dir), { recursive: true });
+    writeFileSync(
+      join(root, dir, 'has-throw.ts'),
+      'export function go() {\n  throw new Error("nope");\n}\n',
+    );
+    writeFileSync(
+      join(root, dir, 'has-throw.test.ts'),
+      'import { go } from "./has-throw.ts";\nexpect(() => go()).toThrow();\n',
+    );
+
+    const paths = listBoundaryFiles({
+      root,
+      boundaries: [{ dir, extensions: ['.ts'] }],
+      files: [],
+    });
+    expect(paths).toEqual(['packages/integrations/slack/src/has-throw.ts']);
+
+    const findings = scanFiles({ root, paths });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.line).toBe(2);
+  });
+
+  it('includes explicit per-file boundaries', () => {
+    const dir = 'packages/cli-tools/src/orchestration';
+    mkdirSync(join(root, dir), { recursive: true });
+    writeFileSync(join(root, dir, 'core.ts'), 'export function ok() { return 1; }\n');
+
+    const paths = listBoundaryFiles({
+      root,
+      boundaries: [],
+      files: ['packages/cli-tools/src/orchestration/core.ts'],
+    });
+
+    expect(paths).toEqual(['packages/cli-tools/src/orchestration/core.ts']);
+  });
+});

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
@@ -127,10 +127,12 @@ export function isCommentOnlyLine({ line }: { line: string }): boolean {
 /**
  * Match `throw` as a keyword: at start of line (with whitespace), after
  * an opening brace, after a semicolon, or after `else `. The keyword
- * itself must be followed by whitespace so we don't fire on identifiers
- * like `mythrow`.
+ * uses a word boundary so we don't fire on identifiers like `mythrow`,
+ * and a lookahead accepts both `throw ` (whitespace) and `throw(` (no
+ * space — valid JS like `throw(new Error(…))`) so the scanner can't be
+ * bypassed by writing the throw without a trailing space.
  */
-const THROW_KEYWORD_PATTERN = /(?:^|[\s;{])throw\s/;
+const THROW_KEYWORD_PATTERN = /(?:^|[\s;{])throw\b(?=\s|\()/;
 
 /**
  * Find lines in `content` that contain a `throw` keyword and aren't

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
@@ -1,0 +1,166 @@
+/**
+ * Pure functions for the neverthrow service-boundary check.
+ *
+ * The rule (per `.claude/rules/error-handling.md` and #41): files inside
+ * the configured "service boundaries" must not throw. Service code
+ * returns `Result<T, E>` / `ResultAsync<T, E>` instead. Recovery catches
+ * (e.g. swallowing per-platform poll failures so the overall session
+ * proceeds) are legitimate and stay — those don't show up as `throw`
+ * statements, so the same scanner that flags throws ignores them.
+ *
+ * Boundaries are an explicit list rather than a sweeping glob so we can
+ * point at the smallest set of files that actually constitute the
+ * service surface. Test files, recording fixtures, and src/test/
+ * helpers are excluded — they're scaffolding, not service code.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface ServiceBoundaryDir {
+  readonly dir: string;
+  readonly extensions: ReadonlyArray<string>;
+}
+
+export interface ThrowFinding {
+  readonly file: string;
+  readonly line: number;
+  readonly text: string;
+}
+
+const SERVICE_BOUNDARY_DIRS: ReadonlyArray<ServiceBoundaryDir> = [
+  { dir: 'packages/integrations/core/src', extensions: ['.ts'] },
+  { dir: 'packages/integrations/github/src', extensions: ['.ts'] },
+  { dir: 'packages/integrations/slack/src', extensions: ['.ts'] },
+  { dir: 'packages/mcp-server/src/tools', extensions: ['.ts'] },
+  { dir: 'apps/mcp-local/src/connect', extensions: ['.ts'] },
+];
+
+const SERVICE_BOUNDARY_FILES: ReadonlyArray<string> = [
+  'packages/cli-tools/src/orchestration/core.ts',
+  'packages/cli-tools/src/orchestration/runtime.ts',
+];
+
+const EXCLUDED_DIR_NAMES = new Set([
+  'test',
+  'tests',
+  'test-setup',
+  '__tests__',
+  '__recordings__',
+  'node_modules',
+  'dist',
+]);
+const EXCLUDED_FILE_SUFFIXES = ['.test.ts', '.smoke.test.ts', '.cassette.test.ts'];
+
+/**
+ * Recursively list `.ts` files under `root/<boundary.dir>`, skipping test
+ * files and helper subdirectories. Returns workspace-relative paths so
+ * findings print stably regardless of the caller's cwd.
+ */
+export function listBoundaryFiles({
+  root,
+  boundaries = SERVICE_BOUNDARY_DIRS,
+  files = SERVICE_BOUNDARY_FILES,
+}: {
+  root: string;
+  boundaries?: ReadonlyArray<ServiceBoundaryDir>;
+  files?: ReadonlyArray<string>;
+}): string[] {
+  const out: string[] = [];
+
+  for (const boundary of boundaries) {
+    const abs = join(root, boundary.dir);
+    if (!existsSync(abs)) continue;
+    walk({ abs, rel: boundary.dir, extensions: boundary.extensions, out });
+  }
+
+  for (const file of files) {
+    const abs = join(root, file);
+    if (existsSync(abs)) out.push(file);
+  }
+
+  return out;
+}
+
+function walk({
+  abs,
+  rel,
+  extensions,
+  out,
+}: {
+  abs: string;
+  rel: string;
+  extensions: ReadonlyArray<string>;
+  out: string[];
+}): void {
+  for (const entry of readdirSync(abs)) {
+    if (EXCLUDED_DIR_NAMES.has(entry)) continue;
+    const childAbs = join(abs, entry);
+    const childRel = `${rel}/${entry}`;
+    const stat = statSync(childAbs);
+    if (stat.isDirectory()) {
+      walk({ abs: childAbs, rel: childRel, extensions, out });
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    if (EXCLUDED_FILE_SUFFIXES.some((suffix) => entry.endsWith(suffix))) continue;
+    if (!extensions.some((ext) => entry.endsWith(ext))) continue;
+    out.push(childRel);
+  }
+}
+
+/**
+ * `// foo` and lines that are part of a `/* … *\/` block (which biome
+ * formats with `*` at line start). The scanner runs against source code
+ * formatted by biome, so the simple form is good enough — we don't need
+ * to track block-comment state across lines.
+ */
+export function isCommentOnlyLine({ line }: { line: string }): boolean {
+  return /^\s*(\/\/|\*|\/\*)/.test(line);
+}
+
+/**
+ * Match `throw` as a keyword: at start of line (with whitespace), after
+ * an opening brace, after a semicolon, or after `else `. The keyword
+ * itself must be followed by whitespace so we don't fire on identifiers
+ * like `mythrow`.
+ */
+const THROW_KEYWORD_PATTERN = /(?:^|[\s;{])throw\s/;
+
+/**
+ * Find lines in `content` that contain a `throw` keyword and aren't
+ * comment-only.
+ */
+export function findThrowSites({
+  content,
+  file,
+}: {
+  content: string;
+  file: string;
+}): ThrowFinding[] {
+  const findings: ThrowFinding[] = [];
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const text = lines[i];
+    if (text === undefined) continue;
+    if (isCommentOnlyLine({ line: text })) continue;
+    if (!THROW_KEYWORD_PATTERN.test(text)) continue;
+    findings.push({ file, line: i + 1, text: text.trimEnd() });
+  }
+  return findings;
+}
+
+export function scanFiles({
+  root,
+  paths,
+}: {
+  root: string;
+  paths: ReadonlyArray<string>;
+}): ThrowFinding[] {
+  const out: ThrowFinding[] = [];
+  for (const file of paths) {
+    const content = readFileSync(join(root, file), 'utf8');
+    out.push(...findThrowSites({ content, file }));
+  }
+  return out;
+}

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
@@ -29,6 +29,8 @@ export interface ThrowFinding {
 }
 
 const SERVICE_BOUNDARY_DIRS: ReadonlyArray<ServiceBoundaryDir> = [
+  { dir: 'packages/db/src', extensions: ['.ts'] },
+  { dir: 'packages/cli-tools/src/lib', extensions: ['.ts'] },
   { dir: 'packages/integrations/core/src', extensions: ['.ts'] },
   { dir: 'packages/integrations/github/src', extensions: ['.ts'] },
   { dir: 'packages/integrations/slack/src', extensions: ['.ts'] },

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
@@ -41,6 +41,9 @@ const SERVICE_BOUNDARY_DIRS: ReadonlyArray<ServiceBoundaryDir> = [
 const SERVICE_BOUNDARY_FILES: ReadonlyArray<string> = [
   'packages/cli-tools/src/orchestration/core.ts',
   'packages/cli-tools/src/orchestration/runtime.ts',
+  'packages/cli-tools/src/worktree/index.ts',
+  'packages/env/src/index.ts',
+  'packages/mcp-server/src/server.ts',
 ];
 
 const EXCLUDED_DIR_NAMES = new Set([

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/index.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/index.ts
@@ -22,7 +22,7 @@ interface CheckResult {
   readonly findings: ReadonlyArray<ThrowFinding>;
 }
 
-function runCheck({ root = findMonorepoRoot() }: { root?: string } = {}): CheckResult {
+function runCheck({ root }: { root: string }): CheckResult {
   const paths = listBoundaryFiles({ root });
   const findings = scanFiles({ root, paths });
   return { ok: findings.length === 0, findings };
@@ -54,7 +54,12 @@ function printReport({
 }
 
 export function runAndExit(): void {
-  const result = runCheck();
+  const rootResult = findMonorepoRoot();
+  if (rootResult.isErr()) {
+    console.error(rootResult.error.message);
+    process.exit(1);
+  }
+  const result = runCheck({ root: rootResult.value });
   printReport({ result });
   if (!result.ok) {
     process.exit(1);

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/index.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/index.ts
@@ -1,0 +1,62 @@
+/**
+ * `pnpm cli check-service-boundaries`
+ *
+ * CI-shaped guard: scans the configured service-boundary files for
+ * `throw` statements and reports findings. Service code must return
+ * `Result<T, E>` instead of throwing; this check is the gate (per
+ * `.claude/rules/error-handling.md` and #41).
+ *
+ * Wiring into `pnpm validate` is intentionally deferred until Phase 6 of
+ * the migration — pre-migration the boundary files contain ~37 existing
+ * throws, so flipping the gate on now would lock validate red until
+ * every migration commit lands. The check is runnable on demand
+ * (`pnpm check:service-boundaries` script) so each migration commit can
+ * verify locally that the count is going down.
+ */
+
+import { findMonorepoRoot } from '../lib/paths.ts';
+import { listBoundaryFiles, scanFiles, type ThrowFinding } from './core.ts';
+
+interface CheckResult {
+  readonly ok: boolean;
+  readonly findings: ReadonlyArray<ThrowFinding>;
+}
+
+function runCheck({ root = findMonorepoRoot() }: { root?: string } = {}): CheckResult {
+  const paths = listBoundaryFiles({ root });
+  const findings = scanFiles({ root, paths });
+  return { ok: findings.length === 0, findings };
+}
+
+function printReport({
+  result,
+  out = console.log,
+  err = console.error,
+}: {
+  result: CheckResult;
+  out?: (line: string) => void;
+  err?: (line: string) => void;
+}): void {
+  if (result.ok) {
+    out('OK: no `throw` statements in service-boundary files.');
+    return;
+  }
+  err('');
+  err(`ERROR: ${result.findings.length} \`throw\` site(s) found in service-boundary files.`);
+  err('Service code must return Result<T, E> via @slopweaver/errors instead of throwing.');
+  err('See .claude/rules/error-handling.md.');
+  err('');
+  err('Findings:');
+  for (const finding of result.findings) {
+    err(`  ${finding.file}:${finding.line}  ${finding.text.trim()}`);
+  }
+  err('');
+}
+
+export function runAndExit(): void {
+  const result = runCheck();
+  printReport({ result });
+  if (!result.ok) {
+    process.exit(1);
+  }
+}

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/index.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/index.ts
@@ -6,12 +6,9 @@
  * `Result<T, E>` instead of throwing; this check is the gate (per
  * `.claude/rules/error-handling.md` and #41).
  *
- * Wiring into `pnpm validate` is intentionally deferred until Phase 6 of
- * the migration — pre-migration the boundary files contain ~37 existing
- * throws, so flipping the gate on now would lock validate red until
- * every migration commit lands. The check is runnable on demand
- * (`pnpm check:service-boundaries` script) so each migration commit can
- * verify locally that the count is going down.
+ * Wired into `pnpm validate` as the first gate. The check is also
+ * runnable on demand via `pnpm cli check-service-boundaries` so a
+ * developer can verify locally before a commit.
  */
 
 import { findMonorepoRoot } from '../lib/paths.ts';

--- a/packages/cli-tools/src/cli.ts
+++ b/packages/cli-tools/src/cli.ts
@@ -11,6 +11,7 @@
  */
 
 import { cac } from 'cac';
+import { runAndExit as runCheckServiceBoundaries } from './check-neverthrow-service-boundaries/index.ts';
 import { runDoctor } from './doctor/index.ts';
 import { normalizeExecutor, prepare, run } from './orchestration/index.ts';
 import { runWorktreeNew } from './worktree/index.ts';
@@ -30,6 +31,16 @@ cli
       console.error(`error: ${result.error}`);
       process.exit(result.exitCode);
     }
+  });
+
+cli
+  .command(
+    'check-service-boundaries',
+    'Fail if `throw` statements appear in service-boundary files (see #41)',
+  )
+  .example('  pnpm cli check-service-boundaries')
+  .action(() => {
+    runCheckServiceBoundaries();
   });
 
 cli

--- a/packages/cli-tools/src/cli.ts
+++ b/packages/cli-tools/src/cli.ts
@@ -27,9 +27,9 @@ cli
   .example('  pnpm cli worktree-new fix-issue-42')
   .action((name: string, options: { install: boolean }) => {
     const result = runWorktreeNew({ rawName: name, options: { install: options.install } });
-    if (!result.ok) {
-      console.error(`error: ${result.error}`);
-      process.exit(result.exitCode);
+    if (result.isErr()) {
+      console.error(`error: ${result.error.message}`);
+      process.exit(result.error.exitCode);
     }
   });
 

--- a/packages/cli-tools/src/cli.ts
+++ b/packages/cli-tools/src/cli.ts
@@ -29,7 +29,8 @@ cli
     const result = runWorktreeNew({ rawName: name, options: { install: options.install } });
     if (result.isErr()) {
       console.error(`error: ${result.error.message}`);
-      process.exit(result.error.exitCode);
+      const exitCode = 'exitCode' in result.error ? result.error.exitCode : 1;
+      process.exit(exitCode);
     }
   });
 
@@ -82,33 +83,42 @@ cli
       chainPath: string,
       options: { executor: string; dryRun?: boolean; notify?: boolean; restart?: boolean },
     ) => {
-      try {
-        if (subcommand === 'prepare') {
-          await prepare(chainPath, {
-            executor: normalizeExecutor(options.executor),
-            restart: options.restart === true,
-          });
-          return;
+      if (subcommand === 'prepare') {
+        const executorResult = normalizeExecutor(options.executor);
+        if (executorResult.isErr()) {
+          console.error(executorResult.error.message);
+          process.exit(1);
         }
-        if (subcommand === 'run') {
-          // `run` is the codex-only fallback runner. The hybrid (Claude-implements)
-          // path is driven by `prepare` + a Claude-side launcher, which is the
-          // maintainer's external tool. Hardcode codex-only here so passing
-          // `--executor hybrid` to `run` doesn't silently behave as codex-only
-          // with hybrid prompt wording.
-          await run(chainPath, {
-            dryRun: options.dryRun === true,
-            executor: 'codex-only',
-            notify: options.notify === true,
-            restart: options.restart === true,
-          });
-          return;
+        const result = await prepare(chainPath, {
+          executor: executorResult.value,
+          restart: options.restart === true,
+        });
+        if (result.isErr()) {
+          console.error(result.error.message);
+          process.exit(1);
         }
-        throw new Error(`Unknown subcommand: ${subcommand}. Use 'prepare' or 'run'.`);
-      } catch (err: unknown) {
-        console.error(err instanceof Error ? err.message : err);
-        process.exit(1);
+        return;
       }
+      if (subcommand === 'run') {
+        // `run` is the codex-only fallback runner. The hybrid (Claude-implements)
+        // path is driven by `prepare` + a Claude-side launcher, which is the
+        // maintainer's external tool. Hardcode codex-only here so passing
+        // `--executor hybrid` to `run` doesn't silently behave as codex-only
+        // with hybrid prompt wording.
+        const result = await run(chainPath, {
+          dryRun: options.dryRun === true,
+          executor: 'codex-only',
+          notify: options.notify === true,
+          restart: options.restart === true,
+        });
+        if (result.isErr()) {
+          console.error(result.error.message);
+          process.exit(1);
+        }
+        return;
+      }
+      console.error(`Unknown subcommand: ${subcommand}. Use 'prepare' or 'run'.`);
+      process.exit(1);
     },
   );
 

--- a/packages/cli-tools/src/doctor/checks.ts
+++ b/packages/cli-tools/src/doctor/checks.ts
@@ -1,7 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { accessSync, constants as fsConstants, statSync } from 'node:fs';
 import { createServer } from 'node:net';
-import { resolveDataDir } from '../lib/data-dir.ts';
 
 export const REQUIRED_NODE_MAJOR = 22;
 export const REQUIRED_NODE_MINOR = 12;
@@ -245,11 +244,7 @@ export function checkCodexAgent({
   };
 }
 
-export function checkDataDir({
-  dataDir = resolveDataDir(),
-}: {
-  dataDir?: string;
-} = {}): CheckResult {
+export function checkDataDir({ dataDir }: { dataDir: string }): CheckResult {
   try {
     const stats = statSync(dataDir);
     if (!stats.isDirectory()) {

--- a/packages/cli-tools/src/doctor/index.ts
+++ b/packages/cli-tools/src/doctor/index.ts
@@ -60,12 +60,29 @@ export async function runDoctor({
   log(pc.bold('SlopWeaver doctor'));
   log('');
 
+  // Resolve the data dir up front; if XDG_DATA_HOME is misconfigured every
+  // downstream check that needs the path would be meaningless, so we report
+  // the validation failure as a single failed check and bail.
+  const dataDirResult = resolveDataDir();
+  if (dataDirResult.isErr()) {
+    const failure: CheckResult = {
+      name: 'Data dir',
+      status: 'fail',
+      detail: dataDirResult.error.message,
+    };
+    log(formatRow(failure));
+    log('');
+    log(pc.red('1 check failed. Fix the items above and re-run.'));
+    return { ok: false, failed: 1, exitCode: 1 };
+  }
+  const dataDir = dataDirResult.value;
+
   const codexResult = checkCodexAgent();
   const results: CheckResult[] = [
     checkNodeVersion(),
     checkPnpmVersion(),
     await checkPortFree({ port: LOCAL_API_PORT }),
-    checkDataDir(),
+    checkDataDir({ dataDir }),
     ...(codexResult ? [codexResult] : []),
   ];
 
@@ -76,12 +93,11 @@ export async function runDoctor({
   // Offer the one fix we know how to apply.
   const dataDirIndex = results.findIndex((r) => r.fixable === 'create-data-dir');
   if (dataDirIndex !== -1) {
-    const dataDir = resolveDataDir();
     log('');
     const shouldCreate = await prompt(`Create data dir at ${dataDir}?`);
     if (shouldCreate) {
       mkdir(dataDir);
-      const recheck = checkDataDir();
+      const recheck = checkDataDir({ dataDir });
       results[dataDirIndex] = recheck;
       log(formatRow(recheck));
     }

--- a/packages/cli-tools/src/lib/data-dir.test.ts
+++ b/packages/cli-tools/src/lib/data-dir.test.ts
@@ -5,24 +5,36 @@ import { resolveDataDir } from './data-dir.ts';
 
 describe('resolveDataDir', () => {
   it('uses XDG_DATA_HOME when supplied', () => {
-    expect(resolveDataDir({ home: '/tmp/fakehome', xdgDataHome: '/tmp/xdg' })).toBe(
-      '/tmp/xdg/slopweaver',
-    );
+    const result = resolveDataDir({ home: '/tmp/fakehome', xdgDataHome: '/tmp/xdg' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('/tmp/xdg/slopweaver');
+    }
   });
 
   it('falls back to .slopweaver under the supplied home directory when XDG_DATA_HOME is unset', () => {
-    expect(resolveDataDir({ home: '/tmp/fakehome', xdgDataHome: '' })).toBe(
-      '/tmp/fakehome/.slopweaver',
-    );
+    const result = resolveDataDir({ home: '/tmp/fakehome', xdgDataHome: '' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('/tmp/fakehome/.slopweaver');
+    }
   });
 
   it('defaults to os.homedir() when no home is supplied and XDG_DATA_HOME is unset', () => {
-    expect(resolveDataDir({ xdgDataHome: '' })).toBe(join(homedir(), '.slopweaver'));
+    const result = resolveDataDir({ xdgDataHome: '' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(join(homedir(), '.slopweaver'));
+    }
   });
 
-  it('throws when XDG_DATA_HOME is set to a relative path', () => {
-    expect(() => resolveDataDir({ xdgDataHome: 'tmp/relative' })).toThrow(
-      /XDG_DATA_HOME must be an absolute path/,
-    );
+  it('returns DATA_PATH_INVALID when XDG_DATA_HOME is set to a relative path', () => {
+    const result = resolveDataDir({ xdgDataHome: 'tmp/relative' });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('DATA_PATH_INVALID');
+      expect(result.error.xdgDataHome).toBe('tmp/relative');
+      expect(result.error.message).toMatch(/XDG_DATA_HOME must be an absolute path/);
+    }
   });
 });

--- a/packages/cli-tools/src/lib/data-dir.ts
+++ b/packages/cli-tools/src/lib/data-dir.ts
@@ -6,10 +6,16 @@
  * otherwise under `~/.slopweaver`. Kept as a per-package helper (rather
  * than imported from `@slopweaver/db`) so cli-tools has no runtime
  * dependency on the SQLite stack.
+ *
+ * Returns the same `DataPathInvalidError` shape (`code: 'DATA_PATH_INVALID'`)
+ * that `@slopweaver/db` returns, so a caller that mixes both resolvers can
+ * exhaustively match on one union.
  */
 
 import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
+import { err, ok, type Result } from '@slopweaver/errors';
+import { type DataPathInvalidError, LibErrors } from './errors.ts';
 
 /**
  * Resolve the directory SlopWeaver uses for local data (database, cached
@@ -18,15 +24,6 @@ import { isAbsolute, join } from 'node:path';
  * Per the XDG Base Directory specification, `XDG_DATA_HOME` must be an
  * absolute path; relative values are rejected so misconfigured environments
  * fail fast instead of writing data under the caller's cwd.
- *
- * @param options - Optional overrides. Inject `home` and/or `xdgDataHome`
- *   in tests to avoid touching the real environment.
- * @returns Absolute path to the SlopWeaver data directory.
- * @throws {Error} If the resolved `XDG_DATA_HOME` is not an absolute path.
- *
- * @example
- * resolveDataDir({ xdgDataHome: '/var/lib' }); // '/var/lib/slopweaver'
- * resolveDataDir({ home: '/Users/alice', xdgDataHome: '' }); // '/Users/alice/.slopweaver'
  */
 export function resolveDataDir({
   home,
@@ -34,15 +31,15 @@ export function resolveDataDir({
 }: {
   home?: string;
   xdgDataHome?: string;
-} = {}): string {
+} = {}): Result<string, DataPathInvalidError> {
   const resolvedXdgDataHome = xdgDataHome ?? process.env.XDG_DATA_HOME;
 
   if (resolvedXdgDataHome) {
     if (!isAbsolute(resolvedXdgDataHome)) {
-      throw new Error(`XDG_DATA_HOME must be an absolute path; got: "${resolvedXdgDataHome}"`);
+      return err(LibErrors.dataPathInvalid(resolvedXdgDataHome));
     }
-    return join(resolvedXdgDataHome, 'slopweaver');
+    return ok(join(resolvedXdgDataHome, 'slopweaver'));
   }
 
-  return join(home ?? homedir(), '.slopweaver');
+  return ok(join(home ?? homedir(), '.slopweaver'));
 }

--- a/packages/cli-tools/src/lib/errors.ts
+++ b/packages/cli-tools/src/lib/errors.ts
@@ -1,0 +1,28 @@
+/**
+ * cli-tools lib-level error union.
+ *
+ * Currently scoped to `DataPathInvalidError` for the XDG validation in
+ * `data-dir.ts`. Defined locally (rather than imported from
+ * `@slopweaver/db`) so cli-tools has no runtime dependency on the SQLite
+ * stack — same reasoning as the duplicated `resolveDataDir` helper.
+ *
+ * The shape and `code: 'DATA_PATH_INVALID'` discriminant match the
+ * `DataPathInvalidError` exported by `@slopweaver/db`, so a caller that
+ * mixes the two surfaces (e.g. `apps/mcp-local`) can exhaustively match on
+ * one union.
+ */
+
+import type { BaseError } from '@slopweaver/errors';
+
+export interface DataPathInvalidError extends BaseError {
+  readonly code: 'DATA_PATH_INVALID';
+  readonly xdgDataHome: string;
+}
+
+export const LibErrors = {
+  dataPathInvalid: (xdgDataHome: string): DataPathInvalidError => ({
+    code: 'DATA_PATH_INVALID',
+    message: `XDG_DATA_HOME must be an absolute path; got: "${xdgDataHome}"`,
+    xdgDataHome,
+  }),
+} as const;

--- a/packages/cli-tools/src/lib/errors.ts
+++ b/packages/cli-tools/src/lib/errors.ts
@@ -19,10 +19,21 @@ export interface DataPathInvalidError extends BaseError {
   readonly xdgDataHome: string;
 }
 
+export interface MonorepoRootNotFoundError extends BaseError {
+  readonly code: 'MONOREPO_ROOT_NOT_FOUND';
+  readonly startedFrom: string;
+}
+
 export const LibErrors = {
   dataPathInvalid: (xdgDataHome: string): DataPathInvalidError => ({
     code: 'DATA_PATH_INVALID',
     message: `XDG_DATA_HOME must be an absolute path; got: "${xdgDataHome}"`,
     xdgDataHome,
+  }),
+
+  monorepoRootNotFound: (startedFrom: string): MonorepoRootNotFoundError => ({
+    code: 'MONOREPO_ROOT_NOT_FOUND',
+    message: `could not find monorepo root (no pnpm-workspace.yaml above ${startedFrom})`,
+    startedFrom,
   }),
 } as const;

--- a/packages/cli-tools/src/lib/paths.test.ts
+++ b/packages/cli-tools/src/lib/paths.test.ts
@@ -5,8 +5,11 @@ import { findMonorepoRoot, resolveWorktreesRoot } from './paths.ts';
 
 describe('findMonorepoRoot', () => {
   it('returns a directory that contains pnpm-workspace.yaml', () => {
-    const root = findMonorepoRoot();
-    expect(existsSync(join(root, 'pnpm-workspace.yaml'))).toBe(true);
+    const result = findMonorepoRoot();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(existsSync(join(result.value, 'pnpm-workspace.yaml'))).toBe(true);
+    }
   });
 });
 

--- a/packages/cli-tools/src/lib/paths.ts
+++ b/packages/cli-tools/src/lib/paths.ts
@@ -1,22 +1,27 @@
 import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { err, ok, type Result } from '@slopweaver/errors';
+import { type MonorepoRootNotFoundError, LibErrors } from './errors.ts';
 
 /**
  * Walks up from this module's directory until a `pnpm-workspace.yaml` is
- * found, treating that directory as the monorepo root. Throws if the file
- * isn't found before reaching `/` (which would indicate a broken install).
+ * found, treating that directory as the monorepo root. Returns
+ * `Result<string, MonorepoRootNotFoundError>` so callers at the CLI
+ * boundary can surface a clean error message instead of an unhandled
+ * exception — the file not being found above the bin's install path
+ * implies a broken install, not a recoverable runtime condition.
  */
-export function findMonorepoRoot(): string {
+export function findMonorepoRoot(): Result<string, MonorepoRootNotFoundError> {
   const here = dirname(fileURLToPath(import.meta.url));
   let current = resolve(here);
   while (current !== '/') {
     if (existsSync(join(current, 'pnpm-workspace.yaml'))) {
-      return current;
+      return ok(current);
     }
     current = dirname(current);
   }
-  throw new Error('could not find monorepo root (no pnpm-workspace.yaml above this file)');
+  return err(LibErrors.monorepoRootNotFound(here));
 }
 
 /**

--- a/packages/cli-tools/src/orchestration/core.test.ts
+++ b/packages/cli-tools/src/orchestration/core.test.ts
@@ -17,8 +17,11 @@ import {
 } from './core.ts';
 
 function readChainFixture({ relativePath }: { relativePath: string }): ParsedChain {
-  const repoRoot = findMonorepoRoot();
-  const chainPath = path.join(repoRoot, relativePath);
+  const rootResult = findMonorepoRoot();
+  if (rootResult.isErr()) {
+    throw new Error(`readChainFixture: ${rootResult.error.message}`);
+  }
+  const chainPath = path.join(rootResult.value, relativePath);
   const result = parseOrchestrationChain({
     chainPath,
     markdown: fs.readFileSync(chainPath, 'utf8'),

--- a/packages/cli-tools/src/orchestration/core.test.ts
+++ b/packages/cli-tools/src/orchestration/core.test.ts
@@ -19,10 +19,14 @@ import {
 function readChainFixture({ relativePath }: { relativePath: string }): ParsedChain {
   const repoRoot = findMonorepoRoot();
   const chainPath = path.join(repoRoot, relativePath);
-  return parseOrchestrationChain({
+  const result = parseOrchestrationChain({
     chainPath,
     markdown: fs.readFileSync(chainPath, 'utf8'),
   });
+  if (result.isErr()) {
+    throw new Error(`readChainFixture: ${result.error.message}`);
+  }
+  return result.value;
 }
 
 describe('orchestration core', () => {
@@ -106,11 +110,14 @@ describe('orchestration core', () => {
       '```',
     ].join('\n');
 
-    const chain = parseOrchestrationChain({
+    const result = parseOrchestrationChain({
       chainPath: '/repo/slopweaver/test-chain.md',
       markdown,
     });
 
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+    const chain = result.value;
     expect(chain.steps).toHaveLength(2);
     expect(chain.steps[0]?.title).toBe('Plan');
     expect(chain.steps[1]?.title).toBe('Review');

--- a/packages/cli-tools/src/orchestration/core.ts
+++ b/packages/cli-tools/src/orchestration/core.ts
@@ -1,4 +1,11 @@
+import { err, ok, type Result } from '@slopweaver/errors';
 import path from 'node:path';
+import {
+  OrchestrationErrors,
+  type OrchestrationInvalidJobIdOutputError,
+  type OrchestrationInvalidPrUrlOutputError,
+  type OrchestrationMissingTitleError,
+} from './errors.ts';
 
 export const ORCHESTRATION_ROLES = [
   'codex-plan',
@@ -178,11 +185,11 @@ export function parseOrchestrationChain({
 }: {
   chainPath: string;
   markdown: string;
-}): ParsedChain {
+}): Result<ParsedChain, OrchestrationMissingTitleError> {
   const lines = markdown.split(/\r?\n/);
   const titleLine = lines.find((line) => line.startsWith('# '));
   if (!titleLine) {
-    throw new Error(`Missing top-level title in orchestration chain: ${chainPath}`);
+    return err(OrchestrationErrors.missingTitle(chainPath));
   }
 
   const steps: ParsedChainStep[] = [];
@@ -266,12 +273,12 @@ export function parseOrchestrationChain({
 
   finalizeStep({ endExclusive: lines.length });
 
-  return {
+  return ok({
     chainPath,
     steps,
     title: titleLine.replace(/^#\s+/, '').trim(),
     variables,
-  };
+  });
 }
 
 export function interpolateTemplate({
@@ -496,23 +503,31 @@ export function buildCiFixPrompt({
       ].join('\n');
 }
 
-export function parseCodexJobId({ output }: { output: string }): string {
+export function parseCodexJobId({
+  output,
+}: {
+  output: string;
+}): Result<string, OrchestrationInvalidJobIdOutputError> {
   // Defensive: widen the character class beyond plain hex so this still works
   // if codex-orchestrator ever returns UUID-style ids (with `-`) or
   // underscored ids. Today's wrapper emits 8-char lowercase hex.
   const match = output.match(/Job started:\s+([a-zA-Z0-9_-]+)/);
   if (!match?.[1]) {
-    throw new Error(`Could not parse codex-agent job id from output:\n${output}`);
+    return err(OrchestrationErrors.invalidJobIdOutput(output));
   }
-  return match[1];
+  return ok(match[1]);
 }
 
-export function parsePullRequestUrl({ output }: { output: string }): string {
+export function parsePullRequestUrl({
+  output,
+}: {
+  output: string;
+}): Result<string, OrchestrationInvalidPrUrlOutputError> {
   const match = output.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/);
   if (!match) {
-    throw new Error(`Could not parse PR URL from output:\n${output}`);
+    return err(OrchestrationErrors.invalidPrUrlOutput(output));
   }
-  return match[0];
+  return ok(match[0]);
 }
 
 export function parsePullRequestNumber({ prUrl }: { prUrl: string }): number | null {

--- a/packages/cli-tools/src/orchestration/errors.ts
+++ b/packages/cli-tools/src/orchestration/errors.ts
@@ -1,10 +1,22 @@
 /**
  * Errors for the orchestration runtime + parsers.
  *
- * Covers the pure-parser failures in core.ts (commit 16) plus the
- * subprocess + state-machine failures the runtime.ts split exposes in
- * later commits. The union is stable from commit 16 onward so consumers
- * don't have to re-match as commits 18-20 land.
+ * Discriminated by `code`. Service code returns `Result<T, OrchestrationError>`
+ * (or one of the constituent variants); callers exhaustively match on `code`
+ * at the boundary.
+ *
+ * The union covers:
+ * - Parser failures in core.ts (parseOrchestrationChain, parseCodexJobId,
+ *   parsePullRequestUrl).
+ * - State preconditions in runtime.ts (worktree merge conflicts, dirty
+ *   worktree, missing planning prompt).
+ * - The model-attempt classifier (`OrchestrationModelAttemptError`) that
+ *   tags transient vs fatal so the retry-fallback loops can decide whether
+ *   to continue to the next candidate.
+ * - Subprocess failures from `createDefaultEnvironment` wrappers
+ *   (`OrchestrationSubprocessFailedError`).
+ * - Terminal "no more retries" errors (all models failed, review loop
+ *   exhausted, CI loop exhausted, CI run id missing for diagnosis).
  */
 
 import type { BaseError } from '@slopweaver/errors';
@@ -26,10 +38,87 @@ export interface OrchestrationInvalidPrUrlOutputError extends BaseError {
   readonly output: string;
 }
 
-// Note: the umbrella `OrchestrationError` union lands in commit 18 once
-// commits 18-20 add the runtime-side error codes. For commit 16 the three
-// parser variants are surfaced individually since each parser returns its
-// specific error type.
+// ---------- runtime.ts state preconditions ----------
+
+export interface OrchestrationWorktreeMergeConflictError extends BaseError {
+  readonly code: 'ORCHESTRATION_WORKTREE_MERGE_CONFLICT';
+  readonly worktreePath: string;
+}
+
+export interface OrchestrationWorktreeDirtyError extends BaseError {
+  readonly code: 'ORCHESTRATION_WORKTREE_DIRTY';
+  readonly worktreePath: string;
+}
+
+export interface OrchestrationMissingPlanPromptError extends BaseError {
+  readonly code: 'ORCHESTRATION_MISSING_PLAN_PROMPT';
+  readonly chainPath: string;
+}
+
+// ---------- runtime.ts retry-loop classifier ----------
+
+/**
+ * Carries the classification needed by the model-attempt retry loops: a
+ * `transient` failure tells the outer loop to advance to the next candidate;
+ * `fatal` tells it to bubble out immediately. `lastError` is the captured
+ * stderr/stdout used for the "All model attempts failed" summary.
+ */
+export interface OrchestrationModelAttemptError extends BaseError {
+  readonly code: 'ORCHESTRATION_MODEL_ATTEMPT';
+  readonly kind: 'transient' | 'fatal';
+  readonly lastError: string;
+}
+
+export interface OrchestrationAllModelsFailedError extends BaseError {
+  readonly code: 'ORCHESTRATION_ALL_MODELS_FAILED';
+  readonly retryKey: string;
+  readonly lastError: string;
+}
+
+// ---------- runtime.ts terminal loop failures ----------
+
+export interface OrchestrationReviewNotConvergedError extends BaseError {
+  readonly code: 'ORCHESTRATION_REVIEW_NOT_CONVERGED';
+  readonly attempts: number;
+  readonly runDirectory: string;
+}
+
+export interface OrchestrationCiNotConvergedError extends BaseError {
+  readonly code: 'ORCHESTRATION_CI_NOT_CONVERGED';
+  readonly attempts: number;
+  readonly runDirectory: string;
+}
+
+export interface OrchestrationCiRunIdMissingError extends BaseError {
+  readonly code: 'ORCHESTRATION_CI_RUN_ID_MISSING';
+}
+
+// ---------- runtime.ts subprocess wrappers ----------
+
+export interface OrchestrationSubprocessFailedError extends BaseError {
+  readonly code: 'ORCHESTRATION_SUBPROCESS_FAILED';
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd: string;
+  readonly exitCode: number;
+  readonly output: string;
+}
+
+// ---------- umbrella union + factories ----------
+
+export type OrchestrationError =
+  | OrchestrationMissingTitleError
+  | OrchestrationInvalidJobIdOutputError
+  | OrchestrationInvalidPrUrlOutputError
+  | OrchestrationMissingPlanPromptError
+  | OrchestrationWorktreeMergeConflictError
+  | OrchestrationWorktreeDirtyError
+  | OrchestrationModelAttemptError
+  | OrchestrationAllModelsFailedError
+  | OrchestrationReviewNotConvergedError
+  | OrchestrationCiNotConvergedError
+  | OrchestrationCiRunIdMissingError
+  | OrchestrationSubprocessFailedError;
 
 export const OrchestrationErrors = {
   missingTitle: (chainPath: string): OrchestrationMissingTitleError => ({
@@ -47,6 +136,103 @@ export const OrchestrationErrors = {
   invalidPrUrlOutput: (output: string): OrchestrationInvalidPrUrlOutputError => ({
     code: 'ORCHESTRATION_INVALID_PR_URL_OUTPUT',
     message: `Could not parse PR URL from output:\n${output}`,
+    output,
+  }),
+
+  worktreeMergeConflict: (worktreePath: string): OrchestrationWorktreeMergeConflictError => ({
+    code: 'ORCHESTRATION_WORKTREE_MERGE_CONFLICT',
+    message: `Worktree has merge conflicts: ${worktreePath}`,
+    worktreePath,
+  }),
+
+  worktreeDirty: (worktreePath: string): OrchestrationWorktreeDirtyError => ({
+    code: 'ORCHESTRATION_WORKTREE_DIRTY',
+    message: `Worktree is dirty: ${worktreePath}`,
+    worktreePath,
+  }),
+
+  missingPlanPrompt: (chainPath: string): OrchestrationMissingPlanPromptError => ({
+    code: 'ORCHESTRATION_MISSING_PLAN_PROMPT',
+    message: `Missing codex-plan prompt in chain: ${chainPath}`,
+    chainPath,
+  }),
+
+  modelAttempt: ({
+    kind,
+    lastError,
+  }: {
+    kind: 'transient' | 'fatal';
+    lastError: string;
+  }): OrchestrationModelAttemptError => ({
+    code: 'ORCHESTRATION_MODEL_ATTEMPT',
+    message: `Model attempt failed (${kind}): ${lastError}`,
+    kind,
+    lastError,
+  }),
+
+  allModelsFailed: ({
+    retryKey,
+    lastError,
+  }: {
+    retryKey: string;
+    lastError: string;
+  }): OrchestrationAllModelsFailedError => ({
+    code: 'ORCHESTRATION_ALL_MODELS_FAILED',
+    message: `All model attempts failed for ${retryKey}.\n${lastError}`,
+    retryKey,
+    lastError,
+  }),
+
+  reviewNotConverged: ({
+    attempts,
+    runDirectory,
+  }: {
+    attempts: number;
+    runDirectory: string;
+  }): OrchestrationReviewNotConvergedError => ({
+    code: 'ORCHESTRATION_REVIEW_NOT_CONVERGED',
+    message: `Review loop did not converge after ${attempts} attempts. Inspect ${runDirectory}/artifacts/review-${attempts}.md and either resume with --restart, fix the chain, or address findings manually.`,
+    attempts,
+    runDirectory,
+  }),
+
+  ciNotConverged: ({
+    attempts,
+    runDirectory,
+  }: {
+    attempts: number;
+    runDirectory: string;
+  }): OrchestrationCiNotConvergedError => ({
+    code: 'ORCHESTRATION_CI_NOT_CONVERGED',
+    message: `CI loop did not converge after ${attempts} attempts. Inspect ${runDirectory}/artifacts/ci-watch-${attempts}.md and either resume with --restart, fix the chain, or address failures manually.`,
+    attempts,
+    runDirectory,
+  }),
+
+  ciRunIdMissing: (): OrchestrationCiRunIdMissingError => ({
+    code: 'ORCHESTRATION_CI_RUN_ID_MISSING',
+    message: 'CI failed but no GitHub run id could be resolved for diagnosis.',
+  }),
+
+  subprocessFailed: ({
+    command,
+    args,
+    cwd,
+    exitCode,
+    output,
+  }: {
+    command: string;
+    args: ReadonlyArray<string>;
+    cwd: string;
+    exitCode: number;
+    output: string;
+  }): OrchestrationSubprocessFailedError => ({
+    code: 'ORCHESTRATION_SUBPROCESS_FAILED',
+    message: `${command} ${args.join(' ')} (cwd=${cwd}) exited ${exitCode}: ${output.trim() || '(no output)'}`,
+    command,
+    args,
+    cwd,
+    exitCode,
     output,
   }),
 } as const;

--- a/packages/cli-tools/src/orchestration/errors.ts
+++ b/packages/cli-tools/src/orchestration/errors.ts
@@ -1,0 +1,52 @@
+/**
+ * Errors for the orchestration runtime + parsers.
+ *
+ * Covers the pure-parser failures in core.ts (commit 16) plus the
+ * subprocess + state-machine failures the runtime.ts split exposes in
+ * later commits. The union is stable from commit 16 onward so consumers
+ * don't have to re-match as commits 18-20 land.
+ */
+
+import type { BaseError } from '@slopweaver/errors';
+
+// ---------- core.ts parsers ----------
+
+export interface OrchestrationMissingTitleError extends BaseError {
+  readonly code: 'ORCHESTRATION_MISSING_TITLE';
+  readonly chainPath: string;
+}
+
+export interface OrchestrationInvalidJobIdOutputError extends BaseError {
+  readonly code: 'ORCHESTRATION_INVALID_JOB_ID_OUTPUT';
+  readonly output: string;
+}
+
+export interface OrchestrationInvalidPrUrlOutputError extends BaseError {
+  readonly code: 'ORCHESTRATION_INVALID_PR_URL_OUTPUT';
+  readonly output: string;
+}
+
+// Note: the umbrella `OrchestrationError` union lands in commit 18 once
+// commits 18-20 add the runtime-side error codes. For commit 16 the three
+// parser variants are surfaced individually since each parser returns its
+// specific error type.
+
+export const OrchestrationErrors = {
+  missingTitle: (chainPath: string): OrchestrationMissingTitleError => ({
+    code: 'ORCHESTRATION_MISSING_TITLE',
+    message: `Missing top-level title in orchestration chain: ${chainPath}`,
+    chainPath,
+  }),
+
+  invalidJobIdOutput: (output: string): OrchestrationInvalidJobIdOutputError => ({
+    code: 'ORCHESTRATION_INVALID_JOB_ID_OUTPUT',
+    message: `Could not parse codex-agent job id from output:\n${output}`,
+    output,
+  }),
+
+  invalidPrUrlOutput: (output: string): OrchestrationInvalidPrUrlOutputError => ({
+    code: 'ORCHESTRATION_INVALID_PR_URL_OUTPUT',
+    message: `Could not parse PR URL from output:\n${output}`,
+    output,
+  }),
+} as const;

--- a/packages/cli-tools/src/orchestration/index.ts
+++ b/packages/cli-tools/src/orchestration/index.ts
@@ -5,9 +5,15 @@
  * commands; their `.action(...)` handlers call `prepare()` / `run()` here,
  * which translate the cac options object into the typed
  * `PrepareOrchestrationOptions` / `RunOrchestrationOptions` the runtime expects.
+ *
+ * Both wrappers return a `Result` from the runtime; the CLI dispatcher
+ * `.match()`es and exits non-zero on Err.
  */
 
+import { err, ok, type Result } from '@slopweaver/errors';
+import type { MonorepoRootNotFoundError } from '../lib/errors.ts';
 import type { ExecutorMode } from './core.ts';
+import type { OrchestrationError } from './errors.ts';
 import { prepareOrchestration, runOrchestration } from './runtime.ts';
 
 interface PrepareCliOptions {
@@ -22,15 +28,28 @@ interface RunCliOptions {
   restart: boolean;
 }
 
-function normalizeExecutor(raw: string): ExecutorMode {
-  if (raw !== 'hybrid' && raw !== 'codex-only') {
-    throw new Error(`Unsupported executor: ${raw}. Use 'hybrid' or 'codex-only'.`);
-  }
-  return raw;
+interface UnsupportedExecutorError {
+  readonly code: 'ORCHESTRATION_UNSUPPORTED_EXECUTOR';
+  readonly message: string;
+  readonly raw: string;
 }
 
-export async function prepare(chainPath: string, options: PrepareCliOptions): Promise<void> {
-  await prepareOrchestration({
+function normalizeExecutor(raw: string): Result<ExecutorMode, UnsupportedExecutorError> {
+  if (raw !== 'hybrid' && raw !== 'codex-only') {
+    return err({
+      code: 'ORCHESTRATION_UNSUPPORTED_EXECUTOR',
+      message: `Unsupported executor: ${raw}. Use 'hybrid' or 'codex-only'.`,
+      raw,
+    });
+  }
+  return ok(raw);
+}
+
+export async function prepare(
+  chainPath: string,
+  options: PrepareCliOptions,
+): Promise<Result<void, OrchestrationError | MonorepoRootNotFoundError>> {
+  return await prepareOrchestration({
     options: {
       chainInputPath: chainPath,
       executor: options.executor,
@@ -39,8 +58,11 @@ export async function prepare(chainPath: string, options: PrepareCliOptions): Pr
   });
 }
 
-export async function run(chainPath: string, options: RunCliOptions): Promise<void> {
-  await runOrchestration({
+export async function run(
+  chainPath: string,
+  options: RunCliOptions,
+): Promise<Result<void, OrchestrationError | MonorepoRootNotFoundError>> {
+  return await runOrchestration({
     options: {
       chainInputPath: chainPath,
       dryRun: options.dryRun,
@@ -51,4 +73,4 @@ export async function run(chainPath: string, options: RunCliOptions): Promise<vo
   });
 }
 
-export { normalizeExecutor };
+export { normalizeExecutor, type UnsupportedExecutorError };

--- a/packages/cli-tools/src/orchestration/runtime.test.ts
+++ b/packages/cli-tools/src/orchestration/runtime.test.ts
@@ -273,7 +273,7 @@ describe('runOrchestration', () => {
 
     expect(result.isErr()).toBe(true);
     // The finally block closed the job exactly once with the parsed jobId.
-    expect(closeCodexJobCalls.length).toBeGreaterThanOrEqual(1);
+    expect(closeCodexJobCalls).toHaveLength(1);
     expect(closeCodexJobCalls[0]?.jobId).toBe('12345');
   });
 });

--- a/packages/cli-tools/src/orchestration/runtime.test.ts
+++ b/packages/cli-tools/src/orchestration/runtime.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Integration-style tests for runOrchestration's risky branches.
+ *
+ * Drives the public `runOrchestration` API against a fully-stubbed
+ * `RunOrchestrationEnvironment` so the internal helpers
+ * (checkWorktreeIsReady, runOneModelAttempt, runOnePlanningAttempt) don't
+ * have to be exposed. CODEX_HOME is set to a per-test tmpdir so state-file
+ * side effects stay isolated.
+ *
+ * Coverage targets the four risky paths called out in the migration plan
+ * and re-flagged by codex review iteration 1 F4:
+ *
+ * - merge-conflict precondition (`ORCHESTRATION_WORKTREE_MERGE_CONFLICT`)
+ * - dirty-worktree precondition (`ORCHESTRATION_WORKTREE_DIRTY`)
+ * - transient-then-success model-attempt fallback (loop advances to next
+ *   candidate when the first attempt's output looks transient)
+ * - all-models-failed terminal (`ORCHESTRATION_ALL_MODELS_FAILED`)
+ * - `closeCodexJob` cleanup when await fails after the job-id parse
+ *   succeeded (locks the `finally { if (jobId !== null) ... }` block)
+ *
+ * Reuses `docs/orchestration/examples/refactor-example.md` as the fixture
+ * chain (same file `core.test.ts` uses).
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { err, ok } from '@slopweaver/errors';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { findMonorepoRoot } from '../lib/paths.ts';
+import { OrchestrationErrors } from './errors.ts';
+import { type RunOrchestrationEnvironment, runOrchestration } from './runtime.ts';
+
+const CHAIN_FIXTURE_RELATIVE = 'docs/orchestration/examples/refactor-example.md';
+
+type CloseCall = { cwd: string; jobId: string };
+type StartCall = { model: string; reasoning: string };
+
+interface FakeEnvOverrides {
+  awaitCodexTurn?: RunOrchestrationEnvironment['awaitCodexTurn'];
+  ensureWorktree?: RunOrchestrationEnvironment['ensureWorktree'];
+  getBranchName?: RunOrchestrationEnvironment['getBranchName'];
+  getWorktreeStatus?: RunOrchestrationEnvironment['getWorktreeStatus'];
+  hasDependencies?: RunOrchestrationEnvironment['hasDependencies'];
+  installDependencies?: RunOrchestrationEnvironment['installDependencies'];
+  startCodexJob?: RunOrchestrationEnvironment['startCodexJob'];
+}
+
+function createFakeEnv(overrides: FakeEnvOverrides = {}): {
+  env: RunOrchestrationEnvironment;
+  closeCodexJobCalls: ReadonlyArray<CloseCall>;
+  startCodexJobCalls: ReadonlyArray<StartCall>;
+} {
+  const closeCalls: CloseCall[] = [];
+  const startCalls: StartCall[] = [];
+  const env: RunOrchestrationEnvironment = {
+    awaitCodexTurn: overrides.awaitCodexTurn ?? (() => ok('LGTM - ready for local testing.')),
+    closeCodexJob: ({ cwd, jobId }) => {
+      closeCalls.push({ cwd, jobId });
+    },
+    commitAll: () => ok(true),
+    createOrReusePr: () => ok('https://github.com/slopweaver/slopweaver/pull/999'),
+    ensureWorktree: overrides.ensureWorktree ?? (() => ok('/tmp/fake-worktree')),
+    getBranchName: overrides.getBranchName ?? (() => ok('worktree/refactor-rename-utility')),
+    getLatestCiRunId: () => '42',
+    getWorktreeStatus: overrides.getWorktreeStatus ?? (() => []),
+    hasDependencies: overrides.hasDependencies ?? (() => true),
+    installDependencies: overrides.installDependencies ?? (() => ok(undefined)),
+    notify: () => {},
+    pushBranch: () => ok(undefined),
+    sendCodexInput: () => ok(undefined),
+    startCodexJob: overrides.startCodexJob
+      ? (args) => {
+          startCalls.push({ model: args.model, reasoning: args.reasoning });
+          return overrides.startCodexJob!(args);
+        }
+      : (args) => {
+          startCalls.push({ model: args.model, reasoning: args.reasoning });
+          return ok('Job started: 12345');
+        },
+    syncEnvFiles: () => {},
+    watchCi: () => ({ output: 'CI green', success: true }),
+  };
+  return { env, closeCodexJobCalls: closeCalls, startCodexJobCalls: startCalls };
+}
+
+function getChainFixturePath(): string {
+  const rootResult = findMonorepoRoot();
+  if (rootResult.isErr()) {
+    throw new Error(`runtime.test setup: ${rootResult.error.message}`);
+  }
+  return path.join(rootResult.value, CHAIN_FIXTURE_RELATIVE);
+}
+
+describe('runOrchestration', () => {
+  let originalCodexHome: string | undefined;
+  let tempCodexHome: string | null = null;
+
+  beforeEach(() => {
+    originalCodexHome = process.env['CODEX_HOME'];
+    tempCodexHome = mkdtempSync(path.join(tmpdir(), 'slopweaver-runtime-test-'));
+    process.env['CODEX_HOME'] = tempCodexHome;
+  });
+
+  afterEach(() => {
+    if (originalCodexHome === undefined) {
+      delete process.env['CODEX_HOME'];
+    } else {
+      process.env['CODEX_HOME'] = originalCodexHome;
+    }
+    if (tempCodexHome) {
+      rmSync(tempCodexHome, { recursive: true, force: true });
+      tempCodexHome = null;
+    }
+  });
+
+  it('returns ORCHESTRATION_WORKTREE_MERGE_CONFLICT when git status shows UU lines', async () => {
+    const { env } = createFakeEnv({
+      getWorktreeStatus: () => ['UU some/file.ts'],
+    });
+
+    const result = await runOrchestration({
+      env,
+      options: {
+        chainInputPath: getChainFixturePath(),
+        dryRun: false,
+        executor: 'codex-only',
+        notify: false,
+        restart: true,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('ORCHESTRATION_WORKTREE_MERGE_CONFLICT');
+      expect(result.error.message).toContain('merge conflicts');
+    }
+  });
+
+  it('returns ORCHESTRATION_WORKTREE_DIRTY when git status shows untracked changes', async () => {
+    const { env } = createFakeEnv({
+      getWorktreeStatus: () => ['?? new-file.md'],
+    });
+
+    const result = await runOrchestration({
+      env,
+      options: {
+        chainInputPath: getChainFixturePath(),
+        dryRun: false,
+        executor: 'codex-only',
+        notify: false,
+        restart: true,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('ORCHESTRATION_WORKTREE_DIRTY');
+      expect(result.error.message).toContain('dirty');
+    }
+  });
+
+  it('advances to the next model candidate when the first attempt is transient', async () => {
+    let attempts = 0;
+    const { env, startCodexJobCalls } = createFakeEnv({
+      // First startCodexJob output contains 'rate limit', which matches
+      // looksLikeTransientModelFailure → loop advances to next candidate.
+      // Second attempt succeeds with a parseable job id.
+      startCodexJob: () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return err(
+            OrchestrationErrors.subprocessFailed({
+              command: 'codex-agent',
+              args: ['start'],
+              cwd: '/tmp/fake-worktree',
+              exitCode: 1,
+              output: 'rate limit exceeded; retry after 60s',
+            }),
+          );
+        }
+        return ok('Job started: 67890');
+      },
+    });
+
+    const result = await runOrchestration({
+      env,
+      options: {
+        chainInputPath: getChainFixturePath(),
+        dryRun: false,
+        executor: 'codex-only',
+        notify: false,
+        restart: true,
+      },
+    });
+
+    // Planning should succeed on the second model candidate; the whole
+    // orchestration then proceeds. The retry advanced model candidates —
+    // assert the two attempts used different models.
+    expect(startCodexJobCalls.length).toBeGreaterThanOrEqual(2);
+    const plannerAttempts = startCodexJobCalls.slice(0, 2);
+    expect(plannerAttempts[0]?.model).not.toBe(plannerAttempts[1]?.model);
+    // Orchestration ran to completion (await/ci/etc were all stubbed Ok).
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('returns ORCHESTRATION_ALL_MODELS_FAILED when every candidate is transient', async () => {
+    const { env, startCodexJobCalls } = createFakeEnv({
+      startCodexJob: () =>
+        err(
+          OrchestrationErrors.subprocessFailed({
+            command: 'codex-agent',
+            args: ['start'],
+            cwd: '/tmp/fake-worktree',
+            exitCode: 1,
+            output: 'rate limit exceeded',
+          }),
+        ),
+    });
+
+    const result = await runOrchestration({
+      env,
+      options: {
+        chainInputPath: getChainFixturePath(),
+        dryRun: false,
+        executor: 'codex-only',
+        notify: false,
+        restart: true,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('ORCHESTRATION_ALL_MODELS_FAILED');
+      // planner-main is the retry key for the planning conversation
+      if (result.error.code === 'ORCHESTRATION_ALL_MODELS_FAILED') {
+        expect(result.error.retryKey).toBe('planner-main');
+      }
+    }
+    // At least one start attempt per candidate, and every one failed
+    // transient, so the loop walked the full candidate list.
+    expect(startCodexJobCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('calls closeCodexJob when awaitCodexTurn fails after the job id was parsed', async () => {
+    const { env, closeCodexJobCalls } = createFakeEnv({
+      startCodexJob: () => ok('Job started: 12345'),
+      // awaitCodexTurn fails with a fatal-looking output — runOneModelAttempt
+      // returns Err({ kind: 'fatal' }) and the fallback loop bubbles out
+      // immediately. The finally{} cleanup MUST close the job we opened.
+      awaitCodexTurn: () =>
+        err(
+          OrchestrationErrors.subprocessFailed({
+            command: 'codex-agent',
+            args: ['await-turn'],
+            cwd: '/tmp/fake-worktree',
+            exitCode: 1,
+            output: 'irrecoverable: agent died',
+          }),
+        ),
+    });
+
+    const result = await runOrchestration({
+      env,
+      options: {
+        chainInputPath: getChainFixturePath(),
+        dryRun: false,
+        executor: 'codex-only',
+        notify: false,
+        restart: true,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    // The finally block closed the job exactly once with the parsed jobId.
+    expect(closeCodexJobCalls.length).toBeGreaterThanOrEqual(1);
+    expect(closeCodexJobCalls[0]?.jobId).toBe('12345');
+  });
+});

--- a/packages/cli-tools/src/orchestration/runtime.ts
+++ b/packages/cli-tools/src/orchestration/runtime.ts
@@ -88,7 +88,7 @@ interface RunState {
   worktreePath: string;
 }
 
-interface RunOrchestrationEnvironment {
+export interface RunOrchestrationEnvironment {
   awaitCodexTurn(args: {
     cwd: string;
     jobId: string;

--- a/packages/cli-tools/src/orchestration/runtime.ts
+++ b/packages/cli-tools/src/orchestration/runtime.ts
@@ -2,7 +2,9 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { err, ok, type Result } from '@slopweaver/errors';
 import { BLUE, GREEN, NC, YELLOW } from '../lib/colors.ts';
+import type { MonorepoRootNotFoundError } from '../lib/errors.ts';
 import { findMonorepoRoot, resolveWorktreesRoot } from '../lib/paths.ts';
 import {
   buildCiDiagnosisPrompt,
@@ -31,6 +33,12 @@ import {
   resolveRunSlug,
   resolveWorktreeName,
 } from './core.ts';
+import {
+  type OrchestrationError,
+  OrchestrationErrors,
+  type OrchestrationModelAttemptError,
+  type OrchestrationSubprocessFailedError,
+} from './errors.ts';
 
 interface RunOrchestrationOptions {
   chainInputPath: string;
@@ -81,19 +89,37 @@ interface RunState {
 }
 
 interface RunOrchestrationEnvironment {
-  awaitCodexTurn(args: { cwd: string; jobId: string }): string;
+  awaitCodexTurn(args: {
+    cwd: string;
+    jobId: string;
+  }): Result<string, OrchestrationSubprocessFailedError>;
   closeCodexJob(args: { cwd: string; jobId: string }): void;
-  commitAll(args: { cwd: string; ignoredPaths: string[]; message: string }): boolean;
-  createOrReusePr(args: { body: string; cwd: string; title: string }): string;
-  ensureWorktree(args: { repoRoot: string; worktreeName: string }): string;
-  getBranchName(args: { cwd: string }): string;
+  commitAll(args: {
+    cwd: string;
+    ignoredPaths: string[];
+    message: string;
+  }): Result<boolean, OrchestrationSubprocessFailedError>;
+  createOrReusePr(args: {
+    body: string;
+    cwd: string;
+    title: string;
+  }): Result<string, OrchestrationError>;
+  ensureWorktree(args: {
+    repoRoot: string;
+    worktreeName: string;
+  }): Result<string, OrchestrationSubprocessFailedError>;
+  getBranchName(args: { cwd: string }): Result<string, OrchestrationSubprocessFailedError>;
   getLatestCiRunId(args: { branchName: string; cwd: string }): string | null;
   getWorktreeStatus(args: { cwd: string }): string[];
   hasDependencies(args: { cwd: string }): boolean;
-  installDependencies(args: { cwd: string }): void;
+  installDependencies(args: { cwd: string }): Result<void, OrchestrationSubprocessFailedError>;
   notify(args: { body: string; enabled: boolean; title: string }): void;
-  pushBranch(args: { cwd: string }): void;
-  sendCodexInput(args: { cwd: string; jobId: string; prompt: string }): void;
+  pushBranch(args: { cwd: string }): Result<void, OrchestrationSubprocessFailedError>;
+  sendCodexInput(args: {
+    cwd: string;
+    jobId: string;
+    prompt: string;
+  }): Result<void, OrchestrationSubprocessFailedError>;
   startCodexJob(args: {
     cwd: string;
     model: string;
@@ -101,7 +127,7 @@ interface RunOrchestrationEnvironment {
     prompt: string;
     reasoning: ModelSelection['reasoning'];
     sandbox: 'read-only' | 'workspace-write';
-  }): string;
+  }): Result<string, OrchestrationSubprocessFailedError>;
   syncEnvFiles(args: { repoRoot: string; worktreePath: string }): void;
   watchCi(args: { cwd: string }): { output: string; success: boolean };
 }
@@ -336,24 +362,26 @@ function getRelevantWorktreeStatus({
   });
 }
 
-function assertWorktreeIsReady({
+function checkWorktreeIsReady({
   env,
   state,
 }: {
   env: RunOrchestrationEnvironment;
   state: RunState;
-}): void {
+}): Result<void, OrchestrationError> {
   const relevantStatus = getRelevantWorktreeStatus({ env, state });
   const hasMergeConflicts = relevantStatus.some(
     (line) => line.startsWith('UU ') || line.startsWith('AA ') || line.startsWith('DD '),
   );
   if (hasMergeConflicts) {
-    throw new Error(`Worktree has merge conflicts: ${state.worktreePath}`);
+    return err(OrchestrationErrors.worktreeMergeConflict(state.worktreePath));
   }
 
   if (relevantStatus.length > 0) {
-    throw new Error(`Worktree is dirty: ${state.worktreePath}`);
+    return err(OrchestrationErrors.worktreeDirty(state.worktreePath));
   }
+
+  return ok(undefined);
 }
 
 function syncChainFileIntoWorktree({
@@ -429,8 +457,10 @@ function bootstrapRunState({
   repoRoot: string;
   state: RunState;
   worktreeName: string;
-}): void {
-  state.worktreePath = env.ensureWorktree({ repoRoot, worktreeName });
+}): Result<void, OrchestrationError> {
+  const worktreeResult = env.ensureWorktree({ repoRoot, worktreeName });
+  if (worktreeResult.isErr()) return err(worktreeResult.error);
+  state.worktreePath = worktreeResult.value;
   env.syncEnvFiles({ repoRoot, worktreePath: state.worktreePath });
 
   const syncedChainPath = syncChainFileIntoWorktree({
@@ -443,11 +473,96 @@ function bootstrapRunState({
   }
 
   if (!env.hasDependencies({ cwd: state.worktreePath })) {
-    env.installDependencies({ cwd: state.worktreePath });
+    const installResult = env.installDependencies({ cwd: state.worktreePath });
+    if (installResult.isErr()) return err(installResult.error);
   }
 
-  state.branchName = env.getBranchName({ cwd: state.worktreePath });
-  assertWorktreeIsReady({ env, state });
+  const branchResult = env.getBranchName({ cwd: state.worktreePath });
+  if (branchResult.isErr()) return err(branchResult.error);
+  state.branchName = branchResult.value;
+
+  return checkWorktreeIsReady({ env, state });
+}
+
+/**
+ * One attempt at a codex job. The catch-IS-the-classifier pattern from the
+ * pre-Result implementation is preserved structurally: every subprocess
+ * failure inside the attempt is classified via `looksLikeTransientModelFailure`
+ * and surfaced as `ORCHESTRATION_MODEL_ATTEMPT { kind: 'transient' | 'fatal' }`.
+ * Job-id parse failures count as fatal — a malformed codex-agent CLI output
+ * isn't going to recover by re-running the same prompt.
+ *
+ * The `finally { closeCodexJob }` cleanup matches the original imperative
+ * shape; keeping it imperative is simpler than threading it through `.map`.
+ */
+function runOneModelAttempt({
+  candidate,
+  cwd,
+  env,
+  notifyOnComplete,
+  prompt,
+  sandbox,
+}: {
+  candidate: ModelSelection;
+  cwd: string;
+  env: RunOrchestrationEnvironment;
+  notifyOnComplete: boolean;
+  prompt: string;
+  sandbox: 'read-only' | 'workspace-write';
+}): Result<string, OrchestrationModelAttemptError> {
+  let jobId: string | null = null;
+
+  try {
+    const startResult = env.startCodexJob({
+      cwd,
+      model: candidate.model,
+      notifyOnComplete,
+      prompt,
+      reasoning: candidate.reasoning,
+      sandbox,
+    });
+    if (startResult.isErr()) {
+      const lastError = startResult.error.message;
+      return err(
+        OrchestrationErrors.modelAttempt({
+          kind: looksLikeTransientModelFailure({ output: lastError }) ? 'transient' : 'fatal',
+          lastError,
+        }),
+      );
+    }
+
+    const jobIdResult = parseCodexJobId({ output: startResult.value });
+    if (jobIdResult.isErr()) {
+      return err(
+        OrchestrationErrors.modelAttempt({ kind: 'fatal', lastError: jobIdResult.error.message }),
+      );
+    }
+    jobId = jobIdResult.value;
+
+    const awaitResult = env.awaitCodexTurn({ cwd, jobId });
+    env.closeCodexJob({ cwd, jobId });
+    jobId = null;
+    if (awaitResult.isErr()) {
+      const lastError = awaitResult.error.message;
+      return err(
+        OrchestrationErrors.modelAttempt({
+          kind: looksLikeTransientModelFailure({ output: lastError }) ? 'transient' : 'fatal',
+          lastError,
+        }),
+      );
+    }
+
+    const output = awaitResult.value;
+    if (looksLikeTransientModelFailure({ output })) {
+      return err(OrchestrationErrors.modelAttempt({ kind: 'transient', lastError: output }));
+    }
+
+    return ok(output);
+  } finally {
+    if (jobId !== null) {
+      env.closeCodexJob({ cwd, jobId });
+    }
+  }
 }
 
 function runCodexPromptWithFallback({
@@ -470,56 +585,46 @@ function runCodexPromptWithFallback({
   runDirectory: string;
   sandbox: 'read-only' | 'workspace-write';
   state: RunState;
-}): string {
+}): Result<string, OrchestrationError> {
   const attemptCount = bumpRetryCount({ key: retryKey, state }) - 1;
   const candidates = getModelCandidates({ attempts: attemptCount, kind });
   let lastError = '';
 
   for (const candidate of candidates) {
-    let jobId: string | null = null;
+    const attempt = runOneModelAttempt({
+      candidate,
+      cwd,
+      env,
+      notifyOnComplete,
+      prompt,
+      sandbox,
+    });
 
-    try {
-      const startOutput = env.startCodexJob({
-        cwd,
-        model: candidate.model,
-        notifyOnComplete,
-        prompt,
-        reasoning: candidate.reasoning,
-        sandbox,
-      });
-      const jobIdResult = parseCodexJobId({ output: startOutput });
-      if (jobIdResult.isErr()) throw new Error(jobIdResult.error.message);
-      jobId = jobIdResult.value;
-      const output = env.awaitCodexTurn({ cwd, jobId });
-      env.closeCodexJob({ cwd, jobId });
-      jobId = null;
-
-      if (looksLikeTransientModelFailure({ output })) {
-        lastError = output;
-        continue;
-      }
-
+    if (attempt.isOk()) {
       writeArtifact({
         filename: `${retryKey}-${candidate.model}.md`,
         runDirectory,
-        value: output,
+        value: attempt.value,
       });
-      return output;
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-      if (!looksLikeTransientModelFailure({ output: lastError })) {
-        throw error;
-      }
-    } finally {
-      if (jobId !== null) {
-        env.closeCodexJob({ cwd, jobId });
-      }
+      return ok(attempt.value);
     }
+
+    lastError = attempt.error.lastError;
+    if (attempt.error.kind === 'fatal') {
+      return err(attempt.error);
+    }
+    // transient → try next candidate
   }
 
-  throw new Error(`All model attempts failed for ${retryKey}.\n${lastError}`);
+  return err(OrchestrationErrors.allModelsFailed({ retryKey, lastError }));
 }
 
+/**
+ * The planning conversation has the same retry-loop structure as
+ * runCodexPromptWithFallback but with an additional follow-up loop: after
+ * the initial plan, each `codex-send` step issues another prompt into the
+ * same job. Every follow-up step is also classified by transient/fatal.
+ */
 function runPlanningConversationWithFallback({
   chain,
   env,
@@ -530,10 +635,10 @@ function runPlanningConversationWithFallback({
   env: RunOrchestrationEnvironment;
   runDirectory: string;
   state: RunState;
-}): { finalPlan: string; initialPlan: string } {
+}): Result<{ finalPlan: string; initialPlan: string }, OrchestrationError> {
   const planStep = chain.steps.find((step) => step.role === 'codex-plan');
   if (!planStep?.promptTemplate) {
-    throw new Error(`Missing codex-plan prompt in chain: ${chain.chainPath}`);
+    return err(OrchestrationErrors.missingPlanPrompt(chain.chainPath));
   }
 
   const sendSteps = chain.steps.filter(
@@ -548,71 +653,153 @@ function runPlanningConversationWithFallback({
   let lastError = '';
 
   for (const candidate of candidates) {
-    let jobId: string | null = null;
+    const attemptResult = runOnePlanningAttempt({
+      candidate,
+      chain,
+      env,
+      initialPrompt,
+      runDirectory,
+      sendSteps,
+      state,
+    });
 
-    try {
-      const startOutput = env.startCodexJob({
-        cwd: state.worktreePath,
-        model: candidate.model,
-        notifyOnComplete: false,
-        prompt: initialPrompt,
-        reasoning: candidate.reasoning,
-        sandbox: 'read-only',
+    if (attemptResult.isOk()) {
+      return ok(attemptResult.value);
+    }
+
+    lastError = attemptResult.error.lastError;
+    if (attemptResult.error.kind === 'fatal') {
+      return err(attemptResult.error);
+    }
+    // transient → try next candidate
+  }
+
+  return err(OrchestrationErrors.allModelsFailed({ retryKey: 'planner-main', lastError }));
+}
+
+function runOnePlanningAttempt({
+  candidate,
+  chain,
+  env,
+  initialPrompt,
+  runDirectory,
+  sendSteps,
+  state,
+}: {
+  candidate: ModelSelection;
+  chain: ParsedChain;
+  env: RunOrchestrationEnvironment;
+  initialPrompt: string;
+  runDirectory: string;
+  sendSteps: ParsedChain['steps'];
+  state: RunState;
+}): Result<{ finalPlan: string; initialPlan: string }, OrchestrationModelAttemptError> {
+  let jobId: string | null = null;
+
+  try {
+    const startResult = env.startCodexJob({
+      cwd: state.worktreePath,
+      model: candidate.model,
+      notifyOnComplete: false,
+      prompt: initialPrompt,
+      reasoning: candidate.reasoning,
+      sandbox: 'read-only',
+    });
+    if (startResult.isErr()) {
+      const lastError = startResult.error.message;
+      return err(
+        OrchestrationErrors.modelAttempt({
+          kind: looksLikeTransientModelFailure({ output: lastError }) ? 'transient' : 'fatal',
+          lastError,
+        }),
+      );
+    }
+
+    const jobIdResult = parseCodexJobId({ output: startResult.value });
+    if (jobIdResult.isErr()) {
+      return err(
+        OrchestrationErrors.modelAttempt({ kind: 'fatal', lastError: jobIdResult.error.message }),
+      );
+    }
+    jobId = jobIdResult.value;
+
+    const initialPlanResult = env.awaitCodexTurn({ cwd: state.worktreePath, jobId });
+    if (initialPlanResult.isErr()) {
+      const lastError = initialPlanResult.error.message;
+      return err(
+        OrchestrationErrors.modelAttempt({
+          kind: looksLikeTransientModelFailure({ output: lastError }) ? 'transient' : 'fatal',
+          lastError,
+        }),
+      );
+    }
+    const initialPlan = initialPlanResult.value;
+    if (looksLikeTransientModelFailure({ output: initialPlan })) {
+      return err(OrchestrationErrors.modelAttempt({ kind: 'transient', lastError: initialPlan }));
+    }
+
+    writeArtifact({
+      filename: `planner-main-step-0-${candidate.model}.md`,
+      runDirectory,
+      value: initialPlan,
+    });
+
+    let finalPlan = initialPlan;
+    const activeJobId = jobId;
+    for (let index = 0; index < sendSteps.length; index += 1) {
+      const step = sendSteps[index];
+      if (!step) continue;
+      const prompt = interpolateTemplate({
+        template: step.promptTemplate ?? '',
+        variables: chain.variables,
       });
-      const jobIdResult = parseCodexJobId({ output: startOutput });
-      if (jobIdResult.isErr()) throw new Error(jobIdResult.error.message);
-      jobId = jobIdResult.value;
 
-      const initialPlan = env.awaitCodexTurn({ cwd: state.worktreePath, jobId });
-      if (looksLikeTransientModelFailure({ output: initialPlan })) {
-        lastError = initialPlan;
-        env.closeCodexJob({ cwd: state.worktreePath, jobId });
-        jobId = null;
-        continue;
+      const sendResult = env.sendCodexInput({
+        cwd: state.worktreePath,
+        jobId: activeJobId,
+        prompt,
+      });
+      if (sendResult.isErr()) {
+        const lastError = sendResult.error.message;
+        return err(
+          OrchestrationErrors.modelAttempt({
+            kind: looksLikeTransientModelFailure({ output: lastError }) ? 'transient' : 'fatal',
+            lastError,
+          }),
+        );
+      }
+
+      const awaitResult = env.awaitCodexTurn({ cwd: state.worktreePath, jobId: activeJobId });
+      if (awaitResult.isErr()) {
+        const lastError = awaitResult.error.message;
+        return err(
+          OrchestrationErrors.modelAttempt({
+            kind: looksLikeTransientModelFailure({ output: lastError }) ? 'transient' : 'fatal',
+            lastError,
+          }),
+        );
+      }
+      finalPlan = awaitResult.value;
+
+      if (looksLikeTransientModelFailure({ output: finalPlan })) {
+        return err(OrchestrationErrors.modelAttempt({ kind: 'transient', lastError: finalPlan }));
       }
 
       writeArtifact({
-        filename: `planner-main-step-0-${candidate.model}.md`,
+        filename: `planner-main-step-${index + 1}-${candidate.model}.md`,
         runDirectory,
-        value: initialPlan,
+        value: finalPlan,
       });
+    }
 
-      let finalPlan = initialPlan;
-      const activeJobId = jobId;
-      sendSteps.forEach((step, index) => {
-        const prompt = interpolateTemplate({
-          template: step.promptTemplate ?? '',
-          variables: chain.variables,
-        });
-        env.sendCodexInput({ cwd: state.worktreePath, jobId: activeJobId, prompt });
-        finalPlan = env.awaitCodexTurn({ cwd: state.worktreePath, jobId: activeJobId });
-        if (looksLikeTransientModelFailure({ output: finalPlan })) {
-          throw new Error(finalPlan);
-        }
-
-        writeArtifact({
-          filename: `planner-main-step-${index + 1}-${candidate.model}.md`,
-          runDirectory,
-          value: finalPlan,
-        });
-      });
-
+    env.closeCodexJob({ cwd: state.worktreePath, jobId });
+    jobId = null;
+    return ok({ finalPlan, initialPlan });
+  } finally {
+    if (jobId !== null) {
       env.closeCodexJob({ cwd: state.worktreePath, jobId });
-      jobId = null;
-      return { finalPlan, initialPlan };
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-      if (!looksLikeTransientModelFailure({ output: lastError })) {
-        throw error;
-      }
-    } finally {
-      if (jobId !== null) {
-        env.closeCodexJob({ cwd: state.worktreePath, jobId });
-      }
     }
   }
-
-  throw new Error(`All model attempts failed for planner-main.\n${lastError}`);
 }
 
 function runPlanningPhase({
@@ -625,17 +812,23 @@ function runPlanningPhase({
   env: RunOrchestrationEnvironment;
   runDirectory: string;
   state: RunState;
-}): string {
+}): Result<string, OrchestrationError> {
   advancePhase({ state, target: 'planning' });
   const cachedPlan = readArtifact({ filename: FINAL_PLAN_FILENAME, runDirectory });
   if (cachedPlan) {
-    return cachedPlan;
+    return ok(cachedPlan);
   }
 
   const planningResult = runPlanningConversationWithFallback({ chain, env, runDirectory, state });
-  writeArtifact({ filename: FINAL_PLAN_FILENAME, runDirectory, value: planningResult.finalPlan });
-  state.plannerOutputs['planner-main'] = planningResult.initialPlan;
-  return planningResult.finalPlan;
+  if (planningResult.isErr()) return err(planningResult.error);
+
+  writeArtifact({
+    filename: FINAL_PLAN_FILENAME,
+    runDirectory,
+    value: planningResult.value.finalPlan,
+  });
+  state.plannerOutputs['planner-main'] = planningResult.value.initialPlan;
+  return ok(planningResult.value.finalPlan);
 }
 
 function runImplementationPhase({
@@ -650,15 +843,15 @@ function runImplementationPhase({
   profile: ChainProfile;
   runDirectory: string;
   state: RunState;
-}): void {
+}): Result<void, OrchestrationError> {
   advancePhase({ state, target: 'implementation' });
 
-  profile.implementationSlices.forEach((slice) => {
+  for (const slice of profile.implementationSlices) {
     if (state.completedSlices.includes(slice.id)) {
-      return;
+      continue;
     }
 
-    const output = runCodexPromptWithFallback({
+    const outputResult = runCodexPromptWithFallback({
       cwd: state.worktreePath,
       env,
       kind: 'implementation',
@@ -674,23 +867,23 @@ function runImplementationPhase({
       sandbox: 'workspace-write',
       state,
     });
+    if (outputResult.isErr()) return err(outputResult.error);
 
+    const output = outputResult.value;
     state.implementationOutputs[slice.id] = output;
     writeArtifact({ filename: `${slice.id}.md`, runDirectory, value: output });
 
-    if (
-      env.commitAll({
-        cwd: state.worktreePath,
-        ignoredPaths: state.ignoredWorktreeRelativePaths,
-        message: slice.commitMessage,
-      })
-    ) {
-      state.completedSlices.push(slice.id);
-      return;
-    }
+    const commitResult = env.commitAll({
+      cwd: state.worktreePath,
+      ignoredPaths: state.ignoredWorktreeRelativePaths,
+      message: slice.commitMessage,
+    });
+    if (commitResult.isErr()) return err(commitResult.error);
 
     state.completedSlices.push(slice.id);
-  });
+  }
+
+  return ok(undefined);
 }
 
 function ensurePr({
@@ -701,14 +894,16 @@ function ensurePr({
   chain: ParsedChain;
   env: RunOrchestrationEnvironment;
   state: RunState;
-}): string {
+}): Result<string, OrchestrationError> {
   advancePhase({ state, target: 'pr' });
   if (state.prUrl) {
-    return state.prUrl;
+    return ok(state.prUrl);
   }
 
-  env.pushBranch({ cwd: state.worktreePath });
-  const prUrl = env.createOrReusePr({
+  const pushResult = env.pushBranch({ cwd: state.worktreePath });
+  if (pushResult.isErr()) return err(pushResult.error);
+
+  const prResult = env.createOrReusePr({
     body: buildPrBody({
       chainPath: chain.chainPath,
       chainTitle: chain.title,
@@ -717,8 +912,10 @@ function ensurePr({
     cwd: state.worktreePath,
     title: chain.title,
   });
-  state.prUrl = prUrl;
-  return prUrl;
+  if (prResult.isErr()) return err(prResult.error);
+
+  state.prUrl = prResult.value;
+  return ok(prResult.value);
 }
 
 function runReviewPhase({
@@ -733,29 +930,31 @@ function runReviewPhase({
   finalPlan: string;
   runDirectory: string;
   state: RunState;
-}): void {
+}): Result<void, OrchestrationError> {
   advancePhase({ state, target: 'review' });
   const reviewStep = chain.steps.find((step) => step.role === 'codex-review');
   if (!reviewStep?.promptTemplate || !state.prUrl) {
-    return;
+    return ok(undefined);
   }
 
   // Early-exit when resuming a run whose last review already passed — avoids
   // re-spawning a review agent against an already-clean PR after a crash
   // between review-success and ci-start.
   if (state.lastReviewOutput && isSuccessfulReview({ reviewOutput: state.lastReviewOutput })) {
-    return;
+    return ok(undefined);
   }
 
   for (;;) {
     if (state.reviewAttempts >= MAX_REVIEW_ATTEMPTS) {
-      throw new Error(
-        `Review loop did not converge after ${MAX_REVIEW_ATTEMPTS} attempts. ` +
-          `Inspect ${runDirectory}/artifacts/review-${state.reviewAttempts}.md and either resume with --restart, fix the chain, or address findings manually.`,
+      return err(
+        OrchestrationErrors.reviewNotConverged({
+          attempts: state.reviewAttempts,
+          runDirectory,
+        }),
       );
     }
 
-    const reviewOutput = runCodexPromptWithFallback({
+    const reviewResult = runCodexPromptWithFallback({
       cwd: state.worktreePath,
       env,
       kind: 'review',
@@ -770,6 +969,8 @@ function runReviewPhase({
       sandbox: 'read-only',
       state,
     });
+    if (reviewResult.isErr()) return err(reviewResult.error);
+    const reviewOutput = reviewResult.value;
 
     state.reviewAttempts += 1;
     state.reviewOutputs.push(reviewOutput);
@@ -781,10 +982,10 @@ function runReviewPhase({
     });
 
     if (isSuccessfulReview({ reviewOutput })) {
-      return;
+      return ok(undefined);
     }
 
-    const fixOutput = runCodexPromptWithFallback({
+    const fixResult = runCodexPromptWithFallback({
       cwd: state.worktreePath,
       env,
       kind: 'implementation',
@@ -799,18 +1000,24 @@ function runReviewPhase({
       sandbox: 'workspace-write',
       state,
     });
+    if (fixResult.isErr()) return err(fixResult.error);
+    const fixOutput = fixResult.value;
 
     writeArtifact({
       filename: `review-fix-${state.reviewAttempts}.md`,
       runDirectory,
       value: fixOutput,
     });
-    env.commitAll({
+
+    const commitResult = env.commitAll({
       cwd: state.worktreePath,
       ignoredPaths: state.ignoredWorktreeRelativePaths,
       message: `fix: address codex review findings ${state.reviewAttempts}`,
     });
-    env.pushBranch({ cwd: state.worktreePath });
+    if (commitResult.isErr()) return err(commitResult.error);
+
+    const pushResult = env.pushBranch({ cwd: state.worktreePath });
+    if (pushResult.isErr()) return err(pushResult.error);
   }
 }
 
@@ -824,14 +1031,16 @@ function runCiPhase({
   finalPlan: string;
   runDirectory: string;
   state: RunState;
-}): void {
+}): Result<void, OrchestrationError> {
   advancePhase({ state, target: 'ci' });
 
   for (;;) {
     if (state.ciAttempts >= MAX_CI_ATTEMPTS) {
-      throw new Error(
-        `CI loop did not converge after ${MAX_CI_ATTEMPTS} attempts. ` +
-          `Inspect ${runDirectory}/artifacts/ci-watch-${state.ciAttempts}.md and either resume with --restart, fix the chain, or address failures manually.`,
+      return err(
+        OrchestrationErrors.ciNotConverged({
+          attempts: state.ciAttempts,
+          runDirectory,
+        }),
       );
     }
 
@@ -844,7 +1053,7 @@ function runCiPhase({
     });
 
     if (ciResult.success) {
-      return;
+      return ok(undefined);
     }
 
     const latestRunId =
@@ -852,10 +1061,10 @@ function runCiPhase({
         ? null
         : env.getLatestCiRunId({ branchName: state.branchName, cwd: state.worktreePath });
     if (latestRunId === null) {
-      throw new Error('CI failed but no GitHub run id could be resolved for diagnosis.');
+      return err(OrchestrationErrors.ciRunIdMissing());
     }
 
-    const diagnosisOutput = runCodexPromptWithFallback({
+    const diagnosisResult = runCodexPromptWithFallback({
       cwd: state.worktreePath,
       env,
       kind: 'diagnosis',
@@ -869,6 +1078,8 @@ function runCiPhase({
       sandbox: 'read-only',
       state,
     });
+    if (diagnosisResult.isErr()) return err(diagnosisResult.error);
+    const diagnosisOutput = diagnosisResult.value;
 
     writeArtifact({
       filename: `ci-diagnosis-${state.ciAttempts}.md`,
@@ -876,7 +1087,7 @@ function runCiPhase({
       value: diagnosisOutput,
     });
 
-    const fixOutput = runCodexPromptWithFallback({
+    const fixResult = runCodexPromptWithFallback({
       cwd: state.worktreePath,
       env,
       kind: 'implementation',
@@ -891,14 +1102,20 @@ function runCiPhase({
       sandbox: 'workspace-write',
       state,
     });
+    if (fixResult.isErr()) return err(fixResult.error);
+    const fixOutput = fixResult.value;
 
     writeArtifact({ filename: `ci-fix-${state.ciAttempts}.md`, runDirectory, value: fixOutput });
-    env.commitAll({
+
+    const commitResult = env.commitAll({
       cwd: state.worktreePath,
       ignoredPaths: state.ignoredWorktreeRelativePaths,
       message: `fix: address ci failures ${state.ciAttempts}`,
     });
-    env.pushBranch({ cwd: state.worktreePath });
+    if (commitResult.isErr()) return err(commitResult.error);
+
+    const pushResult = env.pushBranch({ cwd: state.worktreePath });
+    if (pushResult.isErr()) return err(pushResult.error);
   }
 }
 
@@ -981,22 +1198,27 @@ function logResumeState({
   console.log('');
 }
 
-function resolveChainContext({ chainInputPath }: { chainInputPath: string }): {
-  chain: ParsedChain;
-  profile: ChainProfile;
-  repoRoot: string;
-  runDirectory: string;
-  runSlug: string;
-  stateFilePath: string;
-  worktreePath: string;
-  worktreeName: string;
-} {
-  const repoRoot = findMonorepoRoot();
+function resolveChainContext({ chainInputPath }: { chainInputPath: string }): Result<
+  {
+    chain: ParsedChain;
+    profile: ChainProfile;
+    repoRoot: string;
+    runDirectory: string;
+    runSlug: string;
+    stateFilePath: string;
+    worktreePath: string;
+    worktreeName: string;
+  },
+  OrchestrationError | MonorepoRootNotFoundError
+> {
+  const repoRootResult = findMonorepoRoot();
+  if (repoRootResult.isErr()) return err(repoRootResult.error);
+  const repoRoot = repoRootResult.value;
   const worktreesRoot = resolveWorktreesRoot({ repoRoot });
   const chainPath = resolveChainPath({ inputPath: chainInputPath, repoRoot });
   const markdown = fs.readFileSync(chainPath, 'utf8');
   const chainResult = parseOrchestrationChain({ chainPath, markdown });
-  if (chainResult.isErr()) throw new Error(chainResult.error.message);
+  if (chainResult.isErr()) return err(chainResult.error);
   const chain = chainResult.value;
   const profile = getProfile({ profileId: resolveProfileId() });
   const worktreeName = resolveWorktreeName({ chain });
@@ -1004,7 +1226,7 @@ function resolveChainContext({ chainInputPath }: { chainInputPath: string }): {
   const runSlug = resolveRunSlug({ chainPath, repoRoot });
   const runDirectory = getRunDirectory({ runSlug });
 
-  return {
+  return ok({
     chain,
     profile,
     repoRoot,
@@ -1013,7 +1235,7 @@ function resolveChainContext({ chainInputPath }: { chainInputPath: string }): {
     stateFilePath: getStateFilePath({ runDirectory }),
     worktreeName,
     worktreePath,
-  };
+  });
 }
 
 export async function prepareOrchestration({
@@ -1022,11 +1244,11 @@ export async function prepareOrchestration({
 }: {
   env?: RunOrchestrationEnvironment | undefined;
   options: PrepareOrchestrationOptions;
-}): Promise<void> {
+}): Promise<Result<void, OrchestrationError | MonorepoRootNotFoundError>> {
+  const contextResult = resolveChainContext({ chainInputPath: options.chainInputPath });
+  if (contextResult.isErr()) return err(contextResult.error);
   const { chain, runDirectory, stateFilePath, runSlug, worktreePath, worktreeName, repoRoot } =
-    resolveChainContext({
-      chainInputPath: options.chainInputPath,
-    });
+    contextResult.value;
 
   if (options.restart && fs.existsSync(runDirectory)) {
     fs.rmSync(runDirectory, { force: true, recursive: true });
@@ -1043,7 +1265,8 @@ export async function prepareOrchestration({
 
   ensureRunDirectories({ runDirectory });
   state.executor = options.executor;
-  bootstrapRunState({ env, repoRoot, state, worktreeName });
+  const bootstrapResult = bootstrapRunState({ env, repoRoot, state, worktreeName });
+  if (bootstrapResult.isErr()) return err(bootstrapResult.error);
   saveState({ runDirectory, state });
   logResumeState({ hasExistingState, state });
 
@@ -1075,6 +1298,8 @@ export async function prepareOrchestration({
   if (manifest.reviewPromptTemplateFile !== null) {
     console.log(`${BLUE}Review prompt template:${NC} ${manifest.reviewPromptTemplateFile}`);
   }
+
+  return ok(undefined);
 }
 
 export async function runOrchestration({
@@ -1083,8 +1308,10 @@ export async function runOrchestration({
 }: {
   env?: RunOrchestrationEnvironment | undefined;
   options: RunOrchestrationOptions;
-}): Promise<void> {
+}): Promise<Result<void, OrchestrationError | MonorepoRootNotFoundError>> {
   const executor = options.executor;
+  const contextResult = resolveChainContext({ chainInputPath: options.chainInputPath });
+  if (contextResult.isErr()) return err(contextResult.error);
   const {
     chain,
     profile,
@@ -1094,9 +1321,7 @@ export async function runOrchestration({
     runSlug,
     worktreePath,
     worktreeName,
-  } = resolveChainContext({
-    chainInputPath: options.chainInputPath,
-  });
+  } = contextResult.value;
 
   if (options.restart && fs.existsSync(runDirectory)) {
     fs.rmSync(runDirectory, { force: true, recursive: true });
@@ -1113,12 +1338,13 @@ export async function runOrchestration({
 
   if (options.dryRun) {
     console.log(formatDryRunPlan({ chain, executor, profile }));
-    return;
+    return ok(undefined);
   }
 
   ensureRunDirectories({ runDirectory });
   state.executor = executor;
-  bootstrapRunState({ env, repoRoot, state, worktreeName });
+  const bootstrapResult = bootstrapRunState({ env, repoRoot, state, worktreeName });
+  if (bootstrapResult.isErr()) return err(bootstrapResult.error);
   saveState({ runDirectory, state });
   logResumeState({ hasExistingState, state });
 
@@ -1127,12 +1353,14 @@ export async function runOrchestration({
       `${YELLOW}Run already paused at manual QA:${NC} ${GREEN}${state.prUrl ?? '(no PR URL)'}${NC}`,
     );
     console.log(buildStateSummary({ state }));
-    return;
+    return ok(undefined);
   }
 
   // Planning is always called: it returns the cached plan when present and
   // advancePhase() prevents it from regressing state.phase on a resumed run.
-  const finalPlan = runPlanningPhase({ chain, env, runDirectory, state });
+  const planResult = runPlanningPhase({ chain, env, runDirectory, state });
+  if (planResult.isErr()) return err(planResult.error);
+  const finalPlan = planResult.value;
   saveState({ runDirectory, state });
 
   // Skip phases that have already completed on a previous run. The phase
@@ -1141,22 +1369,26 @@ export async function runOrchestration({
   // lastReviewOutput already passed), but gating here also avoids the
   // overhead of re-entering them.
   if (phaseIndex(state.phase) <= phaseIndex('implementation')) {
-    runImplementationPhase({ env, finalPlan, profile, runDirectory, state });
+    const implResult = runImplementationPhase({ env, finalPlan, profile, runDirectory, state });
+    if (implResult.isErr()) return err(implResult.error);
     saveState({ runDirectory, state });
   }
 
   if (phaseIndex(state.phase) <= phaseIndex('pr')) {
-    ensurePr({ chain, env, state });
+    const prResult = ensurePr({ chain, env, state });
+    if (prResult.isErr()) return err(prResult.error);
     saveState({ runDirectory, state });
   }
 
   if (phaseIndex(state.phase) <= phaseIndex('review')) {
-    runReviewPhase({ chain, env, finalPlan, runDirectory, state });
+    const reviewResult = runReviewPhase({ chain, env, finalPlan, runDirectory, state });
+    if (reviewResult.isErr()) return err(reviewResult.error);
     saveState({ runDirectory, state });
   }
 
   if (phaseIndex(state.phase) <= phaseIndex('ci')) {
-    runCiPhase({ env, finalPlan, runDirectory, state });
+    const ciResult = runCiPhase({ env, finalPlan, runDirectory, state });
+    if (ciResult.isErr()) return err(ciResult.error);
   }
 
   advancePhase({ state, target: 'awaiting_manual_qa' });
@@ -1173,6 +1405,8 @@ export async function runOrchestration({
   console.log(`${BLUE}PR:${NC} ${state.prUrl ?? '(not created)'}`);
   console.log(`${BLUE}State:${NC} ${stateFilePath}`);
   console.log(`${YELLOW}Next:${NC} final review + manual staging QA`);
+
+  return ok(undefined);
 }
 
 function runProcess({
@@ -1236,20 +1470,46 @@ function collectEnvFiles({
   }
 }
 
+function runProcessAsResult({
+  args,
+  captureOutput,
+  command,
+  cwd,
+  env,
+}: {
+  args: string[];
+  captureOutput?: boolean;
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+}): Result<string, OrchestrationSubprocessFailedError> {
+  const opts: Parameters<typeof runProcess>[0] = { args, command, cwd };
+  if (captureOutput !== undefined) opts.captureOutput = captureOutput;
+  if (env !== undefined) opts.env = env;
+  const result = runProcess(opts);
+  if (result.exitCode !== 0) {
+    return err(
+      OrchestrationErrors.subprocessFailed({
+        command,
+        args,
+        cwd,
+        exitCode: result.exitCode,
+        output: result.output,
+      }),
+    );
+  }
+  return ok(result.output);
+}
+
 function createDefaultEnvironment(): RunOrchestrationEnvironment {
   return {
-    awaitCodexTurn: ({ cwd, jobId }) => {
-      const result = runProcess({
+    awaitCodexTurn: ({ cwd, jobId }) =>
+      runProcessAsResult({
         args: ['await-turn', jobId],
         command: 'codex-agent',
         cwd,
         env: getAugmentedPathEnv(),
-      });
-      if (result.exitCode !== 0) {
-        throw new Error(result.output);
-      }
-      return result.output;
-    },
+      }),
     closeCodexJob: ({ cwd, jobId }) => {
       runProcess({
         args: ['send', jobId, '/quit'],
@@ -1274,7 +1534,7 @@ function createDefaultEnvironment(): RunOrchestrationEnvironment {
         });
 
       if (relevantStatus.length === 0) {
-        return false;
+        return ok(false);
       }
 
       const addArgs = ['add', '-A', '--', '.'];
@@ -1282,26 +1542,23 @@ function createDefaultEnvironment(): RunOrchestrationEnvironment {
         addArgs.push(`:(exclude)${ignoredPath}`);
       });
 
-      const addResult = runProcess({
+      const addResult = runProcessAsResult({
         args: addArgs,
         captureOutput: false,
         command: 'git',
         cwd,
       });
-      if (addResult.exitCode !== 0) {
-        throw new Error('Failed to stage changes before commit.');
-      }
+      if (addResult.isErr()) return err(addResult.error);
 
-      const commitResult = runProcess({
+      const commitResult = runProcessAsResult({
         args: ['commit', '-m', message],
         captureOutput: false,
         command: 'git',
         cwd,
       });
-      if (commitResult.exitCode !== 0) {
-        throw new Error(`Failed to commit changes: ${message}`);
-      }
-      return true;
+      if (commitResult.isErr()) return err(commitResult.error);
+
+      return ok(true);
     },
     createOrReusePr: ({ body, cwd, title }) => {
       const existingPr = runProcess({
@@ -1310,48 +1567,43 @@ function createDefaultEnvironment(): RunOrchestrationEnvironment {
         cwd,
       });
       if (existingPr.exitCode === 0 && existingPr.output.trim()) {
-        return existingPr.output.trim();
+        return ok(existingPr.output.trim());
       }
 
-      const createdPr = runProcess({
+      const createdResult = runProcessAsResult({
         args: ['pr', 'create', '--title', title, '--body', body],
         command: 'gh',
         cwd,
       });
-      if (createdPr.exitCode !== 0) {
-        throw new Error(createdPr.output);
-      }
-      const prUrlResult = parsePullRequestUrl({ output: createdPr.output });
-      if (prUrlResult.isErr()) throw new Error(prUrlResult.error.message);
-      return prUrlResult.value;
+      if (createdResult.isErr()) return err(createdResult.error);
+
+      const prUrlResult = parsePullRequestUrl({ output: createdResult.value });
+      if (prUrlResult.isErr()) return err(prUrlResult.error);
+      return ok(prUrlResult.value);
     },
     ensureWorktree: ({ repoRoot, worktreeName }) => {
       const worktreePath = path.join(resolveWorktreesRoot({ repoRoot }), worktreeName);
       if (fs.existsSync(worktreePath)) {
-        return worktreePath;
+        return ok(worktreePath);
       }
 
-      const result = runProcess({
+      const result = runProcessAsResult({
         args: ['cli', 'worktree-new', worktreeName],
         captureOutput: false,
         command: 'pnpm',
         cwd: repoRoot,
       });
-      if (result.exitCode !== 0) {
-        throw new Error(`Failed to create worktree ${worktreeName}`);
-      }
-      return worktreePath;
+      if (result.isErr()) return err(result.error);
+      return ok(worktreePath);
     },
     getBranchName: ({ cwd }) => {
-      const result = runProcess({
+      const result = runProcessAsResult({
         args: ['branch', '--show-current'],
         command: 'git',
         cwd,
       });
-      if (result.exitCode !== 0) {
-        throw new Error(`Failed to determine current branch for ${cwd}`);
-      }
-      return result.output.trim();
+      if (result.isErr()) return err(result.error);
+      return ok(result.value.trim());
     },
     getLatestCiRunId: ({ branchName, cwd }) => {
       const result = runProcess({
@@ -1380,15 +1632,14 @@ function createDefaultEnvironment(): RunOrchestrationEnvironment {
     },
     hasDependencies: ({ cwd }) => fs.existsSync(path.join(cwd, 'node_modules')),
     installDependencies: ({ cwd }) => {
-      const result = runProcess({
+      const result = runProcessAsResult({
         args: ['install', '--frozen-lockfile'],
         captureOutput: false,
         command: 'pnpm',
         cwd,
       });
-      if (result.exitCode !== 0) {
-        throw new Error(`Failed to install dependencies in ${cwd}`);
-      }
+      if (result.isErr()) return err(result.error);
+      return ok(undefined);
     },
     notify: ({ body, enabled, title }) => {
       if (!enabled) {
@@ -1401,26 +1652,24 @@ function createDefaultEnvironment(): RunOrchestrationEnvironment {
       });
     },
     pushBranch: ({ cwd }) => {
-      const result = runProcess({
+      const result = runProcessAsResult({
         args: ['push', '-u', 'origin', 'HEAD'],
         captureOutput: false,
         command: 'git',
         cwd,
       });
-      if (result.exitCode !== 0) {
-        throw new Error(`Failed to push branch from ${cwd}`);
-      }
+      if (result.isErr()) return err(result.error);
+      return ok(undefined);
     },
     sendCodexInput: ({ cwd, jobId, prompt }) => {
-      const result = runProcess({
+      const result = runProcessAsResult({
         args: ['send', jobId, prompt],
         command: 'codex-agent',
         cwd,
         env: getAugmentedPathEnv(),
       });
-      if (result.exitCode !== 0) {
-        throw new Error(result.output);
-      }
+      if (result.isErr()) return err(result.error);
+      return ok(undefined);
     },
     startCodexJob: ({ cwd, model, notifyOnComplete, prompt, reasoning, sandbox }) => {
       const args = [
@@ -1440,16 +1689,12 @@ function createDefaultEnvironment(): RunOrchestrationEnvironment {
         args.push('--notify-on-complete', 'cmux notify --title "Codex" --body "Agent ready"');
       }
 
-      const result = runProcess({
+      return runProcessAsResult({
         args,
         command: 'codex-agent',
         cwd,
         env: getAugmentedPathEnv(),
       });
-      if (result.exitCode !== 0) {
-        throw new Error(result.output);
-      }
-      return result.output;
     },
     syncEnvFiles: ({ repoRoot, worktreePath }) => {
       const envFiles: string[] = [];

--- a/packages/cli-tools/src/orchestration/runtime.ts
+++ b/packages/cli-tools/src/orchestration/runtime.ts
@@ -487,7 +487,9 @@ function runCodexPromptWithFallback({
         reasoning: candidate.reasoning,
         sandbox,
       });
-      jobId = parseCodexJobId({ output: startOutput });
+      const jobIdResult = parseCodexJobId({ output: startOutput });
+      if (jobIdResult.isErr()) throw new Error(jobIdResult.error.message);
+      jobId = jobIdResult.value;
       const output = env.awaitCodexTurn({ cwd, jobId });
       env.closeCodexJob({ cwd, jobId });
       jobId = null;
@@ -557,7 +559,9 @@ function runPlanningConversationWithFallback({
         reasoning: candidate.reasoning,
         sandbox: 'read-only',
       });
-      jobId = parseCodexJobId({ output: startOutput });
+      const jobIdResult = parseCodexJobId({ output: startOutput });
+      if (jobIdResult.isErr()) throw new Error(jobIdResult.error.message);
+      jobId = jobIdResult.value;
 
       const initialPlan = env.awaitCodexTurn({ cwd: state.worktreePath, jobId });
       if (looksLikeTransientModelFailure({ output: initialPlan })) {
@@ -991,7 +995,9 @@ function resolveChainContext({ chainInputPath }: { chainInputPath: string }): {
   const worktreesRoot = resolveWorktreesRoot({ repoRoot });
   const chainPath = resolveChainPath({ inputPath: chainInputPath, repoRoot });
   const markdown = fs.readFileSync(chainPath, 'utf8');
-  const chain = parseOrchestrationChain({ chainPath, markdown });
+  const chainResult = parseOrchestrationChain({ chainPath, markdown });
+  if (chainResult.isErr()) throw new Error(chainResult.error.message);
+  const chain = chainResult.value;
   const profile = getProfile({ profileId: resolveProfileId() });
   const worktreeName = resolveWorktreeName({ chain });
   const worktreePath = path.join(worktreesRoot, worktreeName);
@@ -1315,7 +1321,9 @@ function createDefaultEnvironment(): RunOrchestrationEnvironment {
       if (createdPr.exitCode !== 0) {
         throw new Error(createdPr.output);
       }
-      return parsePullRequestUrl({ output: createdPr.output });
+      const prUrlResult = parsePullRequestUrl({ output: createdPr.output });
+      if (prUrlResult.isErr()) throw new Error(prUrlResult.error.message);
+      return prUrlResult.value;
     },
     ensureWorktree: ({ repoRoot, worktreeName }) => {
       const worktreePath = path.join(resolveWorktreesRoot({ repoRoot }), worktreeName);

--- a/packages/cli-tools/src/worktree/errors.ts
+++ b/packages/cli-tools/src/worktree/errors.ts
@@ -1,0 +1,58 @@
+/**
+ * Errors that can arise from the worktree-new subcommand.
+ *
+ * `exitCode` is carried on every variant so the CLI boundary can pass it
+ * straight to `process.exit(...)` without re-deriving it from the
+ * discriminant.
+ */
+
+import type { BaseError } from '@slopweaver/errors';
+
+export interface WorktreeInvalidNameError extends BaseError {
+  readonly code: 'WORKTREE_INVALID_NAME';
+  readonly exitCode: number;
+}
+
+export interface WorktreeGitFetchFailedError extends BaseError {
+  readonly code: 'WORKTREE_GIT_FETCH_FAILED';
+  readonly exitCode: number;
+}
+
+export interface WorktreeGitAddFailedError extends BaseError {
+  readonly code: 'WORKTREE_GIT_ADD_FAILED';
+  readonly exitCode: number;
+}
+
+export interface WorktreePnpmInstallFailedError extends BaseError {
+  readonly code: 'WORKTREE_PNPM_INSTALL_FAILED';
+  readonly exitCode: number;
+}
+
+export type WorktreeError =
+  | WorktreeInvalidNameError
+  | WorktreeGitFetchFailedError
+  | WorktreeGitAddFailedError
+  | WorktreePnpmInstallFailedError;
+
+export const WorktreeErrors = {
+  invalidName: (message: string): WorktreeInvalidNameError => ({
+    code: 'WORKTREE_INVALID_NAME',
+    message,
+    exitCode: 1,
+  }),
+  gitFetchFailed: (exitCode: number): WorktreeGitFetchFailedError => ({
+    code: 'WORKTREE_GIT_FETCH_FAILED',
+    message: 'git fetch origin main failed',
+    exitCode,
+  }),
+  gitAddFailed: (exitCode: number): WorktreeGitAddFailedError => ({
+    code: 'WORKTREE_GIT_ADD_FAILED',
+    message: 'git worktree add failed',
+    exitCode,
+  }),
+  pnpmInstallFailed: (exitCode: number): WorktreePnpmInstallFailedError => ({
+    code: 'WORKTREE_PNPM_INSTALL_FAILED',
+    message: 'pnpm install failed',
+    exitCode,
+  }),
+} as const;

--- a/packages/cli-tools/src/worktree/index.test.ts
+++ b/packages/cli-tools/src/worktree/index.test.ts
@@ -1,3 +1,4 @@
+import { ok } from '@slopweaver/errors';
 import { describe, expect, it, vi } from 'vitest';
 import { type ExecFn, type ExecResult, runWorktreeNew, type RunWorktreeNewDeps } from './index.ts';
 
@@ -8,7 +9,7 @@ const okExec: ExecFn = () => ({ status: 0 });
 function deps({
   exec = okExec,
   log = vi.fn(),
-  resolveRoots = () => FAKE_ROOTS,
+  resolveRoots = () => ok(FAKE_ROOTS),
 }: Partial<RunWorktreeNewDeps> = {}): RunWorktreeNewDeps {
   return { exec, log, resolveRoots };
 }
@@ -68,7 +69,7 @@ describe('runWorktreeNew', () => {
     });
 
     expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
+    if (result.isErr() && result.error.code !== 'MONOREPO_ROOT_NOT_FOUND') {
       expect(result.error.code).toBe('WORKTREE_INVALID_NAME');
       expect(result.error.message).toMatch(/empty slug/);
       expect(result.error.exitCode).toBe(1);
@@ -89,7 +90,7 @@ describe('runWorktreeNew', () => {
     });
 
     expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
+    if (result.isErr() && result.error.code !== 'MONOREPO_ROOT_NOT_FOUND') {
       expect(result.error.code).toBe('WORKTREE_GIT_FETCH_FAILED');
       expect(result.error.exitCode).toBe(128);
     }
@@ -108,7 +109,7 @@ describe('runWorktreeNew', () => {
     });
 
     expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
+    if (result.isErr() && result.error.code !== 'MONOREPO_ROOT_NOT_FOUND') {
       expect(result.error.code).toBe('WORKTREE_GIT_ADD_FAILED');
       expect(result.error.exitCode).toBe(128);
     }
@@ -127,7 +128,7 @@ describe('runWorktreeNew', () => {
     });
 
     expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
+    if (result.isErr() && result.error.code !== 'MONOREPO_ROOT_NOT_FOUND') {
       expect(result.error.code).toBe('WORKTREE_PNPM_INSTALL_FAILED');
       expect(result.error.exitCode).toBe(1);
     }

--- a/packages/cli-tools/src/worktree/index.test.ts
+++ b/packages/cli-tools/src/worktree/index.test.ts
@@ -27,7 +27,10 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result).toEqual({ ok: true, worktreePath: '/wt/fix-issue-42' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ worktreePath: '/wt/fix-issue-42' });
+    }
     expect(calls).toEqual([
       { cmd: 'git', args: ['fetch', 'origin', 'main'], cwd: '/repo' },
       {
@@ -48,11 +51,14 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result).toEqual({ ok: true, worktreePath: '/wt/quick-fix' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ worktreePath: '/wt/quick-fix' });
+    }
     expect(exec).toHaveBeenCalledTimes(2);
   });
 
-  it('returns an error when sanitisation produces an empty slug', () => {
+  it('returns err WORKTREE_INVALID_NAME when sanitisation produces an empty slug', () => {
     const exec = vi.fn<ExecFn>(() => ({ status: 0 }) as ExecResult);
 
     const result = runWorktreeNew({
@@ -61,15 +67,16 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toMatch(/empty slug/);
-      expect(result.exitCode).toBe(1);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('WORKTREE_INVALID_NAME');
+      expect(result.error.message).toMatch(/empty slug/);
+      expect(result.error.exitCode).toBe(1);
     }
     expect(exec).not.toHaveBeenCalled();
   });
 
-  it('returns the failing exit code when git fetch fails', () => {
+  it('returns err WORKTREE_GIT_FETCH_FAILED with the failing exit code', () => {
     const exec: ExecFn = (cmd, args) => {
       if (cmd === 'git' && args[0] === 'fetch') return { status: 128 };
       return { status: 0 };
@@ -81,10 +88,14 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result).toEqual({ ok: false, error: 'git fetch origin main failed', exitCode: 128 });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('WORKTREE_GIT_FETCH_FAILED');
+      expect(result.error.exitCode).toBe(128);
+    }
   });
 
-  it('returns the failing exit code when git worktree add fails', () => {
+  it('returns err WORKTREE_GIT_ADD_FAILED with the failing exit code', () => {
     const exec: ExecFn = (cmd, args) => {
       if (cmd === 'git' && args[0] === 'worktree') return { status: 128 };
       return { status: 0 };
@@ -96,10 +107,14 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result).toEqual({ ok: false, error: 'git worktree add failed', exitCode: 128 });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('WORKTREE_GIT_ADD_FAILED');
+      expect(result.error.exitCode).toBe(128);
+    }
   });
 
-  it('returns the failing exit code when pnpm install fails', () => {
+  it('returns err WORKTREE_PNPM_INSTALL_FAILED with the failing exit code', () => {
     const exec: ExecFn = (cmd) => {
       if (cmd === 'pnpm') return { status: 1 };
       return { status: 0 };
@@ -111,7 +126,11 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result).toEqual({ ok: false, error: 'pnpm install failed', exitCode: 1 });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('WORKTREE_PNPM_INSTALL_FAILED');
+      expect(result.error.exitCode).toBe(1);
+    }
   });
 
   it('emits human-readable log lines via the injected log function', () => {

--- a/packages/cli-tools/src/worktree/index.test.ts
+++ b/packages/cli-tools/src/worktree/index.test.ts
@@ -69,11 +69,11 @@ describe('runWorktreeNew', () => {
     });
 
     expect(result.isErr()).toBe(true);
-    if (result.isErr() && result.error.code !== 'MONOREPO_ROOT_NOT_FOUND') {
-      expect(result.error.code).toBe('WORKTREE_INVALID_NAME');
-      expect(result.error.message).toMatch(/empty slug/);
-      expect(result.error.exitCode).toBe(1);
-    }
+    if (!result.isErr()) return;
+    expect(result.error.code).toBe('WORKTREE_INVALID_NAME');
+    if (result.error.code !== 'WORKTREE_INVALID_NAME') return;
+    expect(result.error.message).toMatch(/empty slug/);
+    expect(result.error.exitCode).toBe(1);
     expect(exec).not.toHaveBeenCalled();
   });
 
@@ -90,10 +90,10 @@ describe('runWorktreeNew', () => {
     });
 
     expect(result.isErr()).toBe(true);
-    if (result.isErr() && result.error.code !== 'MONOREPO_ROOT_NOT_FOUND') {
-      expect(result.error.code).toBe('WORKTREE_GIT_FETCH_FAILED');
-      expect(result.error.exitCode).toBe(128);
-    }
+    if (!result.isErr()) return;
+    expect(result.error.code).toBe('WORKTREE_GIT_FETCH_FAILED');
+    if (result.error.code !== 'WORKTREE_GIT_FETCH_FAILED') return;
+    expect(result.error.exitCode).toBe(128);
   });
 
   it('returns err WORKTREE_GIT_ADD_FAILED with the failing exit code', () => {
@@ -109,10 +109,10 @@ describe('runWorktreeNew', () => {
     });
 
     expect(result.isErr()).toBe(true);
-    if (result.isErr() && result.error.code !== 'MONOREPO_ROOT_NOT_FOUND') {
-      expect(result.error.code).toBe('WORKTREE_GIT_ADD_FAILED');
-      expect(result.error.exitCode).toBe(128);
-    }
+    if (!result.isErr()) return;
+    expect(result.error.code).toBe('WORKTREE_GIT_ADD_FAILED');
+    if (result.error.code !== 'WORKTREE_GIT_ADD_FAILED') return;
+    expect(result.error.exitCode).toBe(128);
   });
 
   it('returns err WORKTREE_PNPM_INSTALL_FAILED with the failing exit code', () => {
@@ -128,10 +128,10 @@ describe('runWorktreeNew', () => {
     });
 
     expect(result.isErr()).toBe(true);
-    if (result.isErr() && result.error.code !== 'MONOREPO_ROOT_NOT_FOUND') {
-      expect(result.error.code).toBe('WORKTREE_PNPM_INSTALL_FAILED');
-      expect(result.error.exitCode).toBe(1);
-    }
+    if (!result.isErr()) return;
+    expect(result.error.code).toBe('WORKTREE_PNPM_INSTALL_FAILED');
+    if (result.error.code !== 'WORKTREE_PNPM_INSTALL_FAILED') return;
+    expect(result.error.exitCode).toBe(1);
   });
 
   it('emits human-readable log lines via the injected log function', () => {

--- a/packages/cli-tools/src/worktree/index.test.ts
+++ b/packages/cli-tools/src/worktree/index.test.ts
@@ -68,12 +68,11 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) return;
-    expect(result.error.code).toBe('WORKTREE_INVALID_NAME');
-    if (result.error.code !== 'WORKTREE_INVALID_NAME') return;
-    expect(result.error.message).toMatch(/empty slug/);
-    expect(result.error.exitCode).toBe(1);
+    expect(result._unsafeUnwrapErr()).toMatchObject({
+      code: 'WORKTREE_INVALID_NAME',
+      message: expect.stringMatching(/empty slug/),
+      exitCode: 1,
+    });
     expect(exec).not.toHaveBeenCalled();
   });
 
@@ -89,11 +88,10 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) return;
-    expect(result.error.code).toBe('WORKTREE_GIT_FETCH_FAILED');
-    if (result.error.code !== 'WORKTREE_GIT_FETCH_FAILED') return;
-    expect(result.error.exitCode).toBe(128);
+    expect(result._unsafeUnwrapErr()).toMatchObject({
+      code: 'WORKTREE_GIT_FETCH_FAILED',
+      exitCode: 128,
+    });
   });
 
   it('returns err WORKTREE_GIT_ADD_FAILED with the failing exit code', () => {
@@ -108,11 +106,10 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) return;
-    expect(result.error.code).toBe('WORKTREE_GIT_ADD_FAILED');
-    if (result.error.code !== 'WORKTREE_GIT_ADD_FAILED') return;
-    expect(result.error.exitCode).toBe(128);
+    expect(result._unsafeUnwrapErr()).toMatchObject({
+      code: 'WORKTREE_GIT_ADD_FAILED',
+      exitCode: 128,
+    });
   });
 
   it('returns err WORKTREE_PNPM_INSTALL_FAILED with the failing exit code', () => {
@@ -127,11 +124,10 @@ describe('runWorktreeNew', () => {
       deps: deps({ exec }),
     });
 
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) return;
-    expect(result.error.code).toBe('WORKTREE_PNPM_INSTALL_FAILED');
-    if (result.error.code !== 'WORKTREE_PNPM_INSTALL_FAILED') return;
-    expect(result.error.exitCode).toBe(1);
+    expect(result._unsafeUnwrapErr()).toMatchObject({
+      code: 'WORKTREE_PNPM_INSTALL_FAILED',
+      exitCode: 1,
+    });
   });
 
   it('emits human-readable log lines via the injected log function', () => {

--- a/packages/cli-tools/src/worktree/index.ts
+++ b/packages/cli-tools/src/worktree/index.ts
@@ -8,10 +8,16 @@
  * Pure plan-building lives in `./plan.ts`. This file orchestrates: it
  * resolves the monorepo root, builds the plan, then runs git + pnpm via
  * the injected `exec` so tests can stub the subprocess layer.
+ *
+ * Returns `Result<{ worktreePath }, WorktreeError>`. Each `WorktreeError`
+ * variant carries an `exitCode` so the CLI boundary can pass it straight
+ * to `process.exit(...)` without re-deriving from the discriminant.
  */
 
+import { err, ok, type Result } from '@slopweaver/errors';
 import { spawnSync } from 'node:child_process';
 import { findMonorepoRoot, resolveWorktreesRoot } from '../lib/paths.ts';
+import { type WorktreeError, WorktreeErrors } from './errors.ts';
 import { buildWorktreePlan } from './plan.ts';
 
 export type WorktreeNewOptions = { install: boolean };
@@ -20,9 +26,7 @@ export type ExecResult = { status: number };
 
 export type ExecFn = (cmd: string, args: string[], opts: { cwd: string }) => ExecResult;
 
-export type RunWorktreeNewResult =
-  | { ok: true; worktreePath: string }
-  | { ok: false; error: string; exitCode: number };
+export type RunWorktreeNewSuccess = { worktreePath: string };
 
 export type RunWorktreeNewDeps = {
   exec?: ExecFn;
@@ -48,17 +52,15 @@ export function runWorktreeNew({
   rawName: string;
   options: WorktreeNewOptions;
   deps?: RunWorktreeNewDeps;
-}): RunWorktreeNewResult {
+}): Result<RunWorktreeNewSuccess, WorktreeError> {
   const exec = deps.exec ?? defaultExec;
   const log = deps.log ?? console.log;
   const resolveRoots = deps.resolveRoots ?? defaultResolveRoots;
 
   const { repoRoot, worktreesRoot } = resolveRoots();
   const planResult = buildWorktreePlan({ rawName, worktreesRoot });
-  if (!planResult.ok) {
-    return { ok: false, error: planResult.error, exitCode: 1 };
-  }
-  const { plan } = planResult;
+  if (planResult.isErr()) return err(planResult.error);
+  const plan = planResult.value;
 
   log(`creating worktree: ${plan.worktreePath}`);
   log(`new branch:        ${plan.branchName}`);
@@ -67,7 +69,7 @@ export function runWorktreeNew({
 
   const fetchResult = exec('git', ['fetch', 'origin', 'main'], { cwd: repoRoot });
   if (fetchResult.status !== 0) {
-    return { ok: false, error: 'git fetch origin main failed', exitCode: fetchResult.status };
+    return err(WorktreeErrors.gitFetchFailed(fetchResult.status));
   }
 
   const addResult = exec(
@@ -76,7 +78,7 @@ export function runWorktreeNew({
     { cwd: repoRoot },
   );
   if (addResult.status !== 0) {
-    return { ok: false, error: 'git worktree add failed', exitCode: addResult.status };
+    return err(WorktreeErrors.gitAddFailed(addResult.status));
   }
 
   if (options.install) {
@@ -84,12 +86,12 @@ export function runWorktreeNew({
     log(`installing deps in ${plan.worktreePath}`);
     const installResult = exec('pnpm', ['install'], { cwd: plan.worktreePath });
     if (installResult.status !== 0) {
-      return { ok: false, error: 'pnpm install failed', exitCode: installResult.status };
+      return err(WorktreeErrors.pnpmInstallFailed(installResult.status));
     }
   }
 
   log('');
   log('✓ worktree ready');
   log(`next: cd ${plan.worktreePath}`);
-  return { ok: true, worktreePath: plan.worktreePath };
+  return ok({ worktreePath: plan.worktreePath });
 }

--- a/packages/cli-tools/src/worktree/index.ts
+++ b/packages/cli-tools/src/worktree/index.ts
@@ -16,6 +16,7 @@
 
 import { err, ok, type Result } from '@slopweaver/errors';
 import { spawnSync } from 'node:child_process';
+import type { MonorepoRootNotFoundError } from '../lib/errors.ts';
 import { findMonorepoRoot, resolveWorktreesRoot } from '../lib/paths.ts';
 import { type WorktreeError, WorktreeErrors } from './errors.ts';
 import { buildWorktreePlan } from './plan.ts';
@@ -28,10 +29,15 @@ export type ExecFn = (cmd: string, args: string[], opts: { cwd: string }) => Exe
 
 export type RunWorktreeNewSuccess = { worktreePath: string };
 
+export type ResolveRootsResult = Result<
+  { repoRoot: string; worktreesRoot: string },
+  MonorepoRootNotFoundError
+>;
+
 export type RunWorktreeNewDeps = {
   exec?: ExecFn;
   log?: (line: string) => void;
-  resolveRoots?: () => { repoRoot: string; worktreesRoot: string };
+  resolveRoots?: () => ResolveRootsResult;
 };
 
 const defaultExec: ExecFn = (cmd, args, opts) => {
@@ -39,9 +45,11 @@ const defaultExec: ExecFn = (cmd, args, opts) => {
   return { status: result.status ?? 1 };
 };
 
-const defaultResolveRoots = (): { repoRoot: string; worktreesRoot: string } => {
-  const repoRoot = findMonorepoRoot();
-  return { repoRoot, worktreesRoot: resolveWorktreesRoot({ repoRoot }) };
+const defaultResolveRoots = (): ResolveRootsResult => {
+  return findMonorepoRoot().map((repoRoot) => ({
+    repoRoot,
+    worktreesRoot: resolveWorktreesRoot({ repoRoot }),
+  }));
 };
 
 export function runWorktreeNew({
@@ -52,12 +60,14 @@ export function runWorktreeNew({
   rawName: string;
   options: WorktreeNewOptions;
   deps?: RunWorktreeNewDeps;
-}): Result<RunWorktreeNewSuccess, WorktreeError> {
+}): Result<RunWorktreeNewSuccess, WorktreeError | MonorepoRootNotFoundError> {
   const exec = deps.exec ?? defaultExec;
   const log = deps.log ?? console.log;
   const resolveRoots = deps.resolveRoots ?? defaultResolveRoots;
 
-  const { repoRoot, worktreesRoot } = resolveRoots();
+  const rootsResult = resolveRoots();
+  if (rootsResult.isErr()) return err(rootsResult.error);
+  const { repoRoot, worktreesRoot } = rootsResult.value;
   const planResult = buildWorktreePlan({ rawName, worktreesRoot });
   if (planResult.isErr()) return err(planResult.error);
   const plan = planResult.value;

--- a/packages/cli-tools/src/worktree/plan.test.ts
+++ b/packages/cli-tools/src/worktree/plan.test.ts
@@ -28,20 +28,20 @@ describe('sanitiseTaskName', () => {
 });
 
 describe('buildWorktreePlan', () => {
-  it('returns a plan with the worktree path, branch name, and base ref', () => {
+  it('returns ok with the worktree path, branch name, and base ref', () => {
     const result = buildWorktreePlan({
       rawName: 'fix-issue-42',
       worktreesRoot: '/Users/me/dev/worktrees',
     });
-    expect(result).toEqual({
-      ok: true,
-      plan: {
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
         safeName: 'fix-issue-42',
         worktreePath: '/Users/me/dev/worktrees/fix-issue-42',
         branchName: 'worktree/fix-issue-42',
         baseRef: 'origin/main',
-      },
-    });
+      });
+    }
   });
 
   it('sanitises the raw name before building the path', () => {
@@ -49,22 +49,23 @@ describe('buildWorktreePlan', () => {
       rawName: 'Fix Issue 42!!',
       worktreesRoot: '/wt',
     });
-    expect(result).toEqual({
-      ok: true,
-      plan: {
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
         safeName: 'fix-issue-42',
         worktreePath: '/wt/fix-issue-42',
         branchName: 'worktree/fix-issue-42',
         baseRef: 'origin/main',
-      },
-    });
+      });
+    }
   });
 
-  it('returns an error when the sanitised name is empty', () => {
+  it('returns err WORKTREE_INVALID_NAME when the sanitised name is empty', () => {
     const result = buildWorktreePlan({ rawName: '!!!', worktreesRoot: '/wt' });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toMatch(/empty slug/);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('WORKTREE_INVALID_NAME');
+      expect(result.error.message).toMatch(/empty slug/);
     }
   });
 });

--- a/packages/cli-tools/src/worktree/plan.ts
+++ b/packages/cli-tools/src/worktree/plan.ts
@@ -1,4 +1,6 @@
+import { err, ok, type Result } from '@slopweaver/errors';
 import { join } from 'node:path';
+import { type WorktreeError, WorktreeErrors } from './errors.ts';
 
 /** Sanitises a free-text task name into a slug-safe branch + path component. */
 export function sanitiseTaskName({ input }: { input: string }): string {
@@ -17,29 +19,21 @@ export type WorktreePlan = {
   baseRef: string;
 };
 
-export type BuildPlanResult = { ok: true; plan: WorktreePlan } | { ok: false; error: string };
-
 export function buildWorktreePlan({
   rawName,
   worktreesRoot,
 }: {
   rawName: string;
   worktreesRoot: string;
-}): BuildPlanResult {
+}): Result<WorktreePlan, WorktreeError> {
   const safeName = sanitiseTaskName({ input: rawName });
   if (!safeName) {
-    return {
-      ok: false,
-      error: 'task name produced an empty slug after sanitisation',
-    };
+    return err(WorktreeErrors.invalidName('task name produced an empty slug after sanitisation'));
   }
-  return {
-    ok: true,
-    plan: {
-      safeName,
-      worktreePath: join(worktreesRoot, safeName),
-      branchName: `worktree/${safeName}`,
-      baseRef: 'origin/main',
-    },
-  };
+  return ok({
+    safeName,
+    worktreePath: join(worktreesRoot, safeName),
+    branchName: `worktree/${safeName}`,
+    baseRef: 'origin/main',
+  });
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@slopweaver/errors": "workspace:*",
     "better-sqlite3": "12.2.0",
     "drizzle-orm": "0.45.2"
   },

--- a/packages/db/src/errors.ts
+++ b/packages/db/src/errors.ts
@@ -1,0 +1,24 @@
+/**
+ * @slopweaver/db domain-level error union.
+ *
+ * `DatabaseError` (raw output of `safeQuery`) lives in `@slopweaver/errors`
+ * because non-db packages also include it in their unions. The errors here
+ * cover failure modes that originate inside this package but aren't SQLite
+ * runtime errors — currently just `DataPathInvalidError` for the XDG
+ * validation in `path.ts`.
+ */
+
+import type { BaseError } from '@slopweaver/errors';
+
+export interface DataPathInvalidError extends BaseError {
+  readonly code: 'DATA_PATH_INVALID';
+  readonly xdgDataHome: string;
+}
+
+export const DbErrors = {
+  dataPathInvalid: (xdgDataHome: string): DataPathInvalidError => ({
+    code: 'DATA_PATH_INVALID',
+    message: `XDG_DATA_HOME must be an absolute path; got: "${xdgDataHome}"`,
+    xdgDataHome,
+  }),
+} as const;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12,9 +12,9 @@ import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
-import { resolveDbPath } from './path.ts';
 import * as schema from './schema/index.ts';
 
+export * from './errors.ts';
 export * from './integration-tokens.ts';
 export * from './path.ts';
 export * from './safe-query.ts';
@@ -62,20 +62,19 @@ export type CreateDbHandle = {
  * - Enables `foreign_keys` pragma on the connection.
  * - Applies any pending migrations from `packages/db/migrations/`.
  *
- * @param path - Optional override; defaults to {@link resolveDbPath}() which
- *   honours XDG_DATA_HOME. Pass `':memory:'` for ephemeral test databases.
+ * @param path - Absolute filesystem path to the SQLite file, or `':memory:'`
+ *   for an ephemeral test database. Resolve via `resolveDbPath()` at the
+ *   caller's boundary (it returns a `Result` so the XDG validation surface
+ *   propagates cleanly).
  * @returns Handle exposing the Drizzle wrapper, raw better-sqlite3 instance,
  *   and a `close()` shortcut.
  *
  * @example
- * const { db, close } = createDb({ path: ':memory:' });
- * try {
- *   db.insert(evidenceLog).values({ ... }).run();
- * } finally {
- *   close();
- * }
+ * const pathResult = resolveDbPath();
+ * if (pathResult.isErr()) { console.error(pathResult.error.message); process.exit(1); }
+ * const { db, close } = createDb({ path: pathResult.value });
  */
-export function createDb({ path = resolveDbPath() }: { path?: string } = {}): CreateDbHandle {
+export function createDb({ path }: { path: string }): CreateDbHandle {
   if (path !== ':memory:') {
     mkdirSync(dirname(path), { recursive: true });
   }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,7 +17,9 @@ import * as schema from './schema/index.ts';
 
 export * from './integration-tokens.ts';
 export * from './path.ts';
+export * from './safe-query.ts';
 export * from './schema/index.ts';
+export * from './sqlite-error.ts';
 
 /**
  * Absolute path to the directory holding generated Drizzle migration SQL.

--- a/packages/db/src/integration-tokens.test.ts
+++ b/packages/db/src/integration-tokens.test.ts
@@ -2,9 +2,9 @@
  * Unit tests for loadIntegrationToken / saveIntegrationToken.
  *
  * Pins the contracts the CLI subcommands and the future polling layer rely
- * on: missing rows surface as `null` (not exceptions), repeat saves upsert
- * cleanly without resetting `created_at_ms`, and writes are scoped per
- * integration slug.
+ * on: missing rows surface as `null` (not Err), repeat saves upsert cleanly
+ * without resetting `created_at_ms`, and writes are scoped per integration
+ * slug. Result-based assertions per .claude/rules/error-handling.md.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -13,39 +13,48 @@ import { loadIntegrationToken, saveIntegrationToken } from './integration-tokens
 import { integrationTokens } from './schema/integration-tokens.ts';
 
 describe('loadIntegrationToken', () => {
-  it('returns null when no row exists for the integration', () => {
+  it('returns ok(null) when no row exists for the integration', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      expect(loadIntegrationToken({ db: handle.db, integration: 'github' })).toBeNull();
+      const result = await loadIntegrationToken({ db: handle.db, integration: 'github' });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBeNull();
+      }
     } finally {
       handle.close();
     }
   });
 
-  it('returns the stored token + account label after a save', () => {
+  it('returns ok with the stored token + account label after a save', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      saveIntegrationToken({
+      const saveResult = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_test_value',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
       });
+      expect(saveResult.isOk()).toBe(true);
 
-      expect(loadIntegrationToken({ db: handle.db, integration: 'github' })).toEqual({
-        token: 'ghp_test_value',
-        accountLabel: 'octocat',
-      });
+      const loadResult = await loadIntegrationToken({ db: handle.db, integration: 'github' });
+      expect(loadResult.isOk()).toBe(true);
+      if (loadResult.isOk()) {
+        expect(loadResult.value).toEqual({
+          token: 'ghp_test_value',
+          accountLabel: 'octocat',
+        });
+      }
     } finally {
       handle.close();
     }
   });
 
-  it('scopes lookups by integration slug', () => {
+  it('scopes lookups by integration slug', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      saveIntegrationToken({
+      await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_github',
@@ -53,7 +62,11 @@ describe('loadIntegrationToken', () => {
         now: () => 1_746_000_000_000,
       });
 
-      expect(loadIntegrationToken({ db: handle.db, integration: 'slack' })).toBeNull();
+      const result = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBeNull();
+      }
     } finally {
       handle.close();
     }
@@ -61,17 +74,17 @@ describe('loadIntegrationToken', () => {
 });
 
 describe('saveIntegrationToken', () => {
-  it('upserts: re-saving the same integration overwrites token + account label', () => {
+  it('upserts: re-saving the same integration overwrites token + account label', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      saveIntegrationToken({
+      await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_old',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
       });
-      saveIntegrationToken({
+      await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_new',
@@ -79,27 +92,31 @@ describe('saveIntegrationToken', () => {
         now: () => 1_746_000_000_500,
       });
 
-      expect(loadIntegrationToken({ db: handle.db, integration: 'github' })).toEqual({
-        token: 'ghp_new',
-        accountLabel: 'octocat-renamed',
-      });
+      const loaded = await loadIntegrationToken({ db: handle.db, integration: 'github' });
+      expect(loaded.isOk()).toBe(true);
+      if (loaded.isOk()) {
+        expect(loaded.value).toEqual({
+          token: 'ghp_new',
+          accountLabel: 'octocat-renamed',
+        });
+      }
       expect(handle.db.select().from(integrationTokens).all()).toHaveLength(1);
     } finally {
       handle.close();
     }
   });
 
-  it('preserves created_at_ms across re-saves and bumps updated_at_ms', () => {
+  it('preserves created_at_ms across re-saves and bumps updated_at_ms', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      saveIntegrationToken({
+      await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_first',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
       });
-      saveIntegrationToken({
+      await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_second',
@@ -115,10 +132,10 @@ describe('saveIntegrationToken', () => {
     }
   });
 
-  it('accepts a null account label', () => {
+  it('accepts a null account label', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      saveIntegrationToken({
+      await saveIntegrationToken({
         db: handle.db,
         integration: 'slack',
         token: 'xoxb-redacted',
@@ -126,10 +143,14 @@ describe('saveIntegrationToken', () => {
         now: () => 1_746_000_000_000,
       });
 
-      expect(loadIntegrationToken({ db: handle.db, integration: 'slack' })).toEqual({
-        token: 'xoxb-redacted',
-        accountLabel: null,
-      });
+      const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+      expect(loaded.isOk()).toBe(true);
+      if (loaded.isOk()) {
+        expect(loaded.value).toEqual({
+          token: 'xoxb-redacted',
+          accountLabel: null,
+        });
+      }
     } finally {
       handle.close();
     }

--- a/packages/db/src/integration-tokens.test.ts
+++ b/packages/db/src/integration-tokens.test.ts
@@ -54,13 +54,14 @@ describe('loadIntegrationToken', () => {
   it('scopes lookups by integration slug', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      await saveIntegrationToken({
+      const saveResult = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_github',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
       });
+      expect(saveResult.isOk()).toBe(true);
 
       const result = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
       expect(result.isOk()).toBe(true);
@@ -77,20 +78,22 @@ describe('saveIntegrationToken', () => {
   it('upserts: re-saving the same integration overwrites token + account label', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      await saveIntegrationToken({
+      const firstSave = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_old',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
       });
-      await saveIntegrationToken({
+      expect(firstSave.isOk()).toBe(true);
+      const secondSave = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_new',
         accountLabel: 'octocat-renamed',
         now: () => 1_746_000_000_500,
       });
+      expect(secondSave.isOk()).toBe(true);
 
       const loaded = await loadIntegrationToken({ db: handle.db, integration: 'github' });
       expect(loaded.isOk()).toBe(true);
@@ -109,20 +112,22 @@ describe('saveIntegrationToken', () => {
   it('preserves created_at_ms across re-saves and bumps updated_at_ms', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      await saveIntegrationToken({
+      const firstSave = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_first',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
       });
-      await saveIntegrationToken({
+      expect(firstSave.isOk()).toBe(true);
+      const secondSave = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_second',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_999,
       });
+      expect(secondSave.isOk()).toBe(true);
 
       const row = handle.db.select().from(integrationTokens).get();
       expect(row?.createdAtMs).toBe(1_746_000_000_000);
@@ -135,13 +140,14 @@ describe('saveIntegrationToken', () => {
   it('accepts a null account label', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      await saveIntegrationToken({
+      const saveResult = await saveIntegrationToken({
         db: handle.db,
         integration: 'slack',
         token: 'xoxb-redacted',
         accountLabel: null,
         now: () => 1_746_000_000_000,
       });
+      expect(saveResult.isOk()).toBe(true);
 
       const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
       expect(loaded.isOk()).toBe(true);

--- a/packages/db/src/integration-tokens.ts
+++ b/packages/db/src/integration-tokens.ts
@@ -12,8 +12,10 @@
  * boundary, not a storage one.
  */
 
+import type { DatabaseError, ResultAsync } from '@slopweaver/errors';
 import { eq } from 'drizzle-orm';
 import type { SlopweaverDatabase } from './index.ts';
+import { safeQuery } from './safe-query.ts';
 import { integrationTokens } from './schema/integration-tokens.ts';
 
 export type LoadIntegrationTokenArgs = {
@@ -30,22 +32,27 @@ export type LoadIntegrationTokenResult = {
  * Returns the stored token for `integration`, or `null` if no row exists.
  *
  * Polling code must treat `null` as "not connected — skip this integration"
- * rather than throwing, so the local binary can run partially-configured
- * (e.g. user has connected GitHub but not Slack yet).
+ * rather than treating it as an error, so the local binary can run
+ * partially-configured (e.g. user has connected GitHub but not Slack yet).
+ * `Err` is reserved for actual database failures.
  */
 export function loadIntegrationToken({
   db,
   integration,
-}: LoadIntegrationTokenArgs): LoadIntegrationTokenResult | null {
-  const row = db
-    .select({
-      token: integrationTokens.token,
-      accountLabel: integrationTokens.accountLabel,
-    })
-    .from(integrationTokens)
-    .where(eq(integrationTokens.integration, integration))
-    .get();
-  return row ?? null;
+}: LoadIntegrationTokenArgs): ResultAsync<LoadIntegrationTokenResult | null, DatabaseError> {
+  return safeQuery({
+    execute: () => {
+      const row = db
+        .select({
+          token: integrationTokens.token,
+          accountLabel: integrationTokens.accountLabel,
+        })
+        .from(integrationTokens)
+        .where(eq(integrationTokens.integration, integration))
+        .get();
+      return row ?? null;
+    },
+  });
 }
 
 export type SaveIntegrationTokenArgs = {
@@ -68,23 +75,27 @@ export function saveIntegrationToken({
   token,
   accountLabel,
   now = () => Date.now(),
-}: SaveIntegrationTokenArgs): void {
-  const stamp = now();
-  db.insert(integrationTokens)
-    .values({
-      integration,
-      token,
-      accountLabel,
-      createdAtMs: stamp,
-      updatedAtMs: stamp,
-    })
-    .onConflictDoUpdate({
-      target: integrationTokens.integration,
-      set: {
-        token,
-        accountLabel,
-        updatedAtMs: stamp,
-      },
-    })
-    .run();
+}: SaveIntegrationTokenArgs): ResultAsync<void, DatabaseError> {
+  return safeQuery({
+    execute: () => {
+      const stamp = now();
+      db.insert(integrationTokens)
+        .values({
+          integration,
+          token,
+          accountLabel,
+          createdAtMs: stamp,
+          updatedAtMs: stamp,
+        })
+        .onConflictDoUpdate({
+          target: integrationTokens.integration,
+          set: {
+            token,
+            accountLabel,
+            updatedAtMs: stamp,
+          },
+        })
+        .run();
+    },
+  });
 }

--- a/packages/db/src/path.test.ts
+++ b/packages/db/src/path.test.ts
@@ -13,32 +13,54 @@ import { resolveDataDir, resolveDbPath } from './path.ts';
 
 describe('resolveDataDir', () => {
   it('uses XDG_DATA_HOME when supplied', () => {
-    expect(resolveDataDir({ home: '/tmp/fakehome', xdgDataHome: '/tmp/xdg' })).toBe(
-      '/tmp/xdg/slopweaver',
-    );
+    const result = resolveDataDir({ home: '/tmp/fakehome', xdgDataHome: '/tmp/xdg' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('/tmp/xdg/slopweaver');
+    }
   });
 
   it('falls back to .slopweaver under the supplied home directory when XDG_DATA_HOME is unset', () => {
-    expect(resolveDataDir({ home: '/tmp/fakehome', xdgDataHome: '' })).toBe(
-      '/tmp/fakehome/.slopweaver',
-    );
+    const result = resolveDataDir({ home: '/tmp/fakehome', xdgDataHome: '' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('/tmp/fakehome/.slopweaver');
+    }
   });
 
-  it('throws when XDG_DATA_HOME is set to a relative path', () => {
-    expect(() => resolveDataDir({ xdgDataHome: 'tmp/relative' })).toThrow(
-      /XDG_DATA_HOME must be an absolute path/,
-    );
+  it('returns DATA_PATH_INVALID when XDG_DATA_HOME is set to a relative path', () => {
+    const result = resolveDataDir({ xdgDataHome: 'tmp/relative' });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('DATA_PATH_INVALID');
+      expect(result.error.xdgDataHome).toBe('tmp/relative');
+      expect(result.error.message).toMatch(/XDG_DATA_HOME must be an absolute path/);
+    }
   });
 });
 
 describe('resolveDbPath', () => {
   it('appends slopweaver.db to the XDG-aware data dir', () => {
-    expect(resolveDbPath({ xdgDataHome: '/tmp/xdg' })).toBe('/tmp/xdg/slopweaver/slopweaver.db');
+    const result = resolveDbPath({ xdgDataHome: '/tmp/xdg' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('/tmp/xdg/slopweaver/slopweaver.db');
+    }
   });
 
   it('defaults to os.homedir() when no home is supplied and XDG_DATA_HOME is unset', () => {
-    expect(resolveDbPath({ xdgDataHome: '' })).toBe(
-      join(homedir(), '.slopweaver', 'slopweaver.db'),
-    );
+    const result = resolveDbPath({ xdgDataHome: '' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(join(homedir(), '.slopweaver', 'slopweaver.db'));
+    }
+  });
+
+  it('propagates DATA_PATH_INVALID from resolveDataDir', () => {
+    const result = resolveDbPath({ xdgDataHome: 'tmp/relative' });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('DATA_PATH_INVALID');
+    }
   });
 });

--- a/packages/db/src/path.ts
+++ b/packages/db/src/path.ts
@@ -11,6 +11,8 @@
 
 import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
+import { err, ok, type Result } from '@slopweaver/errors';
+import { type DataPathInvalidError, DbErrors } from './errors.ts';
 
 /**
  * Common option bag accepted by both resolvers. All fields are optional —
@@ -34,38 +36,29 @@ type ResolvePathOptions = {
  * absolute path; relative values are rejected so misconfigured environments
  * fail fast at startup instead of silently writing SQLite under the caller's
  * cwd.
- *
- * @param options - Optional overrides for testing.
- * @returns Absolute filesystem path to the SlopWeaver data directory.
- * @throws {Error} If the resolved `XDG_DATA_HOME` is not an absolute path.
- *
- * @example
- * resolveDataDir({ xdgDataHome: '/var/lib' }); // '/var/lib/slopweaver'
- * resolveDataDir({ home: '/Users/alice', xdgDataHome: '' }); // '/Users/alice/.slopweaver'
  */
-export function resolveDataDir({ home, xdgDataHome }: ResolvePathOptions = {}): string {
+export function resolveDataDir({
+  home,
+  xdgDataHome,
+}: ResolvePathOptions = {}): Result<string, DataPathInvalidError> {
   const resolvedXdgDataHome = xdgDataHome ?? process.env.XDG_DATA_HOME;
 
   if (resolvedXdgDataHome) {
     if (!isAbsolute(resolvedXdgDataHome)) {
-      throw new Error(`XDG_DATA_HOME must be an absolute path; got: "${resolvedXdgDataHome}"`);
+      return err(DbErrors.dataPathInvalid(resolvedXdgDataHome));
     }
-    return join(resolvedXdgDataHome, 'slopweaver');
+    return ok(join(resolvedXdgDataHome, 'slopweaver'));
   }
 
-  return join(home ?? homedir(), '.slopweaver');
+  return ok(join(home ?? homedir(), '.slopweaver'));
 }
 
 /**
  * Resolve the absolute path to the SlopWeaver SQLite database file.
  * Equivalent to {@link resolveDataDir} joined with `slopweaver.db`.
- *
- * @param options - Optional overrides for testing.
- * @returns Absolute filesystem path to `slopweaver.db`.
- *
- * @example
- * resolveDbPath({ xdgDataHome: '/var/lib' }); // '/var/lib/slopweaver/slopweaver.db'
  */
-export function resolveDbPath(options: ResolvePathOptions = {}): string {
-  return join(resolveDataDir(options), 'slopweaver.db');
+export function resolveDbPath(
+  options: ResolvePathOptions = {},
+): Result<string, DataPathInvalidError> {
+  return resolveDataDir(options).map((dir) => join(dir, 'slopweaver.db'));
 }

--- a/packages/db/src/safe-query.test.ts
+++ b/packages/db/src/safe-query.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Behaviour tests for `safeQuery`. Drives a real in-memory SQLite via
+ * `createDb` so we exercise the actual error shapes better-sqlite3 +
+ * Drizzle produce, not synthetic stubs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDb } from './index.ts';
+import { safeQuery } from './safe-query.ts';
+import { integrationTokens } from './schema/integration-tokens.ts';
+
+describe('safeQuery', () => {
+  let handle: ReturnType<typeof createDb>;
+
+  beforeEach(() => {
+    handle = createDb({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    handle.close();
+  });
+
+  it('returns ok with the query value on success', async () => {
+    const result = await safeQuery({
+      execute: () => handle.db.select().from(integrationTokens).all(),
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([]);
+    }
+  });
+
+  it('returns err with a SQLITE_CONSTRAINT_UNIQUE code on a unique conflict', async () => {
+    handle.db
+      .insert(integrationTokens)
+      .values({
+        integration: 'github',
+        token: 'gh_xxx',
+        accountLabel: null,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      })
+      .run();
+
+    const result = await safeQuery({
+      execute: () =>
+        handle.db
+          .insert(integrationTokens)
+          .values({
+            integration: 'github',
+            token: 'gh_yyy',
+            accountLabel: null,
+            createdAtMs: 2,
+            updatedAtMs: 2,
+          })
+          .run(),
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('SQLITE_CONSTRAINT_PRIMARYKEY');
+      expect(result.error.message).toMatch(/constraint failed/);
+      expect(result.error.cause).toBeDefined();
+    }
+  });
+
+  it('returns err carrying the underlying Error when execute throws a non-sqlite error', async () => {
+    const cause = new Error('handler blew up before reaching sqlite');
+    const result = await safeQuery<unknown>({
+      execute: () => {
+        throw cause;
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBeUndefined();
+      expect(result.error.message).toBe('handler blew up before reaching sqlite');
+      expect(result.error.cause).toBe(cause);
+    }
+  });
+});

--- a/packages/db/src/safe-query.ts
+++ b/packages/db/src/safe-query.ts
@@ -1,0 +1,66 @@
+/**
+ * `safeQuery` — exception-to-`Result` bridge for better-sqlite3 / Drizzle calls.
+ *
+ * Wraps a `Promise<T>` (or synchronous Drizzle call) in
+ * `ResultAsync<T, DatabaseError>`. On failure, walks the error's `.cause`
+ * chain via `extractSqliteErrorShape` to pull SQLite-specific fields
+ * (`SQLITE_CONSTRAINT_UNIQUE`, table name, constraint column), then
+ * returns a uniform `DatabaseError` from `@slopweaver/errors`.
+ *
+ * This is the DB counterpart to `safeApiCall` (which lives in
+ * `@slopweaver/errors` because it's storage-agnostic). `safeQuery` lives
+ * here because the better-sqlite3 dependency belongs to this package.
+ *
+ * Service code should never use `try`/`catch` around a Drizzle call — use
+ * `safeQuery` instead, then `.mapErr()` to a domain error if the raw
+ * `DatabaseError` shape is not what the caller wants.
+ *
+ * @example
+ * ```ts
+ * const result = safeQuery({
+ *   execute: () =>
+ *     db.insert(integrationTokens).values({ … }).run(),
+ * });
+ * if (result.isErr() && result.error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+ *   // …
+ * }
+ * ```
+ *
+ * Drizzle's better-sqlite3 driver is synchronous, so `execute` may return
+ * a plain `T` — the wrapper handles both via `Promise.resolve().then`.
+ */
+
+import type { DatabaseError } from '@slopweaver/errors';
+import { ResultAsync } from '@slopweaver/errors';
+import { extractSqliteErrorShape } from './sqlite-error.ts';
+
+export function safeQuery<T>({
+  execute,
+}: {
+  execute: () => Promise<T> | T;
+}): ResultAsync<T, DatabaseError> {
+  return ResultAsync.fromPromise(
+    Promise.resolve().then(execute),
+    (error): DatabaseError => mapDatabaseError({ error }),
+  );
+}
+
+function mapDatabaseError({ error }: { error: unknown }): DatabaseError {
+  const shape = extractSqliteErrorShape({ error });
+
+  const fallbackMessage =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : 'Database operation failed';
+
+  return {
+    cause: error,
+    message: shape?.message ?? fallbackMessage,
+    ...(shape?.code !== undefined && { code: shape.code }),
+    ...(shape?.constraint !== undefined && { constraint: shape.constraint }),
+    ...(shape?.detail !== undefined && { detail: shape.detail }),
+    ...(shape?.table !== undefined && { table: shape.table }),
+  };
+}

--- a/packages/db/src/safe-query.ts
+++ b/packages/db/src/safe-query.ts
@@ -17,7 +17,7 @@
  *
  * @example
  * ```ts
- * const result = safeQuery({
+ * const result = await safeQuery({
  *   execute: () =>
  *     db.insert(integrationTokens).values({ … }).run(),
  * });

--- a/packages/db/src/sqlite-error.test.ts
+++ b/packages/db/src/sqlite-error.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { extractSqliteErrorShape } from './sqlite-error.ts';
+
+describe('extractSqliteErrorShape', () => {
+  it('returns null for non-error values', () => {
+    expect(extractSqliteErrorShape({ error: undefined })).toBeNull();
+    expect(extractSqliteErrorShape({ error: null })).toBeNull();
+    expect(extractSqliteErrorShape({ error: 42 })).toBeNull();
+  });
+
+  it('extracts SQLITE_* code and message from a top-level SqliteError-shaped object', () => {
+    const error = Object.assign(new Error('UNIQUE constraint failed: users.email'), {
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+    });
+
+    const shape = extractSqliteErrorShape({ error });
+
+    expect(shape).toEqual({
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+      message: 'UNIQUE constraint failed: users.email',
+      table: 'users',
+      constraint: 'email',
+    });
+  });
+
+  it('parses table-only when constraint message has no column', () => {
+    const error = Object.assign(new Error('FOREIGN KEY constraint failed'), {
+      code: 'SQLITE_CONSTRAINT_FOREIGNKEY',
+    });
+
+    const shape = extractSqliteErrorShape({ error });
+
+    expect(shape?.code).toBe('SQLITE_CONSTRAINT_FOREIGNKEY');
+    expect(shape?.message).toBe('FOREIGN KEY constraint failed');
+    expect(shape?.table).toBeUndefined();
+    expect(shape?.constraint).toBeUndefined();
+  });
+
+  it('walks the .cause chain to find the SqliteError when wrapped', () => {
+    const inner = Object.assign(new Error('UNIQUE constraint failed: t.col'), {
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+    });
+    const wrapped = new Error('drizzle: failed to insert', { cause: inner });
+
+    const shape = extractSqliteErrorShape({ error: wrapped });
+
+    expect(shape?.code).toBe('SQLITE_CONSTRAINT_UNIQUE');
+    expect(shape?.table).toBe('t');
+    expect(shape?.constraint).toBe('col');
+  });
+
+  it('rejects codes that do not match SQLITE_* and falls back to message-only', () => {
+    const error = Object.assign(new Error('something broke'), { code: 'EBADREQ' });
+    const shape = extractSqliteErrorShape({ error });
+
+    expect(shape?.code).toBeUndefined();
+    expect(shape?.message).toBe('something broke');
+  });
+
+  it('returns a shape carrying just the message when no code is present anywhere', () => {
+    const error = new Error('plain error, no code');
+    const shape = extractSqliteErrorShape({ error });
+
+    expect(shape).toEqual({ message: 'plain error, no code' });
+  });
+});

--- a/packages/db/src/sqlite-error.ts
+++ b/packages/db/src/sqlite-error.ts
@@ -1,0 +1,115 @@
+/**
+ * better-sqlite3 error-shape extractor.
+ *
+ * better-sqlite3 throws errors (often `SqliteError`) with a `.code` field
+ * like `"SQLITE_CONSTRAINT_UNIQUE"`, `"SQLITE_BUSY"`, or
+ * `"SQLITE_CONSTRAINT_FOREIGNKEY"` and a human-readable `.message`.
+ * Drizzle ORM may catch and re-throw, attaching the raw sqlite error
+ * via `.cause` — so the extractor walks the `.cause` chain looking for
+ * the most specific shape.
+ *
+ * Mirrors `extractDatabaseErrorShape` in `slopweaver-private`'s
+ * postgres-error.utils, scoped to the SQLite error vocabulary. There's
+ * no separate `constraint` / `table` field on a SqliteError (that
+ * info is embedded in the message), so the parser pulls them out
+ * heuristically when the message has the standard
+ * `"UNIQUE constraint failed: tablename.column"` shape.
+ */
+
+export interface SqliteErrorShape {
+  message: string;
+  code?: string;
+  constraint?: string;
+  table?: string;
+  detail?: string;
+}
+
+const SQLITE_ERROR_CODE_PATTERN = /^SQLITE_[A-Z_]+$/;
+const CONSTRAINT_FAILED_PATTERN =
+  /^(?:UNIQUE|FOREIGN KEY|CHECK|NOT NULL|PRIMARY KEY) constraint failed:\s*(?<rest>.+)$/u;
+
+interface SqliteErrorLike {
+  message?: unknown;
+  code?: unknown;
+  cause?: unknown;
+}
+
+const asOptionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+const isObjectLike = (value: unknown): value is Record<string, unknown> =>
+  (typeof value === 'object' || typeof value === 'function') && value !== null;
+
+const isSqliteCode = (code: string | undefined): code is string =>
+  code !== undefined && SQLITE_ERROR_CODE_PATTERN.test(code);
+
+/**
+ * `"UNIQUE constraint failed: integration_tokens.integration"` →
+ * `{ table: "integration_tokens", constraint: "integration" }`.
+ *
+ * Returns an empty object if the message doesn't match the expected
+ * SQLite constraint-failed format.
+ */
+function parseConstraintMessage(message: string): { table?: string; constraint?: string } {
+  const match = CONSTRAINT_FAILED_PATTERN.exec(message);
+  const rest = match?.groups?.['rest']?.trim();
+  if (!rest) return {};
+
+  const [tableAndColumn] = rest.split(/[\s,]/);
+  if (!tableAndColumn) return {};
+
+  const [table, ...columnParts] = tableAndColumn.split('.');
+  if (!table) return {};
+
+  const constraint = columnParts.join('.');
+  return constraint ? { table, constraint } : { table };
+}
+
+export function extractSqliteErrorShape({ error }: { error: unknown }): SqliteErrorShape | null {
+  const queue: unknown[] = [error];
+  const visited = new Set<unknown>();
+  const candidates: SqliteErrorLike[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined || current === null) continue;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    if (!isObjectLike(current)) continue;
+    const errorLike: SqliteErrorLike = current;
+
+    const code = asOptionalString(errorLike.code);
+    if (isSqliteCode(code) || asOptionalString(errorLike.message) !== undefined) {
+      candidates.push(errorLike);
+    }
+
+    if (errorLike.cause !== undefined) {
+      queue.push(errorLike.cause);
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  // Prefer the most specific candidate (the one with a SQLITE_* code);
+  // fall back to the first candidate (which carries at least a message).
+  const candidateWithCode = candidates.find((c) => isSqliteCode(asOptionalString(c.code)));
+  const selected = candidateWithCode ?? candidates[0];
+  if (!selected) return null;
+
+  const code = asOptionalString(selected.code);
+  const rootMessage =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : 'Database operation failed';
+  const message = asOptionalString(selected.message) ?? rootMessage;
+  const { table, constraint } = parseConstraintMessage(message);
+
+  const result: SqliteErrorShape = { message };
+  if (isSqliteCode(code)) result.code = code;
+  if (table) result.table = table;
+  if (constraint) result.constraint = constraint;
+  return result;
+}

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -4,9 +4,9 @@
 
 Single source of truth for the SlopWeaver binary's environment variable
 contract. Defines a Zod schema and a `loadEnv()` helper that parses,
-freezes, and returns the result. On invalid input, throws one
-`EnvValidationError` with the full list of issues — never fail-fast on
-the first.
+freezes, and returns the result wrapped in a neverthrow `Result`. On
+invalid input the `Err` carries one `EnvValidationError` with the full
+list of issues — never fail-fast on the first.
 
 ## API
 
@@ -14,18 +14,24 @@ the first.
   string), `NODE_ENV` (`'development' | 'production' | 'test'`, default
   `'production'`), and `LOG_LEVEL` (`'debug' | 'info' | 'warn' | 'error'`,
   default `'info'`).
-- `loadEnv({ env = process.env })` — parses and returns a frozen `Env`.
-  Throws `EnvValidationError` (with `.issues: ReadonlyArray<EnvIssue>`)
-  on failure.
-- `Env`, `NodeEnv`, `LogLevel`, `EnvIssue` — inferred and helper types.
+- `loadEnv({ env = process.env })` — returns
+  `Result<Readonly<Env>, EnvValidationError>`. The `Err` value is an
+  `EnvValidationError` instance with `.issues: ReadonlyArray<EnvIssue>`.
+- `Env`, `NodeEnv`, `LogLevel`, `EnvIssue`, `EnvValidationError` —
+  inferred and helper types.
 
 ## Usage
 
 ```ts
 import { loadEnv } from '@slopweaver/env';
 
-// At the top of an app entrypoint:
-const env = loadEnv();
+// At an app entrypoint, unwrap the Result at the user-facing boundary:
+const result = loadEnv();
+if (result.isErr()) {
+  process.stderr.write(`${result.error.message}\n`);
+  process.exit(1);
+}
+const env = result.value;
 // env.NODE_ENV, env.LOG_LEVEL, env.XDG_DATA_HOME — all validated and frozen.
 ```
 

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -27,6 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@slopweaver/errors": "workspace:*",
     "zod": "4.4.2"
   },
   "devDependencies": {

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { EnvValidationError, loadEnv } from './index.ts';
 
 describe('loadEnv', () => {
-  it('parses a fully-specified env object', () => {
-    const env = loadEnv({
+  it('returns ok with a fully-specified env object', () => {
+    const result = loadEnv({
       env: {
         XDG_DATA_HOME: '/tmp/slopweaver-test',
         NODE_ENV: 'test',
@@ -11,70 +11,79 @@ describe('loadEnv', () => {
       },
     });
 
-    expect(env).toEqual({
-      XDG_DATA_HOME: '/tmp/slopweaver-test',
-      NODE_ENV: 'test',
-      LOG_LEVEL: 'debug',
-    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        XDG_DATA_HOME: '/tmp/slopweaver-test',
+        NODE_ENV: 'test',
+        LOG_LEVEL: 'debug',
+      });
+    }
   });
 
   it('applies defaults for NODE_ENV and LOG_LEVEL when env is empty', () => {
-    const env = loadEnv({ env: {} });
+    const result = loadEnv({ env: {} });
 
-    expect(env.NODE_ENV).toBe('production');
-    expect(env.LOG_LEVEL).toBe('info');
-    expect(env.XDG_DATA_HOME).toBeUndefined();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.NODE_ENV).toBe('production');
+      expect(result.value.LOG_LEVEL).toBe('info');
+      expect(result.value.XDG_DATA_HOME).toBeUndefined();
+    }
   });
 
   it('keeps XDG_DATA_HOME undefined when only the typed fields are set', () => {
-    const env = loadEnv({
+    const result = loadEnv({
       env: {
         NODE_ENV: 'development',
         LOG_LEVEL: 'warn',
       },
     });
 
-    expect(env.XDG_DATA_HOME).toBeUndefined();
-    expect(env.NODE_ENV).toBe('development');
-    expect(env.LOG_LEVEL).toBe('warn');
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.XDG_DATA_HOME).toBeUndefined();
+      expect(result.value.NODE_ENV).toBe('development');
+      expect(result.value.LOG_LEVEL).toBe('warn');
+    }
   });
 
-  it('aggregates every failure into a single EnvValidationError', () => {
-    let caught: unknown = null;
-    try {
-      loadEnv({
-        env: {
-          XDG_DATA_HOME: '',
-          NODE_ENV: 'banana',
-          LOG_LEVEL: 'shout',
-        },
-      });
-    } catch (error) {
-      caught = error;
+  it('returns err with an EnvValidationError aggregating every failure', () => {
+    const result = loadEnv({
+      env: {
+        XDG_DATA_HOME: '',
+        NODE_ENV: 'banana',
+        LOG_LEVEL: 'shout',
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(EnvValidationError);
+      expect(result.error.issues).toHaveLength(3);
+
+      const paths = result.error.issues.map((i) => i.path).sort();
+      expect(paths).toEqual(['LOG_LEVEL', 'NODE_ENV', 'XDG_DATA_HOME']);
+
+      expect(result.error.message).toContain('XDG_DATA_HOME');
+      expect(result.error.message).toContain('NODE_ENV');
+      expect(result.error.message).toContain('LOG_LEVEL');
+
+      const nodeEnvIssue = result.error.issues.find((i) => i.path === 'NODE_ENV');
+      expect(nodeEnvIssue?.received).toBe('banana');
     }
-
-    expect(caught).toBeInstanceOf(EnvValidationError);
-    const error = caught as EnvValidationError;
-    expect(error.issues).toHaveLength(3);
-
-    const paths = error.issues.map((i) => i.path).sort();
-    expect(paths).toEqual(['LOG_LEVEL', 'NODE_ENV', 'XDG_DATA_HOME']);
-
-    expect(error.message).toContain('XDG_DATA_HOME');
-    expect(error.message).toContain('NODE_ENV');
-    expect(error.message).toContain('LOG_LEVEL');
-
-    const nodeEnvIssue = error.issues.find((i) => i.path === 'NODE_ENV');
-    expect(nodeEnvIssue?.received).toBe('banana');
   });
 
   it('returns a frozen object that rejects mutation', () => {
-    const env = loadEnv({ env: { NODE_ENV: 'test' } });
+    const result = loadEnv({ env: { NODE_ENV: 'test' } });
 
-    expect(Object.isFrozen(env)).toBe(true);
-    expect(() => {
-      // @ts-expect-error: assigning to a readonly field at runtime to verify the freeze
-      env.NODE_ENV = 'development';
-    }).toThrow(TypeError);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(Object.isFrozen(result.value)).toBe(true);
+      expect(() => {
+        // @ts-expect-error: assigning to a readonly field at runtime to verify the freeze
+        result.value.NODE_ENV = 'development';
+      }).toThrow(TypeError);
+    }
   });
 });

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,3 +1,4 @@
+import { err, ok, type Result } from '@slopweaver/errors';
 import { z } from 'zod';
 
 export const NodeEnvSchema = z.enum(['development', 'production', 'test']);
@@ -36,7 +37,11 @@ export class EnvValidationError extends Error {
   }
 }
 
-export function loadEnv({ env = process.env }: { env?: NodeJS.ProcessEnv } = {}): Readonly<Env> {
+export function loadEnv({
+  env = process.env,
+}: {
+  env?: NodeJS.ProcessEnv;
+} = {}): Result<Readonly<Env>, EnvValidationError> {
   const result = EnvSchema.safeParse(env);
   if (!result.success) {
     const issues: EnvIssue[] = result.error.issues.map((i) => {
@@ -48,7 +53,7 @@ export function loadEnv({ env = process.env }: { env?: NodeJS.ProcessEnv } = {})
           : undefined;
       return { path, message: i.message, received };
     });
-    throw new EnvValidationError(issues);
+    return err(new EnvValidationError(issues));
   }
-  return Object.freeze(result.data);
+  return ok(Object.freeze(result.data));
 }

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,0 +1,85 @@
+# @slopweaver/errors
+
+## Purpose
+
+Shared error types and exception-to-`Result` boundary wrappers built on
+[neverthrow](https://github.com/supermacro/neverthrow). Every package in
+the monorepo uses these primitives so error handling is uniform: services
+return `Result<T, E>` / `ResultAsync<T, E>` instead of throwing.
+
+## API
+
+- `BaseError` — `{ code: string; message: string }`. Every domain error
+  interface extends this; `code` is the discriminant.
+- `ApiCallError` — raw output of `safeApiCall` before service-layer
+  mapping. Carries `provider`, `message`, optional `status`, optional
+  `code`, optional `cause`.
+- `DatabaseError` — raw output of `safeQuery` (lives in
+  `@slopweaver/db`) before service-layer mapping. Defined here so
+  non-DB packages can include it in their error unions without
+  depending on `@slopweaver/db`.
+- `safeApiCall({ execute, provider, extractError? })` — wraps a
+  `Promise<T>` (or sync value) in `ResultAsync<T, ApiCallError>`. Per-SDK
+  `extractError` callback pulls structured fields (HTTP status, error
+  code) from the raw exception.
+
+The DB-side wrapper `safeQuery` lives in `@slopweaver/db` because the
+better-sqlite3 dependency belongs there.
+
+## Conventions
+
+Error definitions follow the discriminated-union pattern with a `code`
+discriminant in `SCREAMING_SNAKE_CASE`. Each package exposes both an
+error union type and a factory namespace:
+
+```ts
+import type { BaseError } from '@slopweaver/errors';
+
+export interface SlackTokenInvalidError extends BaseError {
+  readonly code: 'SLACK_TOKEN_INVALID';
+  readonly tokenPrefix: string;
+}
+
+export type SlackError = SlackTokenInvalidError | /* … */;
+
+export const SlackErrors = {
+  tokenInvalid: (tokenPrefix: string): SlackTokenInvalidError => ({
+    code: 'SLACK_TOKEN_INVALID',
+    message: `Slack token must start with xoxp- or xoxb-, got "${tokenPrefix}"`,
+    tokenPrefix,
+  }),
+} as const;
+```
+
+See `.claude/rules/error-handling.md` for the full convention.
+
+## Usage
+
+External API call:
+
+```ts
+import { safeApiCall } from '@slopweaver/errors';
+
+const result = safeApiCall({
+  execute: () => octokit.rest.users.getAuthenticated(),
+  provider: 'github',
+  extractError: ({ error }) =>
+    error instanceof RequestError ? { status: error.status, code: 'GITHUB_API_ERROR' } : {},
+});
+
+if (result.isErr()) {
+  // result.error is an ApiCallError
+}
+```
+
+Test discipline:
+
+```ts
+expect(result.isErr()).toBe(true); // never .toBeTruthy()
+if (result.isErr()) {
+  expect(result.error.code).toBe('SLACK_TOKEN_INVALID');
+}
+```
+
+`eslint-plugin-neverthrow`'s `must-use-result` rule enforces that every
+`Result` / `ResultAsync` is consumed.

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -81,5 +81,9 @@ if (result.isErr()) {
 }
 ```
 
-`eslint-plugin-neverthrow`'s `must-use-result` rule enforces that every
-`Result` / `ResultAsync` is consumed.
+`eslint-plugin-neverthrow`'s `must-use-result` rule would enforce that every
+`Result` / `ResultAsync` is consumed, but it's currently incompatible with
+ESLint 10 and is deferred (#41). The CLI service-boundary scanner at
+`packages/cli-tools/src/check-neverthrow-service-boundaries/` covers the
+highest-risk regression class (no thrown errors at service boundaries) in
+the meantime.

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@slopweaver/errors",
+  "version": "0.0.0",
+  "private": false,
+  "description": "SlopWeaver shared error types and Result/ResultAsync boundary wrappers built on neverthrow.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "compile": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "neverthrow": "8.2.0"
+  },
+  "devDependencies": {
+    "typescript": "6.0.3",
+    "vitest": "4.1.5"
+  }
+}

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,0 +1,4 @@
+export { err, errAsync, ok, okAsync, Result, ResultAsync, fromThrowable } from 'neverthrow';
+
+export type { ApiCallError, BaseError, DatabaseError } from './types.ts';
+export { safeApiCall } from './safe-api-call.ts';

--- a/packages/errors/src/safe-api-call.test.ts
+++ b/packages/errors/src/safe-api-call.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { safeApiCall } from './safe-api-call.ts';
+
+describe('safeApiCall', () => {
+  it('returns ok with the resolved value on success', async () => {
+    const result = await safeApiCall({
+      execute: () => Promise.resolve({ id: 1, name: 'kit' }),
+      provider: 'test',
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ id: 1, name: 'kit' });
+    }
+  });
+
+  it('wraps a thrown Error into an ApiCallError carrying provider, message, and cause', async () => {
+    const cause = new Error('upstream said no');
+    const result = await safeApiCall({
+      execute: () => {
+        throw cause;
+      },
+      provider: 'github',
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.provider).toBe('github');
+      expect(result.error.message).toBe('upstream said no');
+      expect(result.error.cause).toBe(cause);
+    }
+  });
+
+  it('uses the extractor to pull SDK-specific fields, then enforces provider/message/cause', async () => {
+    const cause = { status: 429, body: { error: 'rate_limit' } };
+    const result = await safeApiCall({
+      execute: () => Promise.reject(cause),
+      provider: 'slack',
+      extractError: ({ error }) => {
+        const e = error as { status?: number; body?: { error?: string } };
+        const out: Partial<{ status: number; code: string }> = {};
+        if (typeof e.status === 'number') out.status = e.status;
+        if (typeof e.body?.error === 'string') out.code = e.body.error;
+        return out;
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status).toBe(429);
+      expect(result.error.code).toBe('rate_limit');
+      expect(result.error.provider).toBe('slack');
+      expect(result.error.cause).toBe(cause);
+    }
+  });
+
+  it('falls back to a generic message when the thrown value is not an Error or string', async () => {
+    const result = await safeApiCall({
+      execute: () => Promise.reject({ weird: 'shape' }),
+      provider: 'test',
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe('API call failed');
+    }
+  });
+
+  it('uses the extracted message when the extractor provides one', async () => {
+    const result = await safeApiCall({
+      execute: () => Promise.reject(new Error('raw')),
+      provider: 'test',
+      extractError: () => ({ message: 'extracted' }),
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe('extracted');
+    }
+  });
+});

--- a/packages/errors/src/safe-api-call.ts
+++ b/packages/errors/src/safe-api-call.ts
@@ -53,7 +53,18 @@ function mapApiCallError({
   provider: string;
   extractError?: (({ error }: { error: unknown }) => Partial<ApiCallError>) | undefined;
 }): ApiCallError {
-  const extracted = extractError?.({ error }) ?? {};
+  // Guard the extractor: a throwing extractor would propagate out of the
+  // ResultAsync.fromPromise error mapper and reject the ResultAsync instead
+  // of resolving to Err, breaking the Result-boundary guarantee. Fall back
+  // to an empty shape if it throws.
+  let extracted: Partial<ApiCallError> = {};
+  if (extractError) {
+    try {
+      extracted = extractError({ error }) ?? {};
+    } catch {
+      extracted = {};
+    }
+  }
 
   const fallbackMessage =
     error instanceof Error ? error.message : typeof error === 'string' ? error : 'API call failed';

--- a/packages/errors/src/safe-api-call.ts
+++ b/packages/errors/src/safe-api-call.ts
@@ -1,0 +1,67 @@
+/**
+ * `safeApiCall` — exception-to-`Result` bridge for external API/SDK calls.
+ *
+ * Wraps a `Promise<T>` (or synchronous value) in
+ * `ResultAsync<T, ApiCallError>`. On failure, an optional per-SDK
+ * `extractError` callback pulls structured fields (HTTP status, vendor
+ * error code) out of the raw exception; the wrapper then fills in
+ * `provider`, `message`, and `cause` to produce a uniform `ApiCallError`.
+ *
+ * This is the external-API counterpart to `safeQuery` (which lives in
+ * `@slopweaver/db` because the better-sqlite3 dependency belongs there).
+ * Service code should never use `try`/`catch` around a vendor SDK call —
+ * use `safeApiCall` instead, then `.mapErr()` to a domain error if the
+ * raw `ApiCallError` shape is not what the caller wants.
+ *
+ * @example
+ * ```ts
+ * const result = safeApiCall({
+ *   execute: () => slack.search.messages({ query, count: 100 }),
+ *   provider: 'slack',
+ *   extractError: ({ error }) =>
+ *     error instanceof WebAPIPlatformError
+ *       ? { code: error.data?.error ?? 'SLACK_API_ERROR' }
+ *       : {},
+ * });
+ * ```
+ */
+
+import { ResultAsync } from 'neverthrow';
+import type { ApiCallError } from './types.ts';
+
+export function safeApiCall<T>({
+  execute,
+  provider,
+  extractError,
+}: {
+  execute: () => Promise<T> | T;
+  provider: string;
+  extractError?: ({ error }: { error: unknown }) => Partial<ApiCallError>;
+}): ResultAsync<T, ApiCallError> {
+  return ResultAsync.fromPromise(
+    Promise.resolve().then(execute),
+    (error): ApiCallError => mapApiCallError({ error, extractError, provider }),
+  );
+}
+
+function mapApiCallError({
+  error,
+  provider,
+  extractError,
+}: {
+  error: unknown;
+  provider: string;
+  extractError?: (({ error }: { error: unknown }) => Partial<ApiCallError>) | undefined;
+}): ApiCallError {
+  const extracted = extractError?.({ error }) ?? {};
+
+  const fallbackMessage =
+    error instanceof Error ? error.message : typeof error === 'string' ? error : 'API call failed';
+
+  return {
+    ...extracted,
+    cause: error,
+    message: extracted.message ?? fallbackMessage,
+    provider,
+  };
+}

--- a/packages/errors/src/types.ts
+++ b/packages/errors/src/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared error type primitives.
+ *
+ * Every domain error interface in the monorepo extends `BaseError`. The
+ * `code` field is the discriminant — exhaustive `.match()` / switch on
+ * `code` is how callers handle error unions without ad-hoc string
+ * comparison.
+ *
+ * `ApiCallError` and `DatabaseError` are the raw output shapes of the
+ * boundary wrappers (`safeApiCall` here, `safeQuery` in `@slopweaver/db`).
+ * Service layers `.mapErr()` these into their own domain-specific
+ * code'd errors when needed.
+ */
+
+export interface BaseError {
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface ApiCallError {
+  readonly message: string;
+  readonly provider: string;
+  readonly cause?: unknown;
+  readonly status?: number;
+  readonly code?: string;
+}
+
+export interface DatabaseError {
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly code?: string;
+  readonly constraint?: string;
+  readonly detail?: string;
+  readonly table?: string;
+}

--- a/packages/errors/tsconfig.build.json
+++ b/packages/errors/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/errors/vitest.config.ts
+++ b/packages/errors/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/integrations/core/package.json
+++ b/packages/integrations/core/package.json
@@ -35,6 +35,7 @@
     "@pollyjs/core": "6.0.6",
     "@pollyjs/persister-fs": "6.0.6",
     "@slopweaver/db": "workspace:*",
+    "@slopweaver/errors": "workspace:*",
     "drizzle-orm": "0.45.2",
     "nock": "13.5.6",
     "node-fetch": "3.3.2",

--- a/packages/integrations/core/src/upsert.test.ts
+++ b/packages/integrations/core/src/upsert.test.ts
@@ -14,8 +14,8 @@ afterEach(() => {
 });
 
 describe('upsertEvidence', () => {
-  it('inserts a new row keyed by (integration, externalId)', () => {
-    upsertEvidence({
+  it('inserts a new row keyed by (integration, externalId)', async () => {
+    const result = await upsertEvidence({
       db: handle.db,
       integration: 'github',
       externalId: 'pr_1',
@@ -27,6 +27,7 @@ describe('upsertEvidence', () => {
       occurredAtMs: 100,
       now: 200,
     });
+    expect(result.isOk()).toBe(true);
 
     const rows = handle.db.select().from(evidenceLog).all();
     expect(rows).toHaveLength(1);
@@ -42,8 +43,8 @@ describe('upsertEvidence', () => {
     });
   });
 
-  it('on conflict updates mutable fields but preserves firstSeenAtMs and createdAtMs', () => {
-    upsertEvidence({
+  it('on conflict updates mutable fields but preserves firstSeenAtMs and createdAtMs', async () => {
+    await upsertEvidence({
       db: handle.db,
       integration: 'github',
       externalId: 'pr_1',
@@ -56,7 +57,7 @@ describe('upsertEvidence', () => {
       now: 200,
     });
 
-    upsertEvidence({
+    await upsertEvidence({
       db: handle.db,
       integration: 'github',
       externalId: 'pr_1',
@@ -84,8 +85,8 @@ describe('upsertEvidence', () => {
     });
   });
 
-  it('keeps rows for different integrations independent under the same externalId', () => {
-    upsertEvidence({
+  it('keeps rows for different integrations independent under the same externalId', async () => {
+    await upsertEvidence({
       db: handle.db,
       integration: 'github',
       externalId: 'shared_id',
@@ -97,7 +98,7 @@ describe('upsertEvidence', () => {
       occurredAtMs: 1,
       now: 1,
     });
-    upsertEvidence({
+    await upsertEvidence({
       db: handle.db,
       integration: 'slack',
       externalId: 'shared_id',
@@ -116,8 +117,9 @@ describe('upsertEvidence', () => {
 });
 
 describe('integration_state helpers', () => {
-  it('markPollStarted inserts a fresh row when none exists', () => {
-    markPollStarted({ db: handle.db, integration: 'github', now: 1000 });
+  it('markPollStarted inserts a fresh row when none exists', async () => {
+    const result = await markPollStarted({ db: handle.db, integration: 'github', now: 1000 });
+    expect(result.isOk()).toBe(true);
 
     const row = handle.db
       .select()
@@ -134,9 +136,9 @@ describe('integration_state helpers', () => {
     });
   });
 
-  it('markPollStarted bumps the timestamp on subsequent calls', () => {
-    markPollStarted({ db: handle.db, integration: 'github', now: 1000 });
-    markPollStarted({ db: handle.db, integration: 'github', now: 2000 });
+  it('markPollStarted bumps the timestamp on subsequent calls', async () => {
+    await markPollStarted({ db: handle.db, integration: 'github', now: 1000 });
+    await markPollStarted({ db: handle.db, integration: 'github', now: 2000 });
 
     const row = handle.db
       .select()
@@ -148,14 +150,15 @@ describe('integration_state helpers', () => {
     expect(row?.createdAtMs).toBe(1000);
   });
 
-  it('markPollCompleted writes cursor + completion timestamp', () => {
-    markPollStarted({ db: handle.db, integration: 'github', now: 1000 });
-    markPollCompleted({
+  it('markPollCompleted writes cursor + completion timestamp', async () => {
+    await markPollStarted({ db: handle.db, integration: 'github', now: 1000 });
+    const result = await markPollCompleted({
       db: handle.db,
       integration: 'github',
       cursor: '2026-05-01T00:00:00Z',
       now: 1500,
     });
+    expect(result.isOk()).toBe(true);
 
     const row = handle.db
       .select()
@@ -169,28 +172,39 @@ describe('integration_state helpers', () => {
     });
   });
 
-  it('markPollCompleted returns 0 if markPollStarted never ran', () => {
-    const changes = markPollCompleted({
+  it('markPollCompleted returns ok(0) if markPollStarted never ran', async () => {
+    const result = await markPollCompleted({
       db: handle.db,
       integration: 'github',
       cursor: 'x',
       now: 1,
     });
-    expect(changes).toBe(0);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(0);
+    }
   });
 
-  it('readCursor returns null when no row exists', () => {
-    expect(readCursor({ db: handle.db, integration: 'github' })).toBeNull();
+  it('readCursor returns ok(null) when no row exists', async () => {
+    const result = await readCursor({ db: handle.db, integration: 'github' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBeNull();
+    }
   });
 
-  it('readCursor returns the stored cursor', () => {
-    markPollStarted({ db: handle.db, integration: 'github', now: 1000 });
-    markPollCompleted({
+  it('readCursor returns ok with the stored cursor', async () => {
+    await markPollStarted({ db: handle.db, integration: 'github', now: 1000 });
+    await markPollCompleted({
       db: handle.db,
       integration: 'github',
       cursor: '2026-05-01T00:00:00Z',
       now: 1500,
     });
-    expect(readCursor({ db: handle.db, integration: 'github' })).toBe('2026-05-01T00:00:00Z');
+    const result = await readCursor({ db: handle.db, integration: 'github' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('2026-05-01T00:00:00Z');
+    }
   });
 });

--- a/packages/integrations/core/src/upsert.ts
+++ b/packages/integrations/core/src/upsert.ts
@@ -13,10 +13,14 @@
  * never finished" doctor signal.
  *
  * Generic over `integration: string`. Integration packages call these
- * directly with their slug (`'github'`, `'slack'`, …).
+ * directly with their slug (`'github'`, `'slack'`, …). All four functions
+ * return `ResultAsync<…, DatabaseError>` via `safeQuery`; service callers
+ * are responsible for handling the `Err` (typically by translating into
+ * their own per-platform error union).
  */
 
-import { type SlopweaverDatabase, evidenceLog, integrationState } from '@slopweaver/db';
+import { evidenceLog, integrationState, safeQuery, type SlopweaverDatabase } from '@slopweaver/db';
+import type { DatabaseError, ResultAsync } from '@slopweaver/errors';
 import { eq, sql } from 'drizzle-orm';
 
 export type UpsertEvidenceArgs = {
@@ -43,36 +47,40 @@ export function upsertEvidence({
   payloadJson,
   occurredAtMs,
   now,
-}: UpsertEvidenceArgs): void {
-  db.insert(evidenceLog)
-    .values({
-      integration,
-      externalId,
-      kind,
-      title,
-      body,
-      citationUrl,
-      payloadJson,
-      occurredAtMs,
-      firstSeenAtMs: now,
-      lastSeenAtMs: now,
-      createdAtMs: now,
-      updatedAtMs: now,
-    })
-    .onConflictDoUpdate({
-      target: [evidenceLog.integration, evidenceLog.externalId],
-      set: {
-        kind,
-        title,
-        body,
-        citationUrl,
-        payloadJson,
-        occurredAtMs,
-        lastSeenAtMs: sql`excluded.last_seen_at_ms`,
-        updatedAtMs: sql`excluded.updated_at_ms`,
-      },
-    })
-    .run();
+}: UpsertEvidenceArgs): ResultAsync<void, DatabaseError> {
+  return safeQuery({
+    execute: () => {
+      db.insert(evidenceLog)
+        .values({
+          integration,
+          externalId,
+          kind,
+          title,
+          body,
+          citationUrl,
+          payloadJson,
+          occurredAtMs,
+          firstSeenAtMs: now,
+          lastSeenAtMs: now,
+          createdAtMs: now,
+          updatedAtMs: now,
+        })
+        .onConflictDoUpdate({
+          target: [evidenceLog.integration, evidenceLog.externalId],
+          set: {
+            kind,
+            title,
+            body,
+            citationUrl,
+            payloadJson,
+            occurredAtMs,
+            lastSeenAtMs: sql`excluded.last_seen_at_ms`,
+            updatedAtMs: sql`excluded.updated_at_ms`,
+          },
+        })
+        .run();
+    },
+  });
 }
 
 export function markPollStarted({
@@ -83,24 +91,28 @@ export function markPollStarted({
   db: SlopweaverDatabase;
   integration: string;
   now: number;
-}): void {
-  db.insert(integrationState)
-    .values({
-      integration,
-      cursor: null,
-      lastPollStartedAtMs: now,
-      lastPollCompletedAtMs: null,
-      createdAtMs: now,
-      updatedAtMs: now,
-    })
-    .onConflictDoUpdate({
-      target: integrationState.integration,
-      set: {
-        lastPollStartedAtMs: now,
-        updatedAtMs: now,
-      },
-    })
-    .run();
+}): ResultAsync<void, DatabaseError> {
+  return safeQuery({
+    execute: () => {
+      db.insert(integrationState)
+        .values({
+          integration,
+          cursor: null,
+          lastPollStartedAtMs: now,
+          lastPollCompletedAtMs: null,
+          createdAtMs: now,
+          updatedAtMs: now,
+        })
+        .onConflictDoUpdate({
+          target: integrationState.integration,
+          set: {
+            lastPollStartedAtMs: now,
+            updatedAtMs: now,
+          },
+        })
+        .run();
+    },
+  });
 }
 
 /**
@@ -119,17 +131,21 @@ export function markPollCompleted({
   integration: string;
   cursor: string | null;
   now: number;
-}): number {
-  const result = db
-    .update(integrationState)
-    .set({
-      cursor,
-      lastPollCompletedAtMs: now,
-      updatedAtMs: now,
-    })
-    .where(eq(integrationState.integration, integration))
-    .run();
-  return result.changes;
+}): ResultAsync<number, DatabaseError> {
+  return safeQuery({
+    execute: () => {
+      const result = db
+        .update(integrationState)
+        .set({
+          cursor,
+          lastPollCompletedAtMs: now,
+          updatedAtMs: now,
+        })
+        .where(eq(integrationState.integration, integration))
+        .run();
+      return result.changes;
+    },
+  });
 }
 
 export function readCursor({
@@ -138,11 +154,15 @@ export function readCursor({
 }: {
   db: SlopweaverDatabase;
   integration: string;
-}): string | null {
-  const row = db
-    .select()
-    .from(integrationState)
-    .where(eq(integrationState.integration, integration))
-    .get();
-  return row?.cursor ?? null;
+}): ResultAsync<string | null, DatabaseError> {
+  return safeQuery({
+    execute: () => {
+      const row = db
+        .select()
+        .from(integrationState)
+        .where(eq(integrationState.integration, integration))
+        .get();
+      return row?.cursor ?? null;
+    },
+  });
 }

--- a/packages/integrations/github/package.json
+++ b/packages/integrations/github/package.json
@@ -31,6 +31,7 @@
     "@octokit/request-error": "7.1.0",
     "@octokit/rest": "22.0.1",
     "@slopweaver/db": "workspace:*",
+    "@slopweaver/errors": "workspace:*",
     "@slopweaver/integrations-core": "workspace:*",
     "drizzle-orm": "0.45.2"
   },

--- a/packages/integrations/github/src/errors.ts
+++ b/packages/integrations/github/src/errors.ts
@@ -24,7 +24,7 @@ export interface GithubDatabaseError extends BaseError {
 
 export type GithubError = GithubApiError | GithubDatabaseError;
 
-const GithubErrors = {
+export const GithubErrors = {
   apiError: (
     endpoint: string,
     opts: { status?: number; cause?: unknown; message?: string } = {},

--- a/packages/integrations/github/src/errors.ts
+++ b/packages/integrations/github/src/errors.ts
@@ -1,0 +1,82 @@
+/**
+ * GitHub-domain error union and factories.
+ *
+ * Discriminated by `code`. Mirrors the Slack package's shape so the public
+ * surface across integrations is uniform. `safeGithubCall` wraps Octokit
+ * calls, lifting `@octokit/request-error` instances (RequestError) into a
+ * structured `GithubApiError` carrying the HTTP status.
+ */
+
+import type { ApiCallError, BaseError, DatabaseError, ResultAsync } from '@slopweaver/errors';
+import { safeApiCall } from '@slopweaver/errors';
+
+export interface GithubApiError extends BaseError {
+  readonly code: 'GITHUB_API_ERROR';
+  readonly endpoint: string;
+  readonly status?: number;
+  readonly cause?: unknown;
+}
+
+export interface GithubDatabaseError extends BaseError {
+  readonly code: 'GITHUB_DATABASE_ERROR';
+  readonly cause?: unknown;
+}
+
+export type GithubError = GithubApiError | GithubDatabaseError;
+
+const GithubErrors = {
+  apiError: (
+    endpoint: string,
+    opts: { status?: number; cause?: unknown; message?: string } = {},
+  ): GithubApiError => ({
+    code: 'GITHUB_API_ERROR',
+    message: opts.message ?? `GitHub API call failed: ${endpoint}`,
+    endpoint,
+    ...(opts.status !== undefined && { status: opts.status }),
+    ...(opts.cause !== undefined && { cause: opts.cause }),
+  }),
+
+  databaseError: (message: string, cause?: unknown): GithubDatabaseError => ({
+    code: 'GITHUB_DATABASE_ERROR',
+    message,
+    ...(cause !== undefined && { cause }),
+  }),
+} as const;
+
+export function fromDatabaseError(dbError: DatabaseError): GithubDatabaseError {
+  return GithubErrors.databaseError(dbError.message, dbError.cause);
+}
+
+/**
+ * GitHub-aware wrapper around `safeApiCall`. Tags failure with the endpoint
+ * and pulls Octokit's `RequestError.status` so callers can branch on HTTP
+ * status without inspecting the raw exception.
+ */
+export function safeGithubCall<T>({
+  execute,
+  endpoint,
+}: {
+  execute: () => Promise<T> | T;
+  endpoint: string;
+}): ResultAsync<T, GithubApiError> {
+  return safeApiCall({
+    execute,
+    provider: 'github',
+    extractError: ({ error }) => {
+      if (error === null || typeof error !== 'object') return {};
+      const e = error as { status?: unknown; name?: unknown };
+      const status = typeof e.status === 'number' ? e.status : undefined;
+      const out: Partial<ApiCallError> = {
+        ...(status !== undefined && { status }),
+      };
+      return out;
+    },
+  }).mapErr(
+    (apiErr): GithubApiError =>
+      GithubErrors.apiError(endpoint, {
+        ...(apiErr.status !== undefined && { status: apiErr.status }),
+        cause: apiErr.cause,
+        message: apiErr.message,
+      }),
+  );
+}

--- a/packages/integrations/github/src/identity.test.ts
+++ b/packages/integrations/github/src/identity.test.ts
@@ -17,12 +17,15 @@ afterEach(() => {
 
 describe('fetchIdentity', () => {
   it('inserts an identity_graph row for the authenticated user', async () => {
-    const { canonicalId, externalId } = await fetchIdentity({
+    const result = await fetchIdentity({
       db: handle.db,
       token: REPLAY_TOKEN,
       now: () => 1000,
     });
 
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+    const { canonicalId, externalId } = result.value;
     expect(canonicalId).toBe(`github:${externalId}`);
 
     const row = handle.db
@@ -42,14 +45,16 @@ describe('fetchIdentity', () => {
   });
 
   it('on second call updates mutable fields but preserves createdAtMs', async () => {
-    await fetchIdentity({ db: handle.db, token: REPLAY_TOKEN, now: () => 1000 });
+    const first = await fetchIdentity({ db: handle.db, token: REPLAY_TOKEN, now: () => 1000 });
+    expect(first.isOk()).toBe(true);
     const before = handle.db
       .select()
       .from(identityGraph)
       .where(eq(identityGraph.integration, 'github'))
       .get();
 
-    await fetchIdentity({ db: handle.db, token: REPLAY_TOKEN, now: () => 2000 });
+    const second = await fetchIdentity({ db: handle.db, token: REPLAY_TOKEN, now: () => 2000 });
+    expect(second.isOk()).toBe(true);
     const after = handle.db
       .select()
       .from(identityGraph)

--- a/packages/integrations/github/src/identity.ts
+++ b/packages/integrations/github/src/identity.ts
@@ -8,9 +8,11 @@
  * a UUID and back-linked.
  */
 
-import { identityGraph, type SlopweaverDatabase } from '@slopweaver/db';
+import { identityGraph, safeQuery, type SlopweaverDatabase } from '@slopweaver/db';
+import type { ResultAsync } from '@slopweaver/errors';
 import { sql } from 'drizzle-orm';
 import { createGithubClient } from './client.ts';
+import { fromDatabaseError, type GithubError, safeGithubCall } from './errors.ts';
 
 const INTEGRATION = 'github';
 
@@ -25,38 +27,47 @@ export type FetchIdentityResult = {
   externalId: string;
 };
 
-export async function fetchIdentity({
+export function fetchIdentity({
   db,
   token,
   now = () => Date.now(),
-}: FetchIdentityArgs): Promise<FetchIdentityResult> {
+}: FetchIdentityArgs): ResultAsync<FetchIdentityResult, GithubError> {
   const octokit = createGithubClient({ token });
-  const { data: user } = await octokit.rest.users.getAuthenticated();
-  const externalId = String(user.id);
-  const canonicalId = `${INTEGRATION}:${externalId}`;
-  const stamp = now();
 
-  db.insert(identityGraph)
-    .values({
-      canonicalId,
-      integration: INTEGRATION,
-      externalId,
-      username: user.login,
-      displayName: user.name ?? null,
-      profileUrl: user.html_url,
-      createdAtMs: stamp,
-      updatedAtMs: stamp,
-    })
-    .onConflictDoUpdate({
-      target: [identityGraph.integration, identityGraph.externalId],
-      set: {
-        username: user.login,
-        displayName: user.name ?? null,
-        profileUrl: user.html_url,
-        updatedAtMs: sql`excluded.updated_at_ms`,
+  return safeGithubCall({
+    execute: () => octokit.rest.users.getAuthenticated(),
+    endpoint: 'users.getAuthenticated',
+  }).andThen(({ data: user }) => {
+    const externalId = String(user.id);
+    const canonicalId = `${INTEGRATION}:${externalId}`;
+    const stamp = now();
+
+    return safeQuery({
+      execute: () => {
+        db.insert(identityGraph)
+          .values({
+            canonicalId,
+            integration: INTEGRATION,
+            externalId,
+            username: user.login,
+            displayName: user.name ?? null,
+            profileUrl: user.html_url,
+            createdAtMs: stamp,
+            updatedAtMs: stamp,
+          })
+          .onConflictDoUpdate({
+            target: [identityGraph.integration, identityGraph.externalId],
+            set: {
+              username: user.login,
+              displayName: user.name ?? null,
+              profileUrl: user.html_url,
+              updatedAtMs: sql`excluded.updated_at_ms`,
+            },
+          })
+          .run();
       },
     })
-    .run();
-
-  return { canonicalId, externalId };
+      .mapErr(fromDatabaseError)
+      .map(() => ({ canonicalId, externalId }));
+  });
 }

--- a/packages/integrations/github/src/index.ts
+++ b/packages/integrations/github/src/index.ts
@@ -1,5 +1,13 @@
 export { createGithubClient } from './client.ts';
 export type { CreateGithubClientArgs, GithubClient } from './client.ts';
+export {
+  fromDatabaseError,
+  GithubErrors,
+  safeGithubCall,
+  type GithubApiError,
+  type GithubDatabaseError,
+  type GithubError,
+} from './errors.ts';
 export { fetchIdentity } from './identity.ts';
 export type { FetchIdentityArgs, FetchIdentityResult } from './identity.ts';
 export { pollIssues, pollMentions, pollPullRequests } from './polling.ts';

--- a/packages/integrations/github/src/polling.test.ts
+++ b/packages/integrations/github/src/polling.test.ts
@@ -1,9 +1,23 @@
 import { createDb, evidenceLog, integrationState } from '@slopweaver/db';
+import type { ResultAsync } from '@slopweaver/errors';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { pollIssues, pollMentions, pollPullRequests } from './polling.ts';
+import type { GithubError } from './errors.ts';
+import { type PollResult, pollIssues, pollMentions, pollPullRequests } from './polling.ts';
 
 const REPLAY_TOKEN = process.env['GH_TOKEN'] ?? 'ghp_replay_token_redacted';
+
+function expectOkValue(promise: ResultAsync<PollResult, GithubError>): Promise<PollResult> {
+  return promise.match(
+    (v) => {
+      expect(true).toBe(true);
+      return v;
+    },
+    (e) => {
+      throw new Error(`expectOkValue: result was Err: ${e.code} (${e.message})`);
+    },
+  );
+}
 
 let handle: ReturnType<typeof createDb>;
 
@@ -17,19 +31,21 @@ afterEach(() => {
 
 describe('pollPullRequests', () => {
   it('upserts each returned PR into evidence_log and bumps integration_state', async () => {
-    const result = await pollPullRequests({
-      db: handle.db,
-      token: REPLAY_TOKEN,
-      since: null,
-    });
+    const value = await expectOkValue(
+      pollPullRequests({
+        db: handle.db,
+        token: REPLAY_TOKEN,
+        since: null,
+      }),
+    );
 
     const rows = handle.db
       .select()
       .from(evidenceLog)
       .where(eq(evidenceLog.kind, 'pull_request'))
       .all();
-    expect(rows.length).toBe(result.fetched);
-    expect(result.fetched).toBeGreaterThan(0);
+    expect(rows.length).toBe(value.fetched);
+    expect(value.fetched).toBeGreaterThan(0);
     for (const row of rows) {
       expect(row.integration).toBe('github');
       expect(row.externalId.startsWith('pr_')).toBe(true);
@@ -42,7 +58,7 @@ describe('pollPullRequests', () => {
       .where(eq(integrationState.integration, 'github'))
       .get();
     expect(state?.lastPollCompletedAtMs).toBeTypeOf('number');
-    expect(state?.cursor).toBe(result.newCursor);
+    expect(state?.cursor).toBe(value.newCursor);
   });
 
   it('is idempotent on repeat polls (row count stays, lastSeenAtMs advances)', async () => {
@@ -52,12 +68,14 @@ describe('pollPullRequests', () => {
       return counter;
     };
 
-    await pollPullRequests({
-      db: handle.db,
-      token: REPLAY_TOKEN,
-      since: null,
-      now: stepClock,
-    });
+    await expectOkValue(
+      pollPullRequests({
+        db: handle.db,
+        token: REPLAY_TOKEN,
+        since: null,
+        now: stepClock,
+      }),
+    );
     const beforeRows = handle.db
       .select()
       .from(evidenceLog)
@@ -71,12 +89,14 @@ describe('pollPullRequests', () => {
     expect(trackedExternalId).toBeDefined();
     const beforeTracked = beforeRows.find((r) => r.externalId === trackedExternalId);
 
-    await pollPullRequests({
-      db: handle.db,
-      token: REPLAY_TOKEN,
-      since: null,
-      now: stepClock,
-    });
+    await expectOkValue(
+      pollPullRequests({
+        db: handle.db,
+        token: REPLAY_TOKEN,
+        since: null,
+        now: stepClock,
+      }),
+    );
     const afterRows = handle.db
       .select()
       .from(evidenceLog)
@@ -92,14 +112,16 @@ describe('pollPullRequests', () => {
 
 describe('pollIssues', () => {
   it('writes issue rows with kind="issue" and prefixed external_id', async () => {
-    const result = await pollIssues({
-      db: handle.db,
-      token: REPLAY_TOKEN,
-      since: null,
-    });
+    const value = await expectOkValue(
+      pollIssues({
+        db: handle.db,
+        token: REPLAY_TOKEN,
+        since: null,
+      }),
+    );
 
     const rows = handle.db.select().from(evidenceLog).where(eq(evidenceLog.kind, 'issue')).all();
-    expect(rows.length).toBe(result.fetched);
+    expect(rows.length).toBe(value.fetched);
     for (const row of rows) {
       expect(row.externalId.startsWith('issue_')).toBe(true);
     }
@@ -108,17 +130,19 @@ describe('pollIssues', () => {
 
 describe('pollMentions', () => {
   it('writes mention rows with kind="mention" and prefixed external_id', async () => {
-    const result = await pollMentions({
-      db: handle.db,
-      token: REPLAY_TOKEN,
-      since: null,
-      // GitHub's `mentions:` qualifier rejects `@me`; the maintainer's public
-      // login is fine to bake into a cassette URL (user logins are public).
-      username: 'lachiejames',
-    });
+    const value = await expectOkValue(
+      pollMentions({
+        db: handle.db,
+        token: REPLAY_TOKEN,
+        since: null,
+        // GitHub's `mentions:` qualifier rejects `@me`; the maintainer's public
+        // login is fine to bake into a cassette URL (user logins are public).
+        username: 'lachiejames',
+      }),
+    );
 
     const rows = handle.db.select().from(evidenceLog).where(eq(evidenceLog.kind, 'mention')).all();
-    expect(rows.length).toBe(result.fetched);
+    expect(rows.length).toBe(value.fetched);
     for (const row of rows) {
       expect(row.externalId.startsWith('mention_')).toBe(true);
     }

--- a/packages/integrations/github/src/polling.test.ts
+++ b/packages/integrations/github/src/polling.test.ts
@@ -17,14 +17,13 @@ afterEach(() => {
 
 describe('pollPullRequests', () => {
   it('upserts each returned PR into evidence_log and bumps integration_state', async () => {
-    const result = await pollPullRequests({
-      db: handle.db,
-      token: REPLAY_TOKEN,
-      since: null,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollPullRequests({
+        db: handle.db,
+        token: REPLAY_TOKEN,
+        since: null,
+      })
+    )._unsafeUnwrap();
 
     const rows = handle.db
       .select()
@@ -99,14 +98,13 @@ describe('pollPullRequests', () => {
 
 describe('pollIssues', () => {
   it('writes issue rows with kind="issue" and prefixed external_id', async () => {
-    const result = await pollIssues({
-      db: handle.db,
-      token: REPLAY_TOKEN,
-      since: null,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollIssues({
+        db: handle.db,
+        token: REPLAY_TOKEN,
+        since: null,
+      })
+    )._unsafeUnwrap();
 
     const rows = handle.db.select().from(evidenceLog).where(eq(evidenceLog.kind, 'issue')).all();
     expect(rows.length).toBe(value.fetched);
@@ -118,17 +116,16 @@ describe('pollIssues', () => {
 
 describe('pollMentions', () => {
   it('writes mention rows with kind="mention" and prefixed external_id', async () => {
-    const result = await pollMentions({
-      db: handle.db,
-      token: REPLAY_TOKEN,
-      since: null,
-      // GitHub's `mentions:` qualifier rejects `@me`; the maintainer's public
-      // login is fine to bake into a cassette URL (user logins are public).
-      username: 'lachiejames',
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollMentions({
+        db: handle.db,
+        token: REPLAY_TOKEN,
+        since: null,
+        // GitHub's `mentions:` qualifier rejects `@me`; the maintainer's public
+        // login is fine to bake into a cassette URL (user logins are public).
+        username: 'lachiejames',
+      })
+    )._unsafeUnwrap();
 
     const rows = handle.db.select().from(evidenceLog).where(eq(evidenceLog.kind, 'mention')).all();
     expect(rows.length).toBe(value.fetched);

--- a/packages/integrations/github/src/polling.test.ts
+++ b/packages/integrations/github/src/polling.test.ts
@@ -1,23 +1,9 @@
 import { createDb, evidenceLog, integrationState } from '@slopweaver/db';
-import type { ResultAsync } from '@slopweaver/errors';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { GithubError } from './errors.ts';
-import { type PollResult, pollIssues, pollMentions, pollPullRequests } from './polling.ts';
+import { pollIssues, pollMentions, pollPullRequests } from './polling.ts';
 
 const REPLAY_TOKEN = process.env['GH_TOKEN'] ?? 'ghp_replay_token_redacted';
-
-function expectOkValue(promise: ResultAsync<PollResult, GithubError>): Promise<PollResult> {
-  return promise.match(
-    (v) => {
-      expect(true).toBe(true);
-      return v;
-    },
-    (e) => {
-      throw new Error(`expectOkValue: result was Err: ${e.code} (${e.message})`);
-    },
-  );
-}
 
 let handle: ReturnType<typeof createDb>;
 
@@ -31,13 +17,14 @@ afterEach(() => {
 
 describe('pollPullRequests', () => {
   it('upserts each returned PR into evidence_log and bumps integration_state', async () => {
-    const value = await expectOkValue(
-      pollPullRequests({
-        db: handle.db,
-        token: REPLAY_TOKEN,
-        since: null,
-      }),
-    );
+    const result = await pollPullRequests({
+      db: handle.db,
+      token: REPLAY_TOKEN,
+      since: null,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     const rows = handle.db
       .select()
@@ -68,14 +55,14 @@ describe('pollPullRequests', () => {
       return counter;
     };
 
-    await expectOkValue(
-      pollPullRequests({
-        db: handle.db,
-        token: REPLAY_TOKEN,
-        since: null,
-        now: stepClock,
-      }),
-    );
+    const first = await pollPullRequests({
+      db: handle.db,
+      token: REPLAY_TOKEN,
+      since: null,
+      now: stepClock,
+    });
+    expect(first.isOk()).toBe(true);
+
     const beforeRows = handle.db
       .select()
       .from(evidenceLog)
@@ -89,14 +76,14 @@ describe('pollPullRequests', () => {
     expect(trackedExternalId).toBeDefined();
     const beforeTracked = beforeRows.find((r) => r.externalId === trackedExternalId);
 
-    await expectOkValue(
-      pollPullRequests({
-        db: handle.db,
-        token: REPLAY_TOKEN,
-        since: null,
-        now: stepClock,
-      }),
-    );
+    const second = await pollPullRequests({
+      db: handle.db,
+      token: REPLAY_TOKEN,
+      since: null,
+      now: stepClock,
+    });
+    expect(second.isOk()).toBe(true);
+
     const afterRows = handle.db
       .select()
       .from(evidenceLog)
@@ -112,13 +99,14 @@ describe('pollPullRequests', () => {
 
 describe('pollIssues', () => {
   it('writes issue rows with kind="issue" and prefixed external_id', async () => {
-    const value = await expectOkValue(
-      pollIssues({
-        db: handle.db,
-        token: REPLAY_TOKEN,
-        since: null,
-      }),
-    );
+    const result = await pollIssues({
+      db: handle.db,
+      token: REPLAY_TOKEN,
+      since: null,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     const rows = handle.db.select().from(evidenceLog).where(eq(evidenceLog.kind, 'issue')).all();
     expect(rows.length).toBe(value.fetched);
@@ -130,16 +118,17 @@ describe('pollIssues', () => {
 
 describe('pollMentions', () => {
   it('writes mention rows with kind="mention" and prefixed external_id', async () => {
-    const value = await expectOkValue(
-      pollMentions({
-        db: handle.db,
-        token: REPLAY_TOKEN,
-        since: null,
-        // GitHub's `mentions:` qualifier rejects `@me`; the maintainer's public
-        // login is fine to bake into a cassette URL (user logins are public).
-        username: 'lachiejames',
-      }),
-    );
+    const result = await pollMentions({
+      db: handle.db,
+      token: REPLAY_TOKEN,
+      since: null,
+      // GitHub's `mentions:` qualifier rejects `@me`; the maintainer's public
+      // login is fine to bake into a cassette URL (user logins are public).
+      username: 'lachiejames',
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     const rows = handle.db.select().from(evidenceLog).where(eq(evidenceLog.kind, 'mention')).all();
     expect(rows.length).toBe(value.fetched);

--- a/packages/integrations/github/src/polling.ts
+++ b/packages/integrations/github/src/polling.ts
@@ -71,7 +71,8 @@ async function runSearch({
   now = () => Date.now(),
 }: PollArgs & { kind: string; qualifier: string }): Promise<PollResult> {
   const startedAt = now();
-  markPollStarted({ db, integration: INTEGRATION, now: startedAt });
+  const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });
+  if (startResult.isErr()) throw new Error(startResult.error.message);
 
   const sinceClause = since ? ` updated:>${since.toISOString()}` : '';
   const octokit = createGithubClient({ token });
@@ -86,7 +87,7 @@ async function runSearch({
   const observedAt = now();
 
   for (const item of items) {
-    upsertEvidence({
+    const upsertResult = await upsertEvidence({
       db,
       integration: INTEGRATION,
       externalId: externalIdFor({ item, kind }),
@@ -98,13 +99,20 @@ async function runSearch({
       occurredAtMs: Date.parse(item.updated_at),
       now: observedAt,
     });
+    if (upsertResult.isErr()) throw new Error(upsertResult.error.message);
   }
 
   // When the poll returns zero items, preserve the prior watermark (`since`)
   // instead of resetting the cursor to null — otherwise the next poll would
   // backfill from the beginning unnecessarily.
   const newCursor = items[0]?.updated_at ?? since?.toISOString() ?? null;
-  markPollCompleted({ db, integration: INTEGRATION, cursor: newCursor, now: observedAt });
+  const completedResult = await markPollCompleted({
+    db,
+    integration: INTEGRATION,
+    cursor: newCursor,
+    now: observedAt,
+  });
+  if (completedResult.isErr()) throw new Error(completedResult.error.message);
   return { fetched: items.length, newCursor };
 }
 

--- a/packages/integrations/github/src/polling.ts
+++ b/packages/integrations/github/src/polling.ts
@@ -9,12 +9,19 @@
  * `external_id` is kind-prefixed (`pr_`, `issue_`, `mention_`) so a single
  * GitHub item observed via both `involves:@me` and `mentions:@me` queries
  * occupies separate rows in `evidence_log`.
+ *
+ * Returns `ResultAsync<PollResult, GithubError>`. Octokit calls flow through
+ * `safeGithubCall` which extracts `RequestError.status`; DB writes flow
+ * through `safeQuery` with `DatabaseError` mapped to `GithubDatabaseError`
+ * via `fromDatabaseError`.
  */
 
 import type { RestEndpointMethodTypes } from '@octokit/rest';
 import type { SlopweaverDatabase } from '@slopweaver/db';
-import { createGithubClient } from './client.ts';
+import { err, ok, type Result, ResultAsync } from '@slopweaver/errors';
 import { markPollCompleted, markPollStarted, upsertEvidence } from '@slopweaver/integrations-core';
+import { createGithubClient } from './client.ts';
+import { fromDatabaseError, type GithubError, safeGithubCall } from './errors.ts';
 
 const INTEGRATION = 'github';
 const PER_PAGE = 50;
@@ -46,15 +53,15 @@ export type PollResult = {
   newCursor: string | null;
 };
 
-export function pollPullRequests(args: PollArgs): Promise<PollResult> {
+export function pollPullRequests(args: PollArgs): ResultAsync<PollResult, GithubError> {
   return runSearch({ ...args, kind: 'pull_request', qualifier: 'is:pr involves:@me' });
 }
 
-export function pollIssues(args: PollArgs): Promise<PollResult> {
+export function pollIssues(args: PollArgs): ResultAsync<PollResult, GithubError> {
   return runSearch({ ...args, kind: 'issue', qualifier: 'is:issue involves:@me' });
 }
 
-export function pollMentions(args: PollMentionsArgs): Promise<PollResult> {
+export function pollMentions(args: PollMentionsArgs): ResultAsync<PollResult, GithubError> {
   return runSearch({
     ...args,
     kind: 'mention',
@@ -62,26 +69,38 @@ export function pollMentions(args: PollMentionsArgs): Promise<PollResult> {
   });
 }
 
-async function runSearch({
+function runSearch(
+  args: PollArgs & { kind: string; qualifier: string },
+): ResultAsync<PollResult, GithubError> {
+  return ResultAsync.fromSafePromise(runSearchInner(args)).andThen((r) => r);
+}
+
+async function runSearchInner({
   db,
   token,
   since,
   kind,
   qualifier,
   now = () => Date.now(),
-}: PollArgs & { kind: string; qualifier: string }): Promise<PollResult> {
+}: PollArgs & { kind: string; qualifier: string }): Promise<Result<PollResult, GithubError>> {
   const startedAt = now();
   const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });
-  if (startResult.isErr()) throw new Error(startResult.error.message);
+  if (startResult.isErr()) return err(fromDatabaseError(startResult.error));
 
   const sinceClause = since ? ` updated:>${since.toISOString()}` : '';
   const octokit = createGithubClient({ token });
-  const { data } = await octokit.rest.search.issuesAndPullRequests({
-    q: `${qualifier}${sinceClause}`,
-    per_page: PER_PAGE,
-    sort: 'updated',
-    order: 'desc',
+  const responseResult = await safeGithubCall({
+    execute: () =>
+      octokit.rest.search.issuesAndPullRequests({
+        q: `${qualifier}${sinceClause}`,
+        per_page: PER_PAGE,
+        sort: 'updated',
+        order: 'desc',
+      }),
+    endpoint: 'search.issuesAndPullRequests',
   });
+  if (responseResult.isErr()) return err(responseResult.error);
+  const { data } = responseResult.value;
 
   const items = data.items ?? [];
   const observedAt = now();
@@ -99,7 +118,7 @@ async function runSearch({
       occurredAtMs: Date.parse(item.updated_at),
       now: observedAt,
     });
-    if (upsertResult.isErr()) throw new Error(upsertResult.error.message);
+    if (upsertResult.isErr()) return err(fromDatabaseError(upsertResult.error));
   }
 
   // When the poll returns zero items, preserve the prior watermark (`since`)
@@ -112,8 +131,9 @@ async function runSearch({
     cursor: newCursor,
     now: observedAt,
   });
-  if (completedResult.isErr()) throw new Error(completedResult.error.message);
-  return { fetched: items.length, newCursor };
+  if (completedResult.isErr()) return err(fromDatabaseError(completedResult.error));
+
+  return ok({ fetched: items.length, newCursor });
 }
 
 function externalIdFor({ item, kind }: { item: SearchItem; kind: string }): string {

--- a/packages/integrations/slack/package.json
+++ b/packages/integrations/slack/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@slack/web-api": "7.15.1",
     "@slopweaver/db": "workspace:*",
+    "@slopweaver/errors": "workspace:*",
     "@slopweaver/integrations-core": "workspace:*",
     "drizzle-orm": "0.45.2"
   },

--- a/packages/integrations/slack/src/client.test.ts
+++ b/packages/integrations/slack/src/client.test.ts
@@ -11,23 +11,33 @@ import { describe, expect, it } from 'vitest';
 import { createSlackClient } from './client.ts';
 
 describe('createSlackClient', () => {
-  it('returns a WebClient instance', () => {
-    const client = createSlackClient({ token: 'xoxb-test' });
-    expect(client).toBeInstanceOf(WebClient);
+  it('returns ok with a WebClient instance', () => {
+    const result = createSlackClient({ token: 'xoxb-test' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBeInstanceOf(WebClient);
+    }
   });
 
-  it('rejects empty tokens at construction time', () => {
-    expect(() => createSlackClient({ token: '' })).toThrowError(/non-empty string/);
+  it('returns err with SLACK_TOKEN_INVALID when token is empty', () => {
+    const result = createSlackClient({ token: '' });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('SLACK_TOKEN_INVALID');
+    }
   });
 
   it('accepts a custom retryConfig override', () => {
-    const client = createSlackClient({
+    const result = createSlackClient({
       token: 'xoxb-test',
       retryConfig: { retries: 7 },
     });
     // The SDK doesn't expose the resolved retry config, so we settle for the
-    // construction-doesn't-throw assertion. The real behaviour is exercised
+    // construction-doesn't-fail assertion. The real behaviour is exercised
     // by integration tests against cassettes.
-    expect(client).toBeInstanceOf(WebClient);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBeInstanceOf(WebClient);
+    }
   });
 });

--- a/packages/integrations/slack/src/client.ts
+++ b/packages/integrations/slack/src/client.ts
@@ -12,6 +12,8 @@
  */
 
 import { WebClient, type WebClientOptions } from '@slack/web-api';
+import { err, ok, type Result } from '@slopweaver/errors';
+import { SlackErrors, type SlackTokenInvalidError } from './errors.ts';
 
 type RetryConfig = NonNullable<WebClientOptions['retryConfig']>;
 
@@ -32,11 +34,11 @@ export function createSlackClient({
 }: {
   token: string;
   retryConfig?: RetryConfig;
-}): WebClient {
+}): Result<WebClient, SlackTokenInvalidError> {
   if (!token) {
-    throw new Error('createSlackClient: token must be a non-empty string');
+    return err(SlackErrors.tokenInvalid(''));
   }
   const resolvedRetryConfig =
     retryConfig ?? (process.env['NODE_ENV'] === 'test' ? TEST_RETRY_CONFIG : PROD_RETRY_CONFIG);
-  return new WebClient(token, { retryConfig: resolvedRetryConfig });
+  return ok(new WebClient(token, { retryConfig: resolvedRetryConfig }));
 }

--- a/packages/integrations/slack/src/dms.test.ts
+++ b/packages/integrations/slack/src/dms.test.ts
@@ -8,8 +8,10 @@
 
 import type { WebClient } from '@slack/web-api';
 import { evidenceLog, integrationState } from '@slopweaver/db';
+import type { ResultAsync } from '@slopweaver/errors';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { pollDMs } from './dms.ts';
+import { pollDMs, type PollResult } from './dms.ts';
+import type { SlackError } from './errors.ts';
 import { openMemoryDb } from './test/db.ts';
 
 type DbHandle = ReturnType<typeof openMemoryDb>;
@@ -20,6 +22,18 @@ function asyncIter<T>(items: T[]): AsyncIterable<T> {
       for (const item of items) yield item;
     },
   };
+}
+
+function expectOkValue(promise: ResultAsync<PollResult, SlackError>): Promise<PollResult> {
+  return promise.match(
+    (v) => {
+      expect(true).toBe(true);
+      return v;
+    },
+    (e) => {
+      throw new Error(`expectOkValue: result was Err: ${e.code} (${e.message})`);
+    },
+  );
 }
 
 describe('pollDMs', () => {
@@ -82,15 +96,17 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: 'xoxb-test',
-      client,
-      now: () => 8_888,
-    });
+    const value = await expectOkValue(
+      pollDMs({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        now: () => 8_888,
+      }),
+    );
 
-    expect(result.fetched).toBe(3);
-    expect(result.newCursor).toBe(new Date(1_762_000_021_000).toISOString());
+    expect(value.fetched).toBe(3);
+    expect(value.newCursor).toBe(new Date(1_762_000_021_000).toISOString());
 
     const rows = dbHandle.db.select().from(evidenceLog).all();
     expect(rows).toHaveLength(3);
@@ -117,14 +133,16 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: 'xoxb-test',
-      client,
-      now: () => nowCounter++,
-    });
+    const value = await expectOkValue(
+      pollDMs({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        now: () => nowCounter++,
+      }),
+    );
 
-    expect(result.newCursor).toBe(new Date(7_000).toISOString());
+    expect(value.newCursor).toBe(new Date(7_000).toISOString());
 
     const state = dbHandle.db.select().from(integrationState).all();
     expect(state).toHaveLength(1);
@@ -147,15 +165,17 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: 'xoxb-test',
-      client,
-      since: new Date('2026-05-01T00:00:00Z'),
-      now: () => 1,
-    });
+    const value = await expectOkValue(
+      pollDMs({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        since: new Date('2026-05-01T00:00:00Z'),
+        now: () => 1,
+      }),
+    );
 
-    expect(result.newCursor).toBe('2026-05-01T00:00:00.000Z');
+    expect(value.newCursor).toBe('2026-05-01T00:00:00.000Z');
   });
 
   it('aggregates messages across multiple history pages for one channel', async () => {
@@ -176,15 +196,17 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: 'xoxb-test',
-      client,
-      now: () => 1,
-    });
+    const value = await expectOkValue(
+      pollDMs({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        now: () => 1,
+      }),
+    );
 
-    expect(result.fetched).toBe(3);
-    expect(result.newCursor).toBe(new Date(3_000).toISOString());
+    expect(value.fetched).toBe(3);
+    expect(value.newCursor).toBe(new Date(3_000).toISOString());
     expect(dbHandle.db.select().from(evidenceLog).all()).toHaveLength(3);
   });
 
@@ -204,13 +226,15 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    await pollDMs({
-      db: dbHandle.db,
-      token: 'xoxb-test',
-      client,
-      since: new Date('2026-05-01T00:00:00Z'),
-      now: () => 1,
-    });
+    await expectOkValue(
+      pollDMs({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        since: new Date('2026-05-01T00:00:00Z'),
+        now: () => 1,
+      }),
+    );
 
     expect(historySeen).toHaveLength(1);
     expect(historySeen[0]).toMatchObject({
@@ -234,8 +258,8 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    await pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 100 });
-    await pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 200 });
+    await expectOkValue(pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 100 }));
+    await expectOkValue(pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 200 }));
 
     expect(dbHandle.db.select().from(evidenceLog).all()).toHaveLength(1);
   });
@@ -255,14 +279,16 @@ describe('pollDMs (cassette)', () => {
   });
 
   it('returns a fetched count and writes integration_state for slack', async () => {
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
-      now: () => 1_000,
-    });
+    const value = await expectOkValue(
+      pollDMs({
+        db: dbHandle.db,
+        token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
+        now: () => 1_000,
+      }),
+    );
 
-    expect(typeof result.fetched).toBe('number');
-    expect(result.fetched).toBeGreaterThanOrEqual(0);
+    expect(typeof value.fetched).toBe('number');
+    expect(value.fetched).toBeGreaterThanOrEqual(0);
 
     const state = dbHandle.db.select().from(integrationState).all();
     expect(state).toHaveLength(1);

--- a/packages/integrations/slack/src/dms.test.ts
+++ b/packages/integrations/slack/src/dms.test.ts
@@ -82,15 +82,14 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: 'xoxb-test',
-      client,
-      now: () => 8_888,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollDMs({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        now: () => 8_888,
+      })
+    )._unsafeUnwrap();
 
     expect(value.fetched).toBe(3);
     expect(value.newCursor).toBe(new Date(1_762_000_021_000).toISOString());
@@ -120,15 +119,14 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: 'xoxb-test',
-      client,
-      now: () => nowCounter++,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollDMs({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        now: () => nowCounter++,
+      })
+    )._unsafeUnwrap();
 
     expect(value.newCursor).toBe(new Date(7_000).toISOString());
 
@@ -153,16 +151,15 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: 'xoxb-test',
-      client,
-      since: new Date('2026-05-01T00:00:00Z'),
-      now: () => 1,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollDMs({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        since: new Date('2026-05-01T00:00:00Z'),
+        now: () => 1,
+      })
+    )._unsafeUnwrap();
 
     expect(value.newCursor).toBe('2026-05-01T00:00:00.000Z');
   });
@@ -185,15 +182,14 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: 'xoxb-test',
-      client,
-      now: () => 1,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollDMs({
+        db: dbHandle.db,
+        token: 'xoxb-test',
+        client,
+        now: () => 1,
+      })
+    )._unsafeUnwrap();
 
     expect(value.fetched).toBe(3);
     expect(value.newCursor).toBe(new Date(3_000).toISOString());
@@ -270,14 +266,13 @@ describe('pollDMs (cassette)', () => {
   });
 
   it('returns a fetched count and writes integration_state for slack', async () => {
-    const result = await pollDMs({
-      db: dbHandle.db,
-      token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
-      now: () => 1_000,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollDMs({
+        db: dbHandle.db,
+        token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
+        now: () => 1_000,
+      })
+    )._unsafeUnwrap();
 
     expect(typeof value.fetched).toBe('number');
     expect(value.fetched).toBeGreaterThanOrEqual(0);

--- a/packages/integrations/slack/src/dms.test.ts
+++ b/packages/integrations/slack/src/dms.test.ts
@@ -8,10 +8,8 @@
 
 import type { WebClient } from '@slack/web-api';
 import { evidenceLog, integrationState } from '@slopweaver/db';
-import type { ResultAsync } from '@slopweaver/errors';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { pollDMs, type PollResult } from './dms.ts';
-import type { SlackError } from './errors.ts';
+import { pollDMs } from './dms.ts';
 import { openMemoryDb } from './test/db.ts';
 
 type DbHandle = ReturnType<typeof openMemoryDb>;
@@ -22,18 +20,6 @@ function asyncIter<T>(items: T[]): AsyncIterable<T> {
       for (const item of items) yield item;
     },
   };
-}
-
-function expectOkValue(promise: ResultAsync<PollResult, SlackError>): Promise<PollResult> {
-  return promise.match(
-    (v) => {
-      expect(true).toBe(true);
-      return v;
-    },
-    (e) => {
-      throw new Error(`expectOkValue: result was Err: ${e.code} (${e.message})`);
-    },
-  );
 }
 
 describe('pollDMs', () => {
@@ -96,14 +82,15 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const value = await expectOkValue(
-      pollDMs({
-        db: dbHandle.db,
-        token: 'xoxb-test',
-        client,
-        now: () => 8_888,
-      }),
-    );
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      now: () => 8_888,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(value.fetched).toBe(3);
     expect(value.newCursor).toBe(new Date(1_762_000_021_000).toISOString());
@@ -133,14 +120,15 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const value = await expectOkValue(
-      pollDMs({
-        db: dbHandle.db,
-        token: 'xoxb-test',
-        client,
-        now: () => nowCounter++,
-      }),
-    );
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      now: () => nowCounter++,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(value.newCursor).toBe(new Date(7_000).toISOString());
 
@@ -165,15 +153,16 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const value = await expectOkValue(
-      pollDMs({
-        db: dbHandle.db,
-        token: 'xoxb-test',
-        client,
-        since: new Date('2026-05-01T00:00:00Z'),
-        now: () => 1,
-      }),
-    );
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      since: new Date('2026-05-01T00:00:00Z'),
+      now: () => 1,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(value.newCursor).toBe('2026-05-01T00:00:00.000Z');
   });
@@ -196,14 +185,15 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    const value = await expectOkValue(
-      pollDMs({
-        db: dbHandle.db,
-        token: 'xoxb-test',
-        client,
-        now: () => 1,
-      }),
-    );
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      now: () => 1,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(value.fetched).toBe(3);
     expect(value.newCursor).toBe(new Date(3_000).toISOString());
@@ -226,15 +216,14 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    await expectOkValue(
-      pollDMs({
-        db: dbHandle.db,
-        token: 'xoxb-test',
-        client,
-        since: new Date('2026-05-01T00:00:00Z'),
-        now: () => 1,
-      }),
-    );
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      since: new Date('2026-05-01T00:00:00Z'),
+      now: () => 1,
+    });
+    expect(result.isOk()).toBe(true);
 
     expect(historySeen).toHaveLength(1);
     expect(historySeen[0]).toMatchObject({
@@ -258,8 +247,10 @@ describe('pollDMs', () => {
       },
     } as unknown as WebClient;
 
-    await expectOkValue(pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 100 }));
-    await expectOkValue(pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 200 }));
+    const r1 = await pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 100 });
+    expect(r1.isOk()).toBe(true);
+    const r2 = await pollDMs({ db: dbHandle.db, token: 'xoxb-test', client, now: () => 200 });
+    expect(r2.isOk()).toBe(true);
 
     expect(dbHandle.db.select().from(evidenceLog).all()).toHaveLength(1);
   });
@@ -279,13 +270,14 @@ describe('pollDMs (cassette)', () => {
   });
 
   it('returns a fetched count and writes integration_state for slack', async () => {
-    const value = await expectOkValue(
-      pollDMs({
-        db: dbHandle.db,
-        token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
-        now: () => 1_000,
-      }),
-    );
+    const result = await pollDMs({
+      db: dbHandle.db,
+      token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
+      now: () => 1_000,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(typeof value.fetched).toBe('number');
     expect(value.fetched).toBeGreaterThanOrEqual(0);

--- a/packages/integrations/slack/src/dms.ts
+++ b/packages/integrations/slack/src/dms.ts
@@ -12,6 +12,11 @@
  * `freshness` consumers (`start_session`, the Diagnostics UI) can see when
  * Slack last ran. Cursor advances to the newest message ts observed across
  * all channels in the poll; preserves prior watermark on empty.
+ *
+ * Returns `ResultAsync<PollResult, SlackError>`. SDK calls are wrapped in
+ * `safeSlackCall`; DB writes flow through `markPollStarted` /
+ * `markPollCompleted` / `upsertSlackMessage` (all `safeQuery`-backed) with
+ * `DatabaseError` mapped to `SlackDatabaseError` via `fromDatabaseError`.
  */
 
 import type {
@@ -20,8 +25,16 @@ import type {
   WebClient,
 } from '@slack/web-api';
 import type { SlopweaverDatabase } from '@slopweaver/db';
+import { err, ok, type Result, ResultAsync } from '@slopweaver/errors';
 import { markPollCompleted, markPollStarted } from '@slopweaver/integrations-core';
 import { createSlackClient } from './client.ts';
+import {
+  fromDatabaseError,
+  safeSlackCall,
+  type SlackError,
+  SlackErrors,
+  type SlackTsParseError,
+} from './errors.ts';
 import { pickNewestTs, upsertSlackMessage } from './upsert.ts';
 
 const INTEGRATION = 'slack';
@@ -39,26 +52,36 @@ export type PollResult = {
   newCursor: string | null;
 };
 
-export async function pollDMs({
+export function pollDMs(args: PollDMsArgs): ResultAsync<PollResult, SlackError> {
+  return ResultAsync.fromSafePromise(pollDMsInner(args)).andThen((r) => r);
+}
+
+async function pollDMsInner({
   db,
   token,
   since,
   client,
   now = Date.now,
-}: PollDMsArgs): Promise<PollResult> {
+}: PollDMsArgs): Promise<Result<PollResult, SlackError>> {
   let slack: WebClient;
   if (client) {
     slack = client;
   } else {
     const created = createSlackClient({ token });
-    if (created.isErr()) throw new Error(created.error.message);
+    if (created.isErr()) return err(created.error);
     slack = created.value;
   }
+
   const startedAt = now();
   const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });
-  if (startResult.isErr()) throw new Error(startResult.error.message);
+  if (startResult.isErr()) return err(fromDatabaseError(startResult.error));
 
-  const auth = await slack.auth.test();
+  const authResult = await safeSlackCall({
+    execute: () => slack.auth.test(),
+    endpoint: 'auth.test',
+  });
+  if (authResult.isErr()) return err(authResult.error);
+  const auth = authResult.value;
   // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees team_id on ok:true
   const teamId = auth.team_id!;
   const workspaceUrl = auth.url ?? null;
@@ -73,53 +96,76 @@ export async function pollDMs({
     limit: 200,
   }) as AsyncIterable<ConversationsListResponse>;
 
-  for await (const listPage of listIterable) {
-    for (const channel of listPage.channels ?? []) {
-      if (channel.is_im === false || !channel.id) continue;
-      const historyIterable = slack.paginate('conversations.history', {
-        channel: channel.id,
-        limit: 100,
-        ...(oldest !== undefined && { oldest }),
-      }) as AsyncIterable<ConversationsHistoryResponse>;
+  // `paginate` throws on SDK error (just like the underlying call); the
+  // try/catch lifts it into the SlackApiError union the rest of this
+  // function already returns. This is the only catch in the function — the
+  // SDK's async iterator surface doesn't compose with `safeSlackCall`
+  // (which works on a single `Promise<T>`, not an iterable).
+  try {
+    for await (const listPage of listIterable) {
+      for (const channel of listPage.channels ?? []) {
+        if (channel.is_im === false || !channel.id) continue;
+        const historyIterable = slack.paginate('conversations.history', {
+          channel: channel.id,
+          limit: 100,
+          ...(oldest !== undefined && { oldest }),
+        }) as AsyncIterable<ConversationsHistoryResponse>;
 
-      for await (const historyPage of historyIterable) {
-        const messages = historyPage.messages ?? [];
-        fetched += messages.length;
+        for await (const historyPage of historyIterable) {
+          const messages = historyPage.messages ?? [];
+          fetched += messages.length;
 
-        const observedAt = now();
-        for (const message of messages) {
-          const upsertResult = await upsertSlackMessage({
-            db,
-            message,
-            kind: 'message',
-            teamId,
-            workspaceUrl,
-            channelId: channel.id,
-            now: observedAt,
-          });
-          if (upsertResult.isErr()) throw new Error(upsertResult.error.message);
-        }
+          const observedAt = now();
+          for (const message of messages) {
+            const upsertResult = await upsertSlackMessage({
+              db,
+              message,
+              kind: 'message',
+              teamId,
+              workspaceUrl,
+              channelId: channel.id,
+              now: observedAt,
+            });
+            if (upsertResult.isErr()) return err(upsertResult.error);
+          }
 
-        const pageNewest = pickNewestTs(messages);
-        if (pageNewest && (newestTs === null || compareTs(pageNewest, newestTs) > 0)) {
-          newestTs = pageNewest;
+          const pageNewest = pickNewestTs(messages);
+          if (pageNewest && (newestTs === null || compareTs(pageNewest, newestTs) > 0)) {
+            newestTs = pageNewest;
+          }
         }
       }
     }
+  } catch (cause) {
+    return err(
+      SlackErrors.apiError('conversations.list', {
+        cause,
+        message: cause instanceof Error ? cause.message : 'conversations.list / .history failed',
+      }),
+    );
   }
 
   // Cursors are always ISO-8601 so the public `since?: Date` /
   // `newCursor: string | null` contract round-trips through `new Date(cursor)`.
   // Match github's polling.ts:106 stable-format rule.
-  const newCursor = newestTs ? slackTsToIso(newestTs) : (since?.toISOString() ?? null);
+  let newCursor: string | null;
+  if (newestTs) {
+    const isoResult = slackTsToIso(newestTs);
+    if (isoResult.isErr()) return err(isoResult.error);
+    newCursor = isoResult.value;
+  } else {
+    newCursor = since?.toISOString() ?? null;
+  }
+
   const completedResult = await markPollCompleted({
     db,
     integration: INTEGRATION,
     cursor: newCursor,
     now: now(),
   });
-  if (completedResult.isErr()) throw new Error(completedResult.error.message);
-  return { fetched, newCursor };
+  if (completedResult.isErr()) return err(fromDatabaseError(completedResult.error));
+
+  return ok({ fetched, newCursor });
 }
 
 function compareTs(a: string, b: string): number {
@@ -134,10 +180,10 @@ function toSlackTs({ date }: { date: Date }): string {
   return `${seconds}.000000`;
 }
 
-function slackTsToIso(ts: string): string {
+function slackTsToIso(ts: string): Result<string, SlackTsParseError> {
   const seconds = Number.parseFloat(ts);
   if (!Number.isFinite(seconds)) {
-    throw new Error(`slackTsToIso: cannot parse ts ${ts}`);
+    return err(SlackErrors.tsParseFailed(ts));
   }
-  return new Date(Math.round(seconds * 1_000)).toISOString();
+  return ok(new Date(Math.round(seconds * 1_000)).toISOString());
 }

--- a/packages/integrations/slack/src/dms.ts
+++ b/packages/integrations/slack/src/dms.ts
@@ -46,7 +46,14 @@ export async function pollDMs({
   client,
   now = Date.now,
 }: PollDMsArgs): Promise<PollResult> {
-  const slack = client ?? createSlackClient({ token });
+  let slack: WebClient;
+  if (client) {
+    slack = client;
+  } else {
+    const created = createSlackClient({ token });
+    if (created.isErr()) throw new Error(created.error.message);
+    slack = created.value;
+  }
   const startedAt = now();
   const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });
   if (startResult.isErr()) throw new Error(startResult.error.message);

--- a/packages/integrations/slack/src/dms.ts
+++ b/packages/integrations/slack/src/dms.ts
@@ -33,6 +33,7 @@ import {
   safeSlackCall,
   type SlackError,
   SlackErrors,
+  type SlackTokenInvalidError,
   type SlackTsParseError,
 } from './errors.ts';
 import { pickNewestTs, upsertSlackMessage } from './upsert.ts';
@@ -63,14 +64,11 @@ async function pollDMsInner({
   client,
   now = Date.now,
 }: PollDMsArgs): Promise<Result<PollResult, SlackError>> {
-  let slack: WebClient;
-  if (client) {
-    slack = client;
-  } else {
-    const created = createSlackClient({ token });
-    if (created.isErr()) return err(created.error);
-    slack = created.value;
-  }
+  const slackResult: Result<WebClient, SlackTokenInvalidError> = client
+    ? ok(client)
+    : createSlackClient({ token });
+  if (slackResult.isErr()) return err(slackResult.error);
+  const slack = slackResult.value;
 
   const startedAt = now();
   const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });

--- a/packages/integrations/slack/src/dms.ts
+++ b/packages/integrations/slack/src/dms.ts
@@ -48,7 +48,8 @@ export async function pollDMs({
 }: PollDMsArgs): Promise<PollResult> {
   const slack = client ?? createSlackClient({ token });
   const startedAt = now();
-  markPollStarted({ db, integration: INTEGRATION, now: startedAt });
+  const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });
+  if (startResult.isErr()) throw new Error(startResult.error.message);
 
   const auth = await slack.auth.test();
   // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees team_id on ok:true
@@ -80,7 +81,7 @@ export async function pollDMs({
 
         const observedAt = now();
         for (const message of messages) {
-          upsertSlackMessage({
+          const upsertResult = await upsertSlackMessage({
             db,
             message,
             kind: 'message',
@@ -89,6 +90,7 @@ export async function pollDMs({
             channelId: channel.id,
             now: observedAt,
           });
+          if (upsertResult.isErr()) throw new Error(upsertResult.error.message);
         }
 
         const pageNewest = pickNewestTs(messages);
@@ -103,7 +105,13 @@ export async function pollDMs({
   // `newCursor: string | null` contract round-trips through `new Date(cursor)`.
   // Match github's polling.ts:106 stable-format rule.
   const newCursor = newestTs ? slackTsToIso(newestTs) : (since?.toISOString() ?? null);
-  markPollCompleted({ db, integration: INTEGRATION, cursor: newCursor, now: now() });
+  const completedResult = await markPollCompleted({
+    db,
+    integration: INTEGRATION,
+    cursor: newCursor,
+    now: now(),
+  });
+  if (completedResult.isErr()) throw new Error(completedResult.error.message);
   return { fetched, newCursor };
 }
 

--- a/packages/integrations/slack/src/errors.ts
+++ b/packages/integrations/slack/src/errors.ts
@@ -1,0 +1,139 @@
+/**
+ * Slack-domain error union and factories.
+ *
+ * Discriminated by `code`. Service code returns `Result<T, SlackError>` /
+ * `ResultAsync<T, SlackError>`; callers exhaustively match on `code` at the
+ * boundary. Mirrors the convention in `slopweaver-private` and the public
+ * convention doc at `.claude/rules/error-handling.md`.
+ */
+
+import type { ApiCallError, BaseError, DatabaseError, ResultAsync } from '@slopweaver/errors';
+import { safeApiCall } from '@slopweaver/errors';
+
+export interface SlackTokenInvalidError extends BaseError {
+  readonly code: 'SLACK_TOKEN_INVALID';
+  readonly tokenPrefix: string;
+}
+
+export interface SlackApiError extends BaseError {
+  readonly code: 'SLACK_API_ERROR';
+  readonly endpoint: string;
+  readonly status?: number;
+  readonly slackCode?: string;
+  readonly cause?: unknown;
+}
+
+export interface SlackDatabaseError extends BaseError {
+  readonly code: 'SLACK_DATABASE_ERROR';
+  readonly cause?: unknown;
+}
+
+export interface SlackPaginationCapError extends BaseError {
+  readonly code: 'SLACK_PAGINATION_CAP_EXCEEDED';
+  readonly totalPages: number;
+  readonly maxPages: number;
+}
+
+export interface SlackTsParseError extends BaseError {
+  readonly code: 'SLACK_TS_PARSE_FAILED';
+  readonly ts: string;
+}
+
+export type SlackError =
+  | SlackTokenInvalidError
+  | SlackApiError
+  | SlackDatabaseError
+  | SlackPaginationCapError
+  | SlackTsParseError;
+
+export const SlackErrors = {
+  tokenInvalid: (tokenPrefix: string): SlackTokenInvalidError => ({
+    code: 'SLACK_TOKEN_INVALID',
+    message: tokenPrefix
+      ? `Slack token has unexpected prefix "${tokenPrefix}"; expected xoxp- or xoxb-.`
+      : 'Slack token must be a non-empty string.',
+    tokenPrefix,
+  }),
+
+  apiError: (
+    endpoint: string,
+    opts: { status?: number; slackCode?: string; cause?: unknown; message?: string } = {},
+  ): SlackApiError => ({
+    code: 'SLACK_API_ERROR',
+    message: opts.message ?? `Slack API call failed: ${endpoint}`,
+    endpoint,
+    ...(opts.status !== undefined && { status: opts.status }),
+    ...(opts.slackCode !== undefined && { slackCode: opts.slackCode }),
+    ...(opts.cause !== undefined && { cause: opts.cause }),
+  }),
+
+  databaseError: (message: string, cause?: unknown): SlackDatabaseError => ({
+    code: 'SLACK_DATABASE_ERROR',
+    message,
+    ...(cause !== undefined && { cause }),
+  }),
+
+  paginationCapExceeded: (totalPages: number, maxPages: number): SlackPaginationCapError => ({
+    code: 'SLACK_PAGINATION_CAP_EXCEEDED',
+    message: `Slack search returned ${totalPages} pages, exceeds MAX_PAGES=${maxPages}; cursor not advanced. Re-run with a more recent since to recover the tail.`,
+    totalPages,
+    maxPages,
+  }),
+
+  tsParseFailed: (ts: string): SlackTsParseError => ({
+    code: 'SLACK_TS_PARSE_FAILED',
+    message: `Cannot parse Slack ts: ${ts}`,
+    ts,
+  }),
+} as const;
+
+/**
+ * Translate a `DatabaseError` (raw output of `safeQuery`) into a
+ * `SlackDatabaseError` so callers see only the SlackError union.
+ */
+export function fromDatabaseError(dbError: DatabaseError): SlackDatabaseError {
+  return SlackErrors.databaseError(dbError.message, dbError.cause);
+}
+
+/**
+ * Slack-aware wrapper around `safeApiCall`. Tags the failure with the
+ * endpoint and pulls Slack's `data.error` (the SDK's `WebAPIPlatformError`
+ * shape) so callers can distinguish e.g. `not_allowed_token_type` from
+ * other API failures by `slackCode`.
+ */
+export function safeSlackCall<T>({
+  execute,
+  endpoint,
+}: {
+  execute: () => Promise<T> | T;
+  endpoint: string;
+}): ResultAsync<T, SlackApiError> {
+  return safeApiCall({
+    execute,
+    provider: 'slack',
+    extractError: ({ error }) => {
+      if (error === null || typeof error !== 'object') return {};
+      const e = error as { code?: unknown; data?: { error?: unknown }; status?: unknown };
+      const status = typeof e.status === 'number' ? e.status : undefined;
+      const slackCode =
+        typeof e.data?.error === 'string'
+          ? e.data.error
+          : typeof e.code === 'string'
+            ? e.code
+            : undefined;
+      const out: Partial<ApiCallError> = {
+        ...(status !== undefined && { status }),
+        ...(slackCode !== undefined && { code: slackCode }),
+      };
+      return out;
+    },
+  }).mapErr(
+    (apiErr): SlackApiError =>
+      SlackErrors.apiError(endpoint, {
+        ...(apiErr.status !== undefined && { status: apiErr.status }),
+        ...(apiErr.code !== undefined && { slackCode: apiErr.code }),
+        cause: apiErr.cause,
+        message: apiErr.message,
+      }),
+  );
+}

--- a/packages/integrations/slack/src/identity.test.ts
+++ b/packages/integrations/slack/src/identity.test.ts
@@ -66,10 +66,13 @@ describe('fetchIdentity', () => {
       now: () => 1_762_000_000_000,
     });
 
-    expect(result).toEqual({
-      canonicalId: 'slack:T0WORKSPACE:U0SLOPBOT',
-      externalId: 'U0SLOPBOT',
-    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        canonicalId: 'slack:T0WORKSPACE:U0SLOPBOT',
+        externalId: 'U0SLOPBOT',
+      });
+    }
 
     const rows = dbHandle.db
       .select()
@@ -111,8 +114,12 @@ describe('fetchIdentity', () => {
         client: fakeWebClient({ authResponse: auth, usersInfoResponse: profile }),
         now: () => 2,
       });
-      expect(a.canonicalId).toBe(b.canonicalId);
-      expect(a.canonicalId).toBe('slack:T0:U0');
+      expect(a.isOk()).toBe(true);
+      expect(b.isOk()).toBe(true);
+      if (a.isOk() && b.isOk()) {
+        expect(a.value.canonicalId).toBe(b.value.canonicalId);
+        expect(a.value.canonicalId).toBe('slack:T0:U0');
+      }
     } finally {
       dbA.close();
       dbB.close();
@@ -150,7 +157,10 @@ describe('fetchIdentity', () => {
       now: () => 5_000,
     });
 
-    expect(result.canonicalId).toBe('slack:T0WORKSPACE:U0SLOPBOT');
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.canonicalId).toBe('slack:T0WORKSPACE:U0SLOPBOT');
+    }
 
     const rows = dbHandle.db.select().from(identityGraph).all();
     expect(rows).toHaveLength(1);
@@ -186,7 +196,7 @@ describe('fetchIdentity', () => {
     expect(row?.displayName).toBe('Alice Liddell');
   });
 
-  it('propagates SDK errors from slack.auth.test', async () => {
+  it('returns err with SLACK_API_ERROR when slack.auth.test throws', async () => {
     const client = {
       auth: {
         test: async () => {
@@ -196,14 +206,20 @@ describe('fetchIdentity', () => {
       users: { info: async () => ({ ok: true, user: { id: 'unused' } }) },
     } as unknown as WebClient;
 
-    await expect(
-      fetchIdentity({
-        db: dbHandle.db,
-        token: 'xoxb-test',
-        client,
-        now: () => 1,
-      }),
-    ).rejects.toThrowError(/invalid_auth/);
+    const result = await fetchIdentity({
+      db: dbHandle.db,
+      token: 'xoxb-test',
+      client,
+      now: () => 1,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('SLACK_API_ERROR');
+      if (result.error.code === 'SLACK_API_ERROR') {
+        expect(result.error.endpoint).toBe('auth.test');
+      }
+    }
   });
 });
 
@@ -230,16 +246,19 @@ describe('fetchIdentity (cassette)', () => {
       now: () => 1_000,
     });
 
-    expect(result.canonicalId).toMatch(/^slack:T[A-Z0-9]+:U[A-Z0-9]+$/);
-    expect(result.externalId).toMatch(/^U[A-Z0-9]+$/);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.canonicalId).toMatch(/^slack:T[A-Z0-9]+:U[A-Z0-9]+$/);
+      expect(result.value.externalId).toMatch(/^U[A-Z0-9]+$/);
 
-    const row = dbHandle.db.select().from(identityGraph).get();
-    expect(row).toMatchObject({
-      canonicalId: result.canonicalId,
-      integration: 'slack',
-      externalId: result.externalId,
-      createdAtMs: 1_000,
-      updatedAtMs: 1_000,
-    });
+      const row = dbHandle.db.select().from(identityGraph).get();
+      expect(row).toMatchObject({
+        canonicalId: result.value.canonicalId,
+        integration: 'slack',
+        externalId: result.value.externalId,
+        createdAtMs: 1_000,
+        updatedAtMs: 1_000,
+      });
+    }
   });
 });

--- a/packages/integrations/slack/src/identity.ts
+++ b/packages/integrations/slack/src/identity.ts
@@ -17,9 +17,11 @@
  */
 
 import type { WebClient } from '@slack/web-api';
-import { type SlopweaverDatabase, identityGraph } from '@slopweaver/db';
+import { identityGraph, safeQuery, type SlopweaverDatabase } from '@slopweaver/db';
+import { errAsync, type ResultAsync } from '@slopweaver/errors';
 import { sql } from 'drizzle-orm';
 import { createSlackClient } from './client.ts';
+import { fromDatabaseError, safeSlackCall, type SlackError } from './errors.ts';
 
 const INTEGRATION = 'slack';
 
@@ -35,55 +37,72 @@ export type FetchIdentityResult = {
   externalId: string;
 };
 
-export async function fetchIdentity({
+export function fetchIdentity({
   db,
   token,
   client,
   now = Date.now,
-}: FetchIdentityArgs): Promise<FetchIdentityResult> {
-  const slack = client ?? createSlackClient({ token });
+}: FetchIdentityArgs): ResultAsync<FetchIdentityResult, SlackError> {
+  let slack: WebClient;
+  if (client) {
+    slack = client;
+  } else {
+    const created = createSlackClient({ token });
+    if (created.isErr()) return errAsync(created.error);
+    slack = created.value;
+  }
 
-  const auth = await slack.auth.test();
-  // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees user_id on ok:true
-  const userId = auth.user_id!;
-  // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees team_id on ok:true
-  const teamId = auth.team_id!;
-  const canonicalId = `${INTEGRATION}:${teamId}:${userId}`;
-
-  const usersInfo = await slack.users.info({ user: userId });
-  const user = usersInfo.user;
-  const profile = user?.profile;
-  const username = user?.name ?? auth.user ?? null;
-  const displayName = profile?.display_name?.trim() || profile?.real_name?.trim() || null;
-  const profileUrl = auth.url ? `${stripTrailingSlash(auth.url)}/team/${userId}` : null;
-
-  const stamp = now();
-
-  db.insert(identityGraph)
-    .values({
-      canonicalId,
-      integration: INTEGRATION,
-      externalId: userId,
-      username,
-      displayName,
-      profileUrl,
-      createdAtMs: stamp,
-      updatedAtMs: stamp,
+  return safeSlackCall({
+    execute: () => slack.auth.test(),
+    endpoint: 'auth.test',
+  })
+    .andThen((auth) => {
+      // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees user_id on ok:true
+      const userId = auth.user_id!;
+      // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees team_id on ok:true
+      const teamId = auth.team_id!;
+      const canonicalId = `${INTEGRATION}:${teamId}:${userId}`;
+      const profileUrl = auth.url ? `${stripTrailingSlash(auth.url)}/team/${userId}` : null;
+      return safeSlackCall({
+        execute: () => slack.users.info({ user: userId }),
+        endpoint: 'users.info',
+      }).map((usersInfo) => ({ auth, userId, canonicalId, profileUrl, usersInfo }));
     })
-    .onConflictDoUpdate({
-      target: [identityGraph.integration, identityGraph.externalId],
-      // canonical_id and created_at_ms are preserved across re-runs by being
-      // absent from the conflict-update set.
-      set: {
-        username,
-        displayName,
-        profileUrl,
-        updatedAtMs: sql`excluded.updated_at_ms`,
-      },
-    })
-    .run();
+    .andThen(({ auth, userId, canonicalId, profileUrl, usersInfo }) => {
+      const user = usersInfo.user;
+      const profile = user?.profile;
+      const username = user?.name ?? auth.user ?? null;
+      const displayName = profile?.display_name?.trim() || profile?.real_name?.trim() || null;
+      const stamp = now();
 
-  return { canonicalId, externalId: userId };
+      return safeQuery({
+        execute: () => {
+          db.insert(identityGraph)
+            .values({
+              canonicalId,
+              integration: INTEGRATION,
+              externalId: userId,
+              username,
+              displayName,
+              profileUrl,
+              createdAtMs: stamp,
+              updatedAtMs: stamp,
+            })
+            .onConflictDoUpdate({
+              target: [identityGraph.integration, identityGraph.externalId],
+              set: {
+                username,
+                displayName,
+                profileUrl,
+                updatedAtMs: sql`excluded.updated_at_ms`,
+              },
+            })
+            .run();
+        },
+      })
+        .mapErr(fromDatabaseError)
+        .map(() => ({ canonicalId, externalId: userId }));
+    });
 }
 
 function stripTrailingSlash(url: string): string {

--- a/packages/integrations/slack/src/identity.ts
+++ b/packages/integrations/slack/src/identity.ts
@@ -18,10 +18,15 @@
 
 import type { WebClient } from '@slack/web-api';
 import { identityGraph, safeQuery, type SlopweaverDatabase } from '@slopweaver/db';
-import { errAsync, type ResultAsync } from '@slopweaver/errors';
+import { errAsync, ok, type Result, type ResultAsync } from '@slopweaver/errors';
 import { sql } from 'drizzle-orm';
 import { createSlackClient } from './client.ts';
-import { fromDatabaseError, safeSlackCall, type SlackError } from './errors.ts';
+import {
+  fromDatabaseError,
+  safeSlackCall,
+  type SlackError,
+  type SlackTokenInvalidError,
+} from './errors.ts';
 
 const INTEGRATION = 'slack';
 
@@ -43,14 +48,11 @@ export function fetchIdentity({
   client,
   now = Date.now,
 }: FetchIdentityArgs): ResultAsync<FetchIdentityResult, SlackError> {
-  let slack: WebClient;
-  if (client) {
-    slack = client;
-  } else {
-    const created = createSlackClient({ token });
-    if (created.isErr()) return errAsync(created.error);
-    slack = created.value;
-  }
+  const slackResult: Result<WebClient, SlackTokenInvalidError> = client
+    ? ok(client)
+    : createSlackClient({ token });
+  if (slackResult.isErr()) return errAsync(slackResult.error);
+  const slack = slackResult.value;
 
   return safeSlackCall({
     execute: () => slack.auth.test(),

--- a/packages/integrations/slack/src/index.ts
+++ b/packages/integrations/slack/src/index.ts
@@ -12,6 +12,17 @@
  */
 
 export { createSlackClient } from './client.ts';
+export {
+  fromDatabaseError,
+  safeSlackCall,
+  SlackErrors,
+  type SlackApiError,
+  type SlackDatabaseError,
+  type SlackError,
+  type SlackPaginationCapError,
+  type SlackTokenInvalidError,
+  type SlackTsParseError,
+} from './errors.ts';
 export { fetchIdentity, type FetchIdentityArgs, type FetchIdentityResult } from './identity.ts';
 export {
   pollMentions,

--- a/packages/integrations/slack/src/mentions.test.ts
+++ b/packages/integrations/slack/src/mentions.test.ts
@@ -9,29 +9,11 @@
 
 import type { WebClient } from '@slack/web-api';
 import { evidenceLog, integrationState } from '@slopweaver/db';
-import type { ResultAsync } from '@slopweaver/errors';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SlackError } from './errors.ts';
-import { pollMentions, type PollResult } from './mentions.ts';
+import { pollMentions } from './mentions.ts';
 import { openMemoryDb } from './test/db.ts';
 
 type DbHandle = ReturnType<typeof openMemoryDb>;
-
-/**
- * Unwrap a `ResultAsync` known to be Ok in this test, with a strong
- * assertion. Equivalent to `expect(r.isOk()).toBe(true); return r.value`.
- */
-function expectOkValue(promise: ResultAsync<PollResult, SlackError>): Promise<PollResult> {
-  return promise.match(
-    (v) => {
-      expect(true).toBe(true);
-      return v;
-    },
-    (e) => {
-      throw new Error(`expectOkValue: result was Err: ${e.code} (${e.message})`);
-    },
-  );
-}
 
 describe('pollMentions', () => {
   let dbHandle: DbHandle;
@@ -82,14 +64,15 @@ describe('pollMentions', () => {
       search: { messages: searchSpy },
     } as unknown as WebClient;
 
-    const value = await expectOkValue(
-      pollMentions({
-        db: dbHandle.db,
-        token: 'xoxp-test',
-        client,
-        now: () => 9_000_000,
-      }),
-    );
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 9_000_000,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(value.fetched).toBe(2);
     // Cursor normalized to ISO-8601 from the newest match's ts. The `.000200`
@@ -134,14 +117,15 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const value = await expectOkValue(
-      pollMentions({
-        db: dbHandle.db,
-        token: 'xoxp-test',
-        client,
-        now: () => nowCounter++,
-      }),
-    );
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => nowCounter++,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(value.newCursor).toBe(new Date(500_000).toISOString());
 
@@ -163,15 +147,16 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const value = await expectOkValue(
-      pollMentions({
-        db: dbHandle.db,
-        token: 'xoxp-test',
-        client,
-        since: new Date('2026-05-01T00:00:00Z'),
-        now: () => 1,
-      }),
-    );
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      since: new Date('2026-05-01T00:00:00Z'),
+      now: () => 1,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     // The since fallback is the ISO date, since no matches yielded a ts.
     expect(value.newCursor).toBe('2026-05-01T00:00:00.000Z');
@@ -192,15 +177,14 @@ describe('pollMentions', () => {
       search: { messages: searchSpy },
     } as unknown as WebClient;
 
-    await expectOkValue(
-      pollMentions({
-        db: dbHandle.db,
-        token: 'xoxp-test',
-        client,
-        since: new Date('2026-05-01T12:00:00Z'),
-        now: () => 1,
-      }),
-    );
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      since: new Date('2026-05-01T12:00:00Z'),
+      now: () => 1,
+    });
+    expect(result.isOk()).toBe(true);
   });
 
   it('walks search.messages pages until messages.paging.pages is reached', async () => {
@@ -229,14 +213,15 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const value = await expectOkValue(
-      pollMentions({
-        db: dbHandle.db,
-        token: 'xoxp-test',
-        client,
-        now: () => 1,
-      }),
-    );
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 1,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(seenPages).toEqual([1, 2, 3]);
     expect(value.fetched).toBe(3);
@@ -309,12 +294,20 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    await expectOkValue(
-      pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 100 }),
-    );
-    await expectOkValue(
-      pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 200 }),
-    );
+    const r1 = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 100,
+    });
+    expect(r1.isOk()).toBe(true);
+    const r2 = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 200,
+    });
+    expect(r2.isOk()).toBe(true);
 
     const rows = dbHandle.db.select().from(evidenceLog).all();
     expect(rows).toHaveLength(1);
@@ -347,14 +340,15 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const value = await expectOkValue(
-      pollMentions({
-        db: dbHandle.db,
-        token: 'xoxp-test',
-        client,
-        now: () => 1,
-      }),
-    );
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 1,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(value.fetched).toBe(2); // counts what Slack returned, not what got upserted
     const rows = dbHandle.db.select().from(evidenceLog).all();
@@ -379,13 +373,14 @@ describe('pollMentions (cassette)', () => {
   });
 
   it('returns a fetched count and writes integration_state for slack', async () => {
-    const value = await expectOkValue(
-      pollMentions({
-        db: dbHandle.db,
-        token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
-        now: () => 1_000,
-      }),
-    );
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
+      now: () => 1_000,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw new Error('unreachable');
+    const value = result.value;
 
     expect(typeof value.fetched).toBe('number');
     expect(value.fetched).toBeGreaterThanOrEqual(0);

--- a/packages/integrations/slack/src/mentions.test.ts
+++ b/packages/integrations/slack/src/mentions.test.ts
@@ -9,11 +9,29 @@
 
 import type { WebClient } from '@slack/web-api';
 import { evidenceLog, integrationState } from '@slopweaver/db';
+import type { ResultAsync } from '@slopweaver/errors';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { pollMentions } from './mentions.ts';
+import type { SlackError } from './errors.ts';
+import { pollMentions, type PollResult } from './mentions.ts';
 import { openMemoryDb } from './test/db.ts';
 
 type DbHandle = ReturnType<typeof openMemoryDb>;
+
+/**
+ * Unwrap a `ResultAsync` known to be Ok in this test, with a strong
+ * assertion. Equivalent to `expect(r.isOk()).toBe(true); return r.value`.
+ */
+function expectOkValue(promise: ResultAsync<PollResult, SlackError>): Promise<PollResult> {
+  return promise.match(
+    (v) => {
+      expect(true).toBe(true);
+      return v;
+    },
+    (e) => {
+      throw new Error(`expectOkValue: result was Err: ${e.code} (${e.message})`);
+    },
+  );
+}
 
 describe('pollMentions', () => {
   let dbHandle: DbHandle;
@@ -64,17 +82,19 @@ describe('pollMentions', () => {
       search: { messages: searchSpy },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      now: () => 9_000_000,
-    });
+    const value = await expectOkValue(
+      pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        now: () => 9_000_000,
+      }),
+    );
 
-    expect(result.fetched).toBe(2);
+    expect(value.fetched).toBe(2);
     // Cursor normalized to ISO-8601 from the newest match's ts. The `.000200`
     // tail is microseconds, which round to 0 ms below epoch-ms granularity.
-    expect(result.newCursor).toBe(new Date(1_762_000_000_000).toISOString());
+    expect(value.newCursor).toBe(new Date(1_762_000_000_000).toISOString());
     expect(searchSpy).toHaveBeenCalledOnce();
 
     const rows = dbHandle.db.select().from(evidenceLog).all();
@@ -114,14 +134,16 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      now: () => nowCounter++,
-    });
+    const value = await expectOkValue(
+      pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        now: () => nowCounter++,
+      }),
+    );
 
-    expect(result.newCursor).toBe(new Date(500_000).toISOString());
+    expect(value.newCursor).toBe(new Date(500_000).toISOString());
 
     const state = dbHandle.db.select().from(integrationState).all();
     expect(state).toHaveLength(1);
@@ -141,17 +163,19 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      since: new Date('2026-05-01T00:00:00Z'),
-      now: () => 1,
-    });
+    const value = await expectOkValue(
+      pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        since: new Date('2026-05-01T00:00:00Z'),
+        now: () => 1,
+      }),
+    );
 
     // The since fallback is the ISO date, since no matches yielded a ts.
-    expect(result.newCursor).toBe('2026-05-01T00:00:00.000Z');
-    expect(result.fetched).toBe(0);
+    expect(value.newCursor).toBe('2026-05-01T00:00:00.000Z');
+    expect(value.fetched).toBe(0);
   });
 
   it('appends a 1-day-padded after: filter when since is provided', async () => {
@@ -168,13 +192,15 @@ describe('pollMentions', () => {
       search: { messages: searchSpy },
     } as unknown as WebClient;
 
-    await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      since: new Date('2026-05-01T12:00:00Z'),
-      now: () => 1,
-    });
+    await expectOkValue(
+      pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        since: new Date('2026-05-01T12:00:00Z'),
+        now: () => 1,
+      }),
+    );
   });
 
   it('walks search.messages pages until messages.paging.pages is reached', async () => {
@@ -203,21 +229,23 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      now: () => 1,
-    });
+    const value = await expectOkValue(
+      pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        now: () => 1,
+      }),
+    );
 
     expect(seenPages).toEqual([1, 2, 3]);
-    expect(result.fetched).toBe(3);
+    expect(value.fetched).toBe(3);
     // Newest ts = 1000003.000000 = 1000003000 ms.
-    expect(result.newCursor).toBe(new Date(1_000_003_000).toISOString());
+    expect(value.newCursor).toBe(new Date(1_000_003_000).toISOString());
     expect(dbHandle.db.select().from(evidenceLog).all()).toHaveLength(3);
   });
 
-  it('throws and does NOT advance the cursor when paging exceeds MAX_PAGES', async () => {
+  it('returns SLACK_PAGINATION_CAP_EXCEEDED without advancing the cursor when paging exceeds MAX_PAGES', async () => {
     // Pre-seed integration_state with a baseline cursor so we can prove it
     // wasn't advanced by the failed poll.
     dbHandle.db
@@ -246,9 +274,17 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    await expect(
-      pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 1 }),
-    ).rejects.toThrowError(/exceeds MAX_PAGES/);
+    const result = await pollMentions({
+      db: dbHandle.db,
+      token: 'xoxp-test',
+      client,
+      now: () => 1,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('SLACK_PAGINATION_CAP_EXCEEDED');
+    }
 
     // Cursor must still be the baseline — markPollCompleted never ran.
     const state = dbHandle.db.select().from(integrationState).get();
@@ -273,8 +309,12 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    await pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 100 });
-    await pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 200 });
+    await expectOkValue(
+      pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 100 }),
+    );
+    await expectOkValue(
+      pollMentions({ db: dbHandle.db, token: 'xoxp-test', client, now: () => 200 }),
+    );
 
     const rows = dbHandle.db.select().from(evidenceLog).all();
     expect(rows).toHaveLength(1);
@@ -307,14 +347,16 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      now: () => 1,
-    });
+    const value = await expectOkValue(
+      pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        now: () => 1,
+      }),
+    );
 
-    expect(result.fetched).toBe(2); // counts what Slack returned, not what got upserted
+    expect(value.fetched).toBe(2); // counts what Slack returned, not what got upserted
     const rows = dbHandle.db.select().from(evidenceLog).all();
     expect(rows).toHaveLength(1);
     expect(rows[0]?.externalId).toBe('mention_101.0:C1');
@@ -337,14 +379,16 @@ describe('pollMentions (cassette)', () => {
   });
 
   it('returns a fetched count and writes integration_state for slack', async () => {
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
-      now: () => 1_000,
-    });
+    const value = await expectOkValue(
+      pollMentions({
+        db: dbHandle.db,
+        token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
+        now: () => 1_000,
+      }),
+    );
 
-    expect(typeof result.fetched).toBe('number');
-    expect(result.fetched).toBeGreaterThanOrEqual(0);
+    expect(typeof value.fetched).toBe('number');
+    expect(value.fetched).toBeGreaterThanOrEqual(0);
 
     const state = dbHandle.db.select().from(integrationState).all();
     expect(state).toHaveLength(1);

--- a/packages/integrations/slack/src/mentions.test.ts
+++ b/packages/integrations/slack/src/mentions.test.ts
@@ -64,15 +64,14 @@ describe('pollMentions', () => {
       search: { messages: searchSpy },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      now: () => 9_000_000,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        now: () => 9_000_000,
+      })
+    )._unsafeUnwrap();
 
     expect(value.fetched).toBe(2);
     // Cursor normalized to ISO-8601 from the newest match's ts. The `.000200`
@@ -117,15 +116,14 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      now: () => nowCounter++,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        now: () => nowCounter++,
+      })
+    )._unsafeUnwrap();
 
     expect(value.newCursor).toBe(new Date(500_000).toISOString());
 
@@ -147,16 +145,15 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      since: new Date('2026-05-01T00:00:00Z'),
-      now: () => 1,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        since: new Date('2026-05-01T00:00:00Z'),
+        now: () => 1,
+      })
+    )._unsafeUnwrap();
 
     // The since fallback is the ISO date, since no matches yielded a ts.
     expect(value.newCursor).toBe('2026-05-01T00:00:00.000Z');
@@ -213,15 +210,14 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      now: () => 1,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        now: () => 1,
+      })
+    )._unsafeUnwrap();
 
     expect(seenPages).toEqual([1, 2, 3]);
     expect(value.fetched).toBe(3);
@@ -340,15 +336,14 @@ describe('pollMentions', () => {
       },
     } as unknown as WebClient;
 
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: 'xoxp-test',
-      client,
-      now: () => 1,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollMentions({
+        db: dbHandle.db,
+        token: 'xoxp-test',
+        client,
+        now: () => 1,
+      })
+    )._unsafeUnwrap();
 
     expect(value.fetched).toBe(2); // counts what Slack returned, not what got upserted
     const rows = dbHandle.db.select().from(evidenceLog).all();
@@ -373,14 +368,13 @@ describe('pollMentions (cassette)', () => {
   });
 
   it('returns a fetched count and writes integration_state for slack', async () => {
-    const result = await pollMentions({
-      db: dbHandle.db,
-      token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
-      now: () => 1_000,
-    });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) throw new Error('unreachable');
-    const value = result.value;
+    const value = (
+      await pollMentions({
+        db: dbHandle.db,
+        token: process.env['SLACK_USER_TOKEN'] ?? 'xoxp-replay-token',
+        now: () => 1_000,
+      })
+    )._unsafeUnwrap();
 
     expect(typeof value.fetched).toBe('number');
     expect(value.fetched).toBeGreaterThanOrEqual(0);

--- a/packages/integrations/slack/src/mentions.ts
+++ b/packages/integrations/slack/src/mentions.ts
@@ -49,7 +49,14 @@ export async function pollMentions({
   client,
   now = Date.now,
 }: PollMentionsArgs): Promise<PollResult> {
-  const slack = client ?? createSlackClient({ token });
+  let slack: WebClient;
+  if (client) {
+    slack = client;
+  } else {
+    const created = createSlackClient({ token });
+    if (created.isErr()) throw new Error(created.error.message);
+    slack = created.value;
+  }
   const startedAt = now();
   const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });
   if (startResult.isErr()) throw new Error(startResult.error.message);

--- a/packages/integrations/slack/src/mentions.ts
+++ b/packages/integrations/slack/src/mentions.ts
@@ -8,21 +8,35 @@
  * `MAX_PAGES` safety cap, currently 20 = ~2k mentions).
  *
  * Slack's `search.messages` historically requires a user token (`xoxp-`); bot
- * tokens get `not_allowed_token_type`. The SDK throws on that envelope; we
- * surface the underlying error rather than swallowing it — token-type policy
- * is an OAuth-flow concern outside this package.
+ * tokens get `not_allowed_token_type`. `safeSlackCall` lifts the SDK's
+ * `WebAPIPlatformError` into a structured `SlackApiError` so callers can
+ * branch on the slack code without inspecting the raw exception.
  *
  * `since` (when provided) becomes a `after:YYYY-MM-DD` modifier on the search
  * query. Slack search has no millisecond cursor and the `after:` operator's
  * timezone semantics are undocumented — we pad backward by 1 day so we never
  * miss boundary messages; the idempotent `(integration, kind_ts:channel)`
  * upsert dedupes the extra rows that pulls in.
+ *
+ * Returns `ResultAsync<PollResult, SlackError>`. When the safety cap fires the
+ * function returns `err(SlackErrors.paginationCapExceeded(…))` without
+ * advancing the cursor — `markPollCompleted` never runs, so the next poll
+ * starts from the prior watermark and the unfetched tail is recoverable by
+ * re-running with a tighter `since`.
  */
 
 import type { WebClient } from '@slack/web-api';
 import type { SlopweaverDatabase } from '@slopweaver/db';
+import { err, errAsync, ok, type Result, ResultAsync } from '@slopweaver/errors';
 import { markPollCompleted, markPollStarted } from '@slopweaver/integrations-core';
 import { createSlackClient } from './client.ts';
+import {
+  fromDatabaseError,
+  safeSlackCall,
+  type SlackError,
+  SlackErrors,
+  type SlackTsParseError,
+} from './errors.ts';
 import { type AnySlackMessage, pickNewestTs, upsertSlackMessage } from './upsert.ts';
 
 const INTEGRATION = 'slack';
@@ -42,29 +56,36 @@ export type PollResult = {
   newCursor: string | null;
 };
 
-export async function pollMentions({
+export function pollMentions(args: PollMentionsArgs): ResultAsync<PollResult, SlackError> {
+  return ResultAsync.fromSafePromise(pollMentionsInner(args)).andThen((r) => r);
+}
+
+async function pollMentionsInner({
   db,
   token,
   since,
   client,
   now = Date.now,
-}: PollMentionsArgs): Promise<PollResult> {
+}: PollMentionsArgs): Promise<Result<PollResult, SlackError>> {
   let slack: WebClient;
   if (client) {
     slack = client;
   } else {
     const created = createSlackClient({ token });
-    if (created.isErr()) throw new Error(created.error.message);
+    if (created.isErr()) return err(created.error);
     slack = created.value;
   }
+
   const startedAt = now();
   const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });
-  if (startResult.isErr()) throw new Error(startResult.error.message);
+  if (startResult.isErr()) return err(fromDatabaseError(startResult.error));
 
-  // Slack guarantees user_id / team_id on ok:true responses; the SDK throws
-  // WebAPIPlatformError on { ok: false } so the asserts below are reached
-  // only when Slack returned values.
-  const auth = await slack.auth.test();
+  const authResult = await safeSlackCall({
+    execute: () => slack.auth.test(),
+    endpoint: 'auth.test',
+  });
+  if (authResult.isErr()) return err(authResult.error);
+  const auth = authResult.value;
   // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees user_id on ok:true
   const userId = auth.user_id!;
   // biome-ignore lint/style/noNonNullAssertion: SDK contract guarantees team_id on ok:true
@@ -84,7 +105,12 @@ export async function pollMentions({
   let totalPages = 1;
 
   while (page <= MAX_PAGES) {
-    const response = await slack.search.messages({ query, count: PER_PAGE, page });
+    const respResult = await safeSlackCall({
+      execute: () => slack.search.messages({ query, count: PER_PAGE, page }),
+      endpoint: 'search.messages',
+    });
+    if (respResult.isErr()) return err(respResult.error);
+    const response = respResult.value;
     const matches = response.messages?.matches ?? [];
     fetched += matches.length;
 
@@ -98,7 +124,7 @@ export async function pollMentions({
         workspaceUrl,
         now: observedAt,
       });
-      if (upsertResult.isErr()) throw new Error(upsertResult.error.message);
+      if (upsertResult.isErr()) return err(upsertResult.error);
     }
 
     const pageNewest = pickNewestTs(matches);
@@ -114,13 +140,11 @@ export async function pollMentions({
 
   // Refuse to advance the cursor if we exited the loop because of the safety
   // cap rather than because Slack said there were no more pages — otherwise
-  // the unfetched tail is unrecoverable on the next poll. Throwing is loud
-  // enough that the operator sees it and can re-run with a tighter `since`.
+  // the unfetched tail is unrecoverable on the next poll. Returning Err is
+  // loud enough that the operator sees it and can re-run with a tighter
+  // `since`.
   if (totalPages > MAX_PAGES) {
-    throw new Error(
-      `pollMentions: search.messages returned ${totalPages} pages, exceeds MAX_PAGES=${MAX_PAGES}; ` +
-        'cursor not advanced. Re-run with a more recent `since` to recover the tail.',
-    );
+    return err(SlackErrors.paginationCapExceeded(totalPages, MAX_PAGES));
   }
 
   // Preserve the prior watermark when the poll returns zero items, otherwise
@@ -128,15 +152,24 @@ export async function pollMentions({
   // empty-page rule. Cursors are always ISO-8601 so the public
   // `since?: Date` / `newCursor: string | null` contract round-trips through
   // `new Date(cursor)` without per-platform parsing.
-  const newCursor = newestTs ? slackTsToIso(newestTs) : (since?.toISOString() ?? null);
+  let newCursor: string | null;
+  if (newestTs) {
+    const isoResult = slackTsToIso(newestTs);
+    if (isoResult.isErr()) return err(isoResult.error);
+    newCursor = isoResult.value;
+  } else {
+    newCursor = since?.toISOString() ?? null;
+  }
+
   const completedResult = await markPollCompleted({
     db,
     integration: INTEGRATION,
     cursor: newCursor,
     now: now(),
   });
-  if (completedResult.isErr()) throw new Error(completedResult.error.message);
-  return { fetched, newCursor };
+  if (completedResult.isErr()) return err(fromDatabaseError(completedResult.error));
+
+  return ok({ fetched, newCursor });
 }
 
 function compareTs(a: string, b: string): number {
@@ -146,14 +179,14 @@ function compareTs(a: string, b: string): number {
   return aN === bN ? 0 : aN > bN ? 1 : -1;
 }
 
-function slackTsToIso(ts: string): string {
+function slackTsToIso(ts: string): Result<string, SlackTsParseError> {
   // Slack ts is "<unix-seconds>.<microseconds>". The `since?: Date` round-
   // trip only needs millisecond precision, so we floor to ms.
   const seconds = Number.parseFloat(ts);
   if (!Number.isFinite(seconds)) {
-    throw new Error(`slackTsToIso: cannot parse ts ${ts}`);
+    return err(SlackErrors.tsParseFailed(ts));
   }
-  return new Date(Math.round(seconds * 1_000)).toISOString();
+  return ok(new Date(Math.round(seconds * 1_000)).toISOString());
 }
 
 function formatSlackDate({ date }: { date: Date }): string {

--- a/packages/integrations/slack/src/mentions.ts
+++ b/packages/integrations/slack/src/mentions.ts
@@ -35,6 +35,7 @@ import {
   safeSlackCall,
   type SlackError,
   SlackErrors,
+  type SlackTokenInvalidError,
   type SlackTsParseError,
 } from './errors.ts';
 import { type AnySlackMessage, pickNewestTs, upsertSlackMessage } from './upsert.ts';
@@ -67,14 +68,11 @@ async function pollMentionsInner({
   client,
   now = Date.now,
 }: PollMentionsArgs): Promise<Result<PollResult, SlackError>> {
-  let slack: WebClient;
-  if (client) {
-    slack = client;
-  } else {
-    const created = createSlackClient({ token });
-    if (created.isErr()) return err(created.error);
-    slack = created.value;
-  }
+  const slackResult: Result<WebClient, SlackTokenInvalidError> = client
+    ? ok(client)
+    : createSlackClient({ token });
+  if (slackResult.isErr()) return err(slackResult.error);
+  const slack = slackResult.value;
 
   const startedAt = now();
   const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });

--- a/packages/integrations/slack/src/mentions.ts
+++ b/packages/integrations/slack/src/mentions.ts
@@ -51,7 +51,8 @@ export async function pollMentions({
 }: PollMentionsArgs): Promise<PollResult> {
   const slack = client ?? createSlackClient({ token });
   const startedAt = now();
-  markPollStarted({ db, integration: INTEGRATION, now: startedAt });
+  const startResult = await markPollStarted({ db, integration: INTEGRATION, now: startedAt });
+  if (startResult.isErr()) throw new Error(startResult.error.message);
 
   // Slack guarantees user_id / team_id on ok:true responses; the SDK throws
   // WebAPIPlatformError on { ok: false } so the asserts below are reached
@@ -82,7 +83,7 @@ export async function pollMentions({
 
     const observedAt = now();
     for (const match of matches) {
-      upsertSlackMessage({
+      const upsertResult = await upsertSlackMessage({
         db,
         message: match,
         kind: 'mention',
@@ -90,6 +91,7 @@ export async function pollMentions({
         workspaceUrl,
         now: observedAt,
       });
+      if (upsertResult.isErr()) throw new Error(upsertResult.error.message);
     }
 
     const pageNewest = pickNewestTs(matches);
@@ -120,7 +122,13 @@ export async function pollMentions({
   // `since?: Date` / `newCursor: string | null` contract round-trips through
   // `new Date(cursor)` without per-platform parsing.
   const newCursor = newestTs ? slackTsToIso(newestTs) : (since?.toISOString() ?? null);
-  markPollCompleted({ db, integration: INTEGRATION, cursor: newCursor, now: now() });
+  const completedResult = await markPollCompleted({
+    db,
+    integration: INTEGRATION,
+    cursor: newCursor,
+    now: now(),
+  });
+  if (completedResult.isErr()) throw new Error(completedResult.error.message);
   return { fetched, newCursor };
 }
 

--- a/packages/integrations/slack/src/upsert.ts
+++ b/packages/integrations/slack/src/upsert.ts
@@ -16,8 +16,9 @@
 
 import type { ConversationsHistoryResponse, SearchMessagesResponse } from '@slack/web-api';
 import type { SlopweaverDatabase } from '@slopweaver/db';
-import { type DatabaseError, okAsync, type ResultAsync } from '@slopweaver/errors';
+import { okAsync, type ResultAsync } from '@slopweaver/errors';
 import { upsertEvidence } from '@slopweaver/integrations-core';
+import { fromDatabaseError, type SlackDatabaseError } from './errors.ts';
 
 type SearchMatch = NonNullable<NonNullable<SearchMessagesResponse['messages']>['matches']>[number];
 type HistoryMessage = NonNullable<ConversationsHistoryResponse['messages']>[number];
@@ -41,7 +42,7 @@ export function upsertSlackMessage({
   workspaceUrl: string | null;
   channelId?: string;
   now: number;
-}): ResultAsync<{ ts: string | null }, DatabaseError> {
+}): ResultAsync<{ ts: string | null }, SlackDatabaseError> {
   const ts = message.ts;
   if (!ts) return okAsync({ ts: null });
 
@@ -70,7 +71,9 @@ export function upsertSlackMessage({
     payloadJson: JSON.stringify({ ...message, _team_id: teamId }),
     occurredAtMs,
     now,
-  }).map(() => ({ ts }));
+  })
+    .mapErr(fromDatabaseError)
+    .map(() => ({ ts }));
 }
 
 /**

--- a/packages/integrations/slack/src/upsert.ts
+++ b/packages/integrations/slack/src/upsert.ts
@@ -16,6 +16,7 @@
 
 import type { ConversationsHistoryResponse, SearchMessagesResponse } from '@slack/web-api';
 import type { SlopweaverDatabase } from '@slopweaver/db';
+import { type DatabaseError, okAsync, type ResultAsync } from '@slopweaver/errors';
 import { upsertEvidence } from '@slopweaver/integrations-core';
 
 type SearchMatch = NonNullable<NonNullable<SearchMessagesResponse['messages']>['matches']>[number];
@@ -40,15 +41,15 @@ export function upsertSlackMessage({
   workspaceUrl: string | null;
   channelId?: string;
   now: number;
-}): { ts: string | null } {
+}): ResultAsync<{ ts: string | null }, DatabaseError> {
   const ts = message.ts;
-  if (!ts) return { ts: null };
+  if (!ts) return okAsync({ ts: null });
 
   const resolvedChannelId = channelId ?? extractChannelId({ message });
-  if (!resolvedChannelId) return { ts: null };
+  if (!resolvedChannelId) return okAsync({ ts: null });
 
   const occurredAtMs = parseSlackTs({ ts });
-  if (occurredAtMs === null) return { ts: null };
+  if (occurredAtMs === null) return okAsync({ ts: null });
 
   const externalId = `${kind}_${ts}:${resolvedChannelId}`;
   const text = message.text ?? '';
@@ -58,7 +59,7 @@ export function upsertSlackMessage({
   const citationUrl =
     permalinkFromMatch ?? buildPermalink({ workspaceUrl, channelId: resolvedChannelId, ts });
 
-  upsertEvidence({
+  return upsertEvidence({
     db,
     integration: 'slack',
     externalId,
@@ -69,9 +70,7 @@ export function upsertSlackMessage({
     payloadJson: JSON.stringify({ ...message, _team_id: teamId }),
     occurredAtMs,
     now,
-  });
-
-  return { ts };
+  }).map(() => ({ ts }));
 }
 
 /**

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -30,6 +30,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@slopweaver/contracts": "workspace:*",
     "@slopweaver/db": "workspace:*",
+    "@slopweaver/errors": "workspace:*",
     "drizzle-orm": "0.45.2",
     "zod": "4.4.2"
   },

--- a/packages/mcp-server/src/errors.ts
+++ b/packages/mcp-server/src/errors.ts
@@ -1,0 +1,32 @@
+/**
+ * MCP tool-domain error union and factories.
+ *
+ * Tools return `Result<TOutput, McpToolError>`. The server dispatcher in
+ * `server.ts` `.match()`es and converts `Err` into an `isError: true`
+ * structured response, so the MCP client sees a typed failure envelope
+ * instead of a generic thrown-exception message.
+ *
+ * `McpToolError` is intentionally small for v1: most tool failures are
+ * either an unexpected exception (`MCP_TOOL_UNEXPECTED`) or a domain
+ * decision the tool itself encodes inside its `ok` output schema. We
+ * expand the union as composite tools surface specific named failures.
+ */
+
+import type { BaseError } from '@slopweaver/errors';
+
+export interface McpToolUnexpectedError extends BaseError {
+  readonly code: 'MCP_TOOL_UNEXPECTED';
+  readonly toolName: string;
+  readonly cause?: unknown;
+}
+
+export type McpToolError = McpToolUnexpectedError;
+
+export const McpErrors = {
+  unexpected: (toolName: string, cause?: unknown, message?: string): McpToolUnexpectedError => ({
+    code: 'MCP_TOOL_UNEXPECTED',
+    message: message ?? `Unexpected error in tool "${toolName}"`,
+    toolName,
+    ...(cause !== undefined && { cause }),
+  }),
+} as const;

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -11,6 +11,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { PingResult, StartSessionResult } from '@slopweaver/contracts';
 import { createDb } from '@slopweaver/db';
+import { ok } from '@slopweaver/errors';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { createMcpServer } from './server.ts';
@@ -79,7 +80,7 @@ describe('createMcpServer + ping', () => {
       outputSchema: z
         .object({ message: z.string(), length: z.number().int().nonnegative() })
         .strict(),
-      handler: async ({ input }) => ({ message: input.message, length: input.message.length }),
+      handler: async ({ input }) => ok({ message: input.message, length: input.message.length }),
     });
 
     const server = createMcpServer({
@@ -126,7 +127,7 @@ describe('createMcpServer + ping', () => {
       outputSchema: z.object({ greeting: z.string() }).strict(),
       handler: async ({ input }) => {
         handlerCalled += 1;
-        return { greeting: `hello, ${input.name}` };
+        return ok({ greeting: `hello, ${input.name}` });
       },
     });
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -42,23 +42,28 @@ export function createMcpServer({ db, tools, version }: CreateMcpServerArgs): Mc
         } catch (cause) {
           // Handlers should return `Err` rather than throw, but a runaway
           // exception is still bound to the tool — wrap as isError so the
-          // client sees a structured envelope.
+          // client sees a structured envelope. Sanitize: only `code` and
+          // `message` cross the MCP boundary; `cause` (which may carry
+          // HTTP response bodies, stack traces, or internal paths via
+          // safeApiCall's wrap) stays server-side.
           const error = McpErrors.unexpected(
             tool.name,
             cause,
             cause instanceof Error ? cause.message : undefined,
           );
+          const clientError = { code: error.code, message: error.message };
           return {
             isError: true,
-            structuredContent: { code: error.code, message: error.message },
-            content: [{ type: 'text', text: JSON.stringify(error) }],
+            structuredContent: clientError,
+            content: [{ type: 'text', text: JSON.stringify(clientError) }],
           };
         }
         if (result.isErr()) {
+          const clientError = { code: result.error.code, message: result.error.message };
           return {
             isError: true,
-            structuredContent: { code: result.error.code, message: result.error.message },
-            content: [{ type: 'text', text: JSON.stringify(result.error) }],
+            structuredContent: clientError,
+            content: [{ type: 'text', text: JSON.stringify(clientError) }],
           };
         }
         const output = result.value;

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -12,6 +12,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SlopweaverDatabase } from '@slopweaver/db';
+import { McpErrors } from './errors.ts';
 import type { Tool } from './tools/registry.ts';
 
 export type CreateMcpServerArgs = {
@@ -35,9 +36,34 @@ export function createMcpServer({ db, tools, version }: CreateMcpServerArgs): Mc
         outputSchema: tool.outputSchema,
       },
       async (input: unknown) => {
-        const output = await tool.handler({ input, ctx: { db } });
+        let result: Awaited<ReturnType<typeof tool.handler>>;
+        try {
+          result = await tool.handler({ input, ctx: { db } });
+        } catch (cause) {
+          // Handlers should return `Err` rather than throw, but a runaway
+          // exception is still bound to the tool — wrap as isError so the
+          // client sees a structured envelope.
+          const error = McpErrors.unexpected(
+            tool.name,
+            cause,
+            cause instanceof Error ? cause.message : undefined,
+          );
+          return {
+            isError: true,
+            structuredContent: { code: error.code, message: error.message },
+            content: [{ type: 'text', text: JSON.stringify(error) }],
+          };
+        }
+        if (result.isErr()) {
+          return {
+            isError: true,
+            structuredContent: { code: result.error.code, message: result.error.message },
+            content: [{ type: 'text', text: JSON.stringify(result.error) }],
+          };
+        }
+        const output = result.value;
         return {
-          structuredContent: output as Record<string, unknown>,
+          structuredContent: output,
           content: [{ type: 'text', text: JSON.stringify(output) }],
         };
       },

--- a/packages/mcp-server/src/tools/builtin/ping.ts
+++ b/packages/mcp-server/src/tools/builtin/ping.ts
@@ -6,6 +6,7 @@
  */
 
 import { PingArgs, PingResult } from '@slopweaver/contracts';
+import { ok } from '@slopweaver/errors';
 import { defineTool, type Tool } from '../registry.ts';
 
 export type CreatePingToolArgs = {
@@ -33,11 +34,11 @@ export function createPingTool({ version, startedAtMs, now = Date.now }: CreateP
     outputSchema: PingResult,
     handler: async () => {
       const elapsedMs = Math.max(0, now() - startedAtMs);
-      return {
+      return ok({
         ok: true as const,
         version,
         uptime_s: Math.floor(elapsedMs / 1000),
-      };
+      });
     },
   });
 }

--- a/packages/mcp-server/src/tools/composite/start-session.test.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.test.ts
@@ -66,13 +66,17 @@ describe('createStartSessionTool', () => {
       .run();
   }
 
-  function callHandler(
+  async function callHandler(
     tool: ReturnType<typeof createStartSessionTool>,
     rawInput: unknown,
   ): Promise<unknown> {
     // Mirror the SDK's pre-handler validation step so handler input is typed.
     const input = StartSessionArgs.parse(rawInput);
-    return tool.handler({ input, ctx: { db: dbHandle.db } });
+    const result = await tool.handler({ input, ctx: { db: dbHandle.db } });
+    if (result.isErr()) {
+      throw new Error(`start_session handler returned Err: ${result.error.code}`);
+    }
+    return result.value;
   }
 
   it('happy path: ranks a Slack mention above an equal-recency GitHub PR via the kind boost', async () => {

--- a/packages/mcp-server/src/tools/composite/start-session.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.ts
@@ -35,6 +35,7 @@ import {
   StartSessionResult,
 } from '@slopweaver/contracts';
 import { evidenceLog, integrationState, type SlopweaverDatabase } from '@slopweaver/db';
+import { ok } from '@slopweaver/errors';
 import { desc, eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { defineTool, type Tool } from '../registry.ts';
@@ -89,12 +90,12 @@ export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): T
       const requested = resolveRequested(db, input.integrations, pollers);
 
       if (requested.length === 0) {
-        return {
+        return ok({
           items: [],
           evidence: [],
           freshness: [],
           generated_at: new Date(nowMs).toISOString(),
-        };
+        });
       }
 
       for (const integration of requested) {
@@ -128,12 +129,12 @@ export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): T
         readFreshness(db, integration, nowMs, staleThresholdMs),
       );
 
-      return {
+      return ok({
         items,
         evidence,
         freshness,
         generated_at: new Date(nowMs).toISOString(),
-      };
+      });
     },
   });
 }

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -15,8 +15,10 @@
  * boundary.
  */
 
-import type { z } from 'zod';
 import type { SlopweaverDatabase } from '@slopweaver/db';
+import type { Result } from '@slopweaver/errors';
+import type { z } from 'zod';
+import type { McpToolError } from '../errors.ts';
 
 /**
  * Per-call context handed to every tool handler. v1 only carries the Drizzle
@@ -32,7 +34,16 @@ export type ToolHandlerArgs<TInput> = {
   ctx: ToolHandlerContext;
 };
 
-export type ToolHandler<TInput, TOutput> = (args: ToolHandlerArgs<TInput>) => Promise<TOutput>;
+/**
+ * Tool handlers return `Promise<Result<TOutput, McpToolError>>`. The server
+ * dispatcher unwraps via `.match()` — `Ok` becomes a normal MCP response,
+ * `Err` becomes an `isError: true` structured response so the MCP client
+ * sees a typed failure envelope. See `.claude/rules/error-handling.md` and
+ * #41.
+ */
+export type ToolHandler<TInput, TOutput> = (
+  args: ToolHandlerArgs<TInput>,
+) => Promise<Result<TOutput, McpToolError>>;
 
 /** Author-facing tool spec; `defineTool` converts this into a {@link Tool}. */
 export type ToolDefinition<TInputSchema extends z.ZodObject, TOutputSchema extends z.ZodObject> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,19 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@types/node@22.19.17)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
+  packages/errors:
+    dependencies:
+      neverthrow:
+        specifier: 8.2.0
+        version: 8.2.0
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@22.19.17)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
   packages/integrations/core:
     dependencies:
       '@pollyjs/adapter-node-http':
@@ -1510,6 +1523,11 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+
   '@sindresorhus/fnv1a@2.0.1':
     resolution: {integrity: sha512-suq9tRQ6bkpMukTG5K5z0sPWB7t0zExMzZCdmYm6xTSSIm/yCKNm7VCL36wVeyTsFr597/UhU1OAYdHGMDiHrw==}
     engines: {node: '>=10'}
@@ -2756,6 +2774,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  neverthrow@8.2.0:
+    resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
+    engines: {node: '>=18'}
 
   nocache@3.0.4:
     resolution: {integrity: sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==}
@@ -4291,6 +4313,9 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
   '@sindresorhus/fnv1a@2.0.1': {}
 
   '@slack/logger@4.0.1':
@@ -5519,6 +5544,10 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
+
+  neverthrow@8.2.0:
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
 
   nocache@3.0.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       '@slopweaver/env':
         specifier: workspace:*
         version: link:../../packages/env
+      '@slopweaver/errors':
+        specifier: workspace:*
+        version: link:../../packages/errors
       '@slopweaver/integrations-github':
         specifier: workspace:*
         version: link:../../packages/integrations/github

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
 
   packages/db:
     dependencies:
+      '@slopweaver/errors':
+        specifier: workspace:*
+        version: link:../errors
       better-sqlite3:
         specifier: 12.2.0
         version: 12.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
 
   packages/env:
     dependencies:
+      '@slopweaver/errors':
+        specifier: workspace:*
+        version: link:../errors
       zod:
         specifier: 4.4.2
         version: 4.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       '@slopweaver/db':
         specifier: workspace:*
         version: link:../db
+      '@slopweaver/errors':
+        specifier: workspace:*
+        version: link:../errors
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       '@slopweaver/db':
         specifier: workspace:*
         version: link:../../db
+      '@slopweaver/errors':
+        specifier: workspace:*
+        version: link:../../errors
       '@slopweaver/integrations-core':
         specifier: workspace:*
         version: link:../core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       '@slopweaver/db':
         specifier: workspace:*
         version: link:../../db
+      '@slopweaver/errors':
+        specifier: workspace:*
+        version: link:../../errors
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)
@@ -237,6 +240,9 @@ importers:
       '@slopweaver/db':
         specifier: workspace:*
         version: link:../../db
+      '@slopweaver/errors':
+        specifier: workspace:*
+        version: link:../../errors
       '@slopweaver/integrations-core':
         specifier: workspace:*
         version: link:../core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@inquirer/prompts':
         specifier: 8.4.2
         version: 8.4.2(@types/node@22.19.17)
+      '@slopweaver/errors':
+        specifier: workspace:*
+        version: link:../errors
       cac:
         specifier: 7.0.0
         version: 7.0.0


### PR DESCRIPTION
## Summary

Adopts the [neverthrow](https://github.com/supermacro/neverthrow) Result/ResultAsync pattern across the SlopWeaver public repo, mirroring the established convention in `slopweaver-private`. Service code returns typed Result unions instead of throwing; boundary wrappers (`safeApiCall`, `safeQuery`) centralize exception-to-Result translation; per-package error unions discriminate on a `code` field; tests assert via strong `.isOk()`/`.isErr()` checks.

Closes #41 (decision-record).

**End-state:** `pnpm check:service-boundaries` reports **0 throws** in service-boundary files and is wired into `pnpm validate` as the first of 6 gates.

## Convention waiver — please read first

This PR exceeds the repo's standard `≤500 LOC per PR` review-comfort ceiling. The maintainer accepted the waiver knowingly, per the migration plan and codex review (gpt-5.4) of the plan: a cross-cutting Result migration must move multiple packages together because the type signatures cascade (e.g. `upsertEvidence` changing return type forces `upsertSlackMessage` to change, which forces `pollMentions` to change, etc.). Splitting this across packages would leave each interim PR in a half-migrated state with inconsistent error shapes.

**Reviewer guidance**: step through the 20 phase-aligned commits in order rather than reading the full diff. Each commit ends with `pnpm validate` green.

## Why

- Every error becomes part of a typed union; exhaustive `.match()` at boundaries replaces "did I remember to catch this?" review burden.
- Pre-alpha repo is the right time to set the convention — no deprecation runway.
- The private repo has converged on this pattern; aligning the public repo makes cross-repo code-sharing cheaper.

Codex (gpt-5.4) reviewed the migration plan and surfaced 10 P0/P1 findings, all of which are incorporated. Notably: `@slopweaver/errors` is publishable (not `"private": true`); ESLint was wired into `pnpm validate` first (it was dormant before); `safeQuery` lives in `@slopweaver/db` while `DatabaseError` is shared via `@slopweaver/errors` so non-DB packages can include it in their unions without a DB dep; the CLI service-boundary check scope includes the cli-tools orchestration files (not just integrations).

## What changed (by phase)

**Phase 0** — `#41` decision-record filed.

**Phase 1** — Foundation
- `52622fb` feat(errors): scaffold `@slopweaver/errors` (publishable; neverthrow@8.2.0 pinned exact)
- `7273393` chore(lint): wire ESLint into `pnpm lint` (it was dormant — only Biome ran)
- `639a283` docs(rules): `.claude/rules/error-handling.md` codifies the convention

**Phase 2** — DB wrapper
- `414446c` feat(db): `safeQuery` + better-sqlite3 error-shape extractor

**Phase 3** — Enforcement
- `8dd34a0` docs(eslint): `eslint-plugin-neverthrow@1.1.4` is incompatible with ESLint 10 (reads `context.parserServices` which moved in ESLint 9+); the rule is deferred until a maintained plugin lands or we ship a custom rule
- `948500f` feat(cli): `pnpm check:service-boundaries` scanner finds forbidden throws in service files

**Phase 4** — Per-package migrations
- `21f791c` feat(env): `loadEnv` returns `Result<Env, EnvValidationError>`
- `768c6c4` feat(db): `integration-tokens` helpers return `ResultAsync` via `safeQuery`
- `5c35711` feat(integrations): core upsert helpers return `ResultAsync`
- `e6af23c` feat(slack): `SlackError` union; `createSlackClient` + `fetchIdentity` return Result
- `6ee5c43` feat(slack): `pollMentions` + `pollDMs` return Result; `MAX_PAGES` becomes `SLACK_PAGINATION_CAP_EXCEEDED`; `slackTsToIso` returns Result
- `ff1d51a` feat(github): `GithubError` union; `fetchIdentity` + pollers return Result; `safeGithubCall` extracts `RequestError.status`
- `6be9864` feat(mcp-server): tool handlers return Result; dispatcher emits `isError: true` structured response on Err

**Phase 5** — cli-tools
- `97b27ea` feat(cli-tools): `worktree-new` returns `Result<…, WorktreeError>`; the homegrown `{ ok, error, exitCode }` discriminated union is replaced
- `86448c2` feat(cli-tools): `orchestration/core.ts` parsers return Result; introduces `OrchestrationErrors` factory + first three variants
- `111788d` feat(db,cli-tools): `resolveDataDir` / `resolveDbPath` return Result; both `@slopweaver/db` and the parallel `cli-tools/lib/data-dir.ts` helper share the `DATA_PATH_INVALID` discriminant; `createDb`/`checkDataDir` drop their default-param resolvers in favor of caller-side `.match()`
- `32ca716` feat(mcp-local): `validateToken` callback contract returns `ResultAsync<{ team }, BaseError>`; the temporary `throw new Error(slackResult.error.message)` rewrap at cli.ts:214 is removed; `@slopweaver/integrations-slack` barrel re-exports `safeSlackCall` + `SlackError` types
- `45d6a04` feat(cli-tools): runtime.ts end-to-end Result conversion — all 25 throws + the `lib/paths.ts` `findMonorepoRoot` throw (now visible to the wider scanner scope) become typed Result errors; new `OrchestrationError` union covers parser, state-precondition, retry-loop classifier (`ORCHESTRATION_MODEL_ATTEMPT { kind: 'transient'|'fatal' }`), all-models-failed, review/CI loop non-convergence, and subprocess wrappers; the 9 throwing methods on `RunOrchestrationEnvironment` change signature to return `Result<T, SubprocessFailedError>`; `prepareOrchestration`/`runOrchestration` return `Promise<Result<void, OrchestrationError | MonorepoRootNotFoundError>>`; cli.ts dispatcher drops the surrounding `try/catch` in favor of `.isErr()` + `process.exit(1)`
- `8d57a76` chore(validate): wire `pnpm check:service-boundaries` as the sixth gate (first in chain — cheapest, fastest feedback)
- `9f8880d` docs(rules): document throw carve-outs (browser fetchers, CLI entries, recovery catches) and the `eslint-plugin-neverthrow` deferral

## Service-boundary throws

Pre-migration: ~30 throws across `integrations/*`, `mcp-server/tools/**`, `cli-tools/orchestration/{core,runtime}.ts`, `apps/mcp-local/src/connect/*`, plus `packages/db/src` and `packages/cli-tools/src/lib` once added to scope.

Post-PR: **0 throws** at every configured service boundary. The scanner is now part of `pnpm validate`.

## Test plan

- [x] `pnpm validate` green on every commit (check:service-boundaries, format:check, lint, compile, test, knip — 6 gates)
- [x] Cassette tests for slack/github integrations replay unchanged (wire behavior preserved)
- [x] In-memory MCP `server.test.ts` round-trip works through new Result-aware dispatcher
- [x] `pnpm cli orchestration run @docs/orchestration/examples/refactor-example.md --dry-run` composes the phase plan correctly
- [x] `pnpm cli check-service-boundaries` reports 0 findings
- [ ] **Reviewer**: run `pnpm cli doctor` end-to-end (touches env, db, integrations indirectly)
- [ ] **Reviewer (optional)**: re-run a fresh codex review on commits 16-20 if a second opinion is wanted on the runtime.ts retry-loop conversion

## Carve-outs (knowingly deferred)

- **`eslint-plugin-neverthrow` runtime `must-use-result` rule** — upstream incompatible with ESLint 10. Documented in `eslint.config.js` and `.claude/rules/error-handling.md`. The CLI service-boundary scanner is the runtime enforcement until upstream catches up.
- **`packages/ui/src/client/api/diagnostics.ts:8`** — browser `fetch` throw, idiomatic for React Query / SWR / error-boundary patterns. Carve-out documented in `.claude/rules/error-handling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-wide adoption of structured Result-style error handling and a new CLI check that scans service boundaries for unsafe throws.

* **Bug Fixes**
  * CLI commands, integration connect flows, polling, DB operations, and server tool dispatch now surface failures consistently with proper exit codes and clearer error output.

* **Documentation**
  * Added a comprehensive error-handling guide documenting conventions and allowed exceptions.

* **Tests**
  * Expanded tests for Result consumption, error discriminants, and the service-boundary scanner.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slopweaver/slopweaver/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->