### PR TITLE
feat(mcp-local): wire integration tokens into start_session pollers

### DIFF
--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -23,15 +23,25 @@ import { readFileSync } from 'node:fs';
 import { argv, env, exit, stderr, stdout } from 'node:process';
 import { password } from '@inquirer/prompts';
 import { cac } from 'cac';
-import { createDb, resolveDataDir, resolveDbPath } from '@slopweaver/db';
+import { createDb, loadIntegrationToken, resolveDataDir, resolveDbPath } from '@slopweaver/db';
 import { loadEnv } from '@slopweaver/env';
-import { createGithubClient, safeGithubCall } from '@slopweaver/integrations-github';
+import {
+  createGithubClient,
+  createGithubPoller,
+  fetchIdentity as fetchGithubIdentity,
+  safeGithubCall,
+} from '@slopweaver/integrations-github';
 import { errAsync } from '@slopweaver/errors';
-import { createSlackClient, safeSlackCall } from '@slopweaver/integrations-slack';
+import {
+  createSlackClient,
+  createSlackPoller,
+  safeSlackCall,
+} from '@slopweaver/integrations-slack';
 import {
   createMcpServer,
   createPingTool,
   createStartSessionTool,
+  type StartSessionPoller,
   startStdio,
 } from '@slopweaver/mcp-server';
 import {
@@ -99,17 +109,61 @@ async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void
   const dbHandle = createDb({ path: dbPathResult.value });
   const dataDir = dataDirResult.value;
 
+  // Load connected integration tokens from `integration_tokens` in parallel,
+  // then build a poller map keyed by integration slug to pass into the
+  // composite `start_session` tool. `null` means "not connected — skip";
+  // `Err` is a real DB failure and propagates via the same if-isErr-throw
+  // CLI-boundary pattern as the env/dbPath/dataDir results above.
+  const [githubTokenResult, slackTokenResult] = await Promise.all([
+    loadIntegrationToken({ db: dbHandle.db, integration: 'github' }),
+    loadIntegrationToken({ db: dbHandle.db, integration: 'slack' }),
+  ]);
+  if (githubTokenResult.isErr()) {
+    throw githubTokenResult.error;
+  }
+  if (slackTokenResult.isErr()) {
+    throw slackTokenResult.error;
+  }
+
+  const pollers: Record<string, StartSessionPoller> = {};
+
+  const githubToken = githubTokenResult.value;
+  if (githubToken !== null) {
+    // fetchIdentity validates the token against the live API and refreshes
+    // identity_graph. A revoked PAT, network blip, or rate-limit response
+    // must not abort startup: log and omit github from the pollers map so
+    // start_session keeps serving slack + cached evidence. The user can
+    // `slopweaver connect github` again later without a restart-relevant
+    // state change. Mirrors the EADDRINUSE fail-soft below.
+    const identityResult = await fetchGithubIdentity({
+      db: dbHandle.db,
+      token: githubToken.token,
+    });
+    if (identityResult.isErr()) {
+      stderr.write(
+        `slopweaver: failed to resolve GitHub identity, skipping live polling: ${identityResult.error.message}\n`,
+      );
+    } else {
+      pollers.github = createGithubPoller({
+        token: githubToken.token,
+        username: identityResult.value.username,
+      });
+    }
+  }
+
+  const slackToken = slackTokenResult.value;
+  if (slackToken !== null) {
+    // Slack's createSlackPoller is network-free; the poller calls
+    // `auth.test()` internally on first invocation. No pre-validation needed
+    // here because there's no analogous pre-resolved field to capture
+    // (mentions/DMs both work from the token alone).
+    pollers.slack = createSlackPoller({ token: slackToken.token });
+  }
+
   const server = createMcpServer({
     db: dbHandle.db,
     version: VERSION,
-    tools: [
-      createPingTool({ version: VERSION, startedAtMs }),
-      // Pollers are intentionally empty in v1: integration auth tokens are
-      // not yet wired through env, so `force_refresh` is a no-op until that
-      // lands. The tool still serves cached evidence and accurate freshness
-      // reports without them.
-      createStartSessionTool(),
-    ],
+    tools: [createPingTool({ version: VERSION, startedAtMs }), createStartSessionTool({ pollers })],
   });
 
   // Start the local Diagnostics web UI (default ON). EADDRINUSE is non-fatal:

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -585,7 +585,7 @@ sequenceDiagram
 - **`apps/mcp-local`'s smoke test spawns the real `dist/cli.js`** — make sure the build succeeded before running it; failures often manifest as opaque ENOENTs.
 - **The orchestration `pnpm cli worktree-new` recursion**: the orchestration runtime shells out to the same CLI binary to create worktrees. Don't introduce circular state in `cli.ts` init.
 - **`SLOPWEAVER_WEB_UI_PORT` parses strictly** — `"60701junk"` is rejected. Use `--no-web-ui` to skip the Diagnostics server in headless setups.
-- **`identity_graph` is NOT written during `connect`** — only the polling layer writes there. `connect` writes only `integration_tokens`. This matters because `connect` is intended to be re-runnable.
+- **`identity_graph` is NOT written during `connect`** — `connect` writes only `integration_tokens` so it stays re-runnable without leaving graph-state debris on a typo. `identity_graph` is written by the GitHub `fetchIdentity` call at `runMcpServer` startup (token validation + username resolution for the github poller) and by the polling layer itself.
 - **The `_team_id` field** is injected into the stored Slack `payload_json` by `upsertSlackMessage` so consumers can resolve workspaces without a separate join.
 
 ---

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -145,10 +145,11 @@ slopweaver/
 1. `loadEnv()` (from `@slopweaver/env`) — validates `NODE_ENV`, `LOG_LEVEL`; throws on invalid.
 2. `resolveDbPath()` / `resolveDataDir()`.
 3. `createDb({ path })` — opens SQLite, runs migrations.
-4. `createMcpServer({ db, version, tools: [createPingTool(...), createStartSessionTool()] })` — v1 has no pollers wired into `start_session` yet.
-5. If UI enabled: `startUiServer({ db, dataDir, port })` (resolved from `SLOPWEAVER_WEB_UI_PORT`, default 60701). `EADDRINUSE` is non-fatal.
-6. Registers `SIGINT`/`SIGTERM` → close server → close UI → close DB.
-7. `startStdio({ server })`.
+4. Load `integration_tokens` rows via `loadIntegrationToken({ db, integration })` for github and slack in parallel; for github, call `fetchIdentity` to resolve the username (skipped + logged on identity failure, e.g. revoked PAT). Build `pollers: Record<string, StartSessionPoller>` from the surviving tokens via `createGithubPoller` / `createSlackPoller`.
+5. `createMcpServer({ db, version, tools: [createPingTool(...), createStartSessionTool({ pollers })] })`.
+6. If UI enabled: `startUiServer({ db, dataDir, port })` (resolved from `SLOPWEAVER_WEB_UI_PORT`, default 60701). `EADDRINUSE` is non-fatal.
+7. Registers `SIGINT`/`SIGTERM` → close server → close UI → close DB.
+8. `startStdio({ server })`.
 
 **`connect <integration>` flow**: prompt (masked via `@inquirer/prompts` `password`) → validate token against API → `saveIntegrationToken` upsert → stdout confirmation. Slack rejects `xoxb-` tokens before the network call (because `search.messages` requires `xoxp-`). Connect does NOT write to `identity_graph` — that is done by the polling layer.
 
@@ -178,7 +179,7 @@ slopweaver/
 - Staleness threshold: 10 minutes (`DEFAULT_STALE_THRESHOLD_MS`). Polls when `force_refresh: true`, no completed poll yet, or last completion older than threshold.
 - **Per-platform failure handling**: v1 has NO try/catch around individual poller invocations. A throwing poller fails the whole call (the outer dispatcher catches and returns `isError: true`). Per-platform isolation is a planned improvement.
 - `pollers` are factory-injected closures (NOT in `ToolHandlerContext`) — auth tokens are captured at host-app startup.
-- `mcp-local` currently calls `createStartSessionTool()` with **no pollers**, so v1 serves cached evidence without polling.
+- `mcp-local` loads connected integration tokens at startup and passes a populated `pollers` map to `createStartSessionTool({ pollers })`; a missing token (not connected) silently skips that integration, and a failed GitHub identity resolve logs to stderr and omits github without aborting the binary.
 - Defensive row shaping: rows missing `title` AND `kind` are skipped; malformed `citation_url` downgrades to a `canonical` ref; unparseable `payload_json` becomes `null`. A single bad row never aborts the call.
 
 **MCP boundary translation**:
@@ -572,7 +573,7 @@ sequenceDiagram
 - **`pnpm validate` has SIX gates** (not four as some older docs say): `check-service-boundaries` → `format:check` → `lint` → `compile` → `test` → `knip`. CI also runs `gitleaks detect` as a seventh gate.
 - **Drizzle migrations are tool-generated only** — run `pnpm drizzle-kit generate` from a clean `main` baseline. Never hand-edit or generate from stale worktree state.
 - **`start_session` has no per-platform isolation in v1** — a throwing poller fails the whole tool call. Per-platform try/catch is a planned improvement.
-- **`createStartSessionTool()` is called with no pollers in `mcp-local`** — v1 serves cached evidence only; live polling is wired in a follow-up PR.
+- **`createStartSessionTool({ pollers })` in `mcp-local`** is populated from `integration_tokens` at startup — a missing token (user hasn't run `connect <integration>`) silently skips that integration; a failed GitHub identity resolve logs and omits github but leaves the binary running.
 - **Slack `search.messages` rejects bot tokens** — `mcp-local`'s `connect slack` pre-rejects `xoxb-` prefix before the network call.
 - **GitHub's `mentions:` qualifier rejects `@me`** — `pollMentions` requires an explicit `username` arg.
 - **GitHub pollers fetch only the first page** (`PER_PAGE = 50`, no pagination loop). The second page is silently dropped.
@@ -637,4 +638,4 @@ sequenceDiagram
 
 ## Repo State
 
-This repo is pre-alpha — v1.0.0 is in active development per the [v1.0.0 roadmap tracking issue](https://github.com/slopweaver/slopweaver/issues/2). The published binary `slopweaver` and the React Diagnostics page exist; live polling is wired in `connect` and the integration packages but not yet attached to `start_session` (the composite tool currently serves cached evidence only). Per-platform isolation, OAuth flows, token encryption at rest, and HTTP transport are all known follow-ups.
+This repo is pre-alpha — v1.0.0 is in active development per the [v1.0.0 roadmap tracking issue](https://github.com/slopweaver/slopweaver/issues/2). The published binary `slopweaver` and the React Diagnostics page exist; live polling is wired through to `start_session` via `createStartSessionTool({ pollers })`, populated from `integration_tokens` at startup. Per-platform isolation inside `start-session.ts`, OAuth flows, token encryption at rest, and HTTP transport are all known follow-ups.

--- a/packages/integrations/github/src/identity.ts
+++ b/packages/integrations/github/src/identity.ts
@@ -25,6 +25,7 @@ export type FetchIdentityArgs = {
 export type FetchIdentityResult = {
   canonicalId: string;
   externalId: string;
+  username: string;
 };
 
 export function fetchIdentity({
@@ -68,6 +69,6 @@ export function fetchIdentity({
       },
     })
       .mapErr(fromDatabaseError)
-      .map(() => ({ canonicalId, externalId }));
+      .map(() => ({ canonicalId, externalId, username: user.login }));
   });
 }


### PR DESCRIPTION
## What this PR does

Wires connected integration tokens into the published `slopweaver` binary so `start_session` returns live polled evidence instead of the empty `[]` it served before. `runMcpServer` now loads `integration_tokens` rows for github and slack at startup, builds a `pollers: Record<string, StartSessionPoller>` map, and passes it into `createStartSessionTool({ pollers })`.

- **GitHub flow:** `loadIntegrationToken` → `fetchIdentity` (validates the PAT, refreshes `identity_graph`, surfaces `user.login`) → `createGithubPoller({ token, username })`. A failed identity resolve (revoked PAT, network blip, rate-limit) logs to stderr and omits github from the map — the binary keeps running so the user can `slopweaver connect github` again later.
- **Slack flow:** `loadIntegrationToken` → `createSlackPoller({ token })`. No pre-validation here because the adapter calls `auth.test()` internally on first invocation.
- **DB errors** propagate via the same if-isErr-throw CLI-boundary pattern as the existing env/dbPath/dataDir handling.

## Why

Second of three "v1-wire" chains. PR #47 (which the chain doc still calls "#44") merged the poller adapters. This PR connects them to the binary — closes the v1 dogfood gap so `slopweaver start_session` returns ranked items instead of `[]` once a user has run `slopweaver connect <integration>`.

closes #45
refs #44
refs #2

## Test plan

- [x] Tests added / updated — `identity.test.ts` continues to pass; smoke test unchanged (see Notes).
- [x] Manually verified — `pnpm validate` green locally (all six gates).
- [x] CI green — `pnpm validate` covers check-service-boundaries / format / lint / compile / test / knip.

```
pnpm validate
# OK: no `throw` statements in service-boundary files.
# format:check ✓ (after one auto-fix re-flow of the tools array)
# lint ✓
# compile ✓ (21 tasks, 18 cached)
# test ✓ (mcp-local 16/16, integrations-github 10/10, all packages passing)
# knip ✓
```

Service boundary scanner: `apps/mcp-local/src/cli.ts` is NOT in the scanned list per `.claude/rules/error-handling.md`'s "Carve-outs" — only `apps/mcp-local/src/connect/**` is — so the existing throw pattern is fine.

## Breaking changes

None. `FetchIdentityResult` gains a `username: string` field — purely additive; the existing test destructures only `{ canonicalId, externalId }` and continues to pass unchanged.

## Notes for the reviewer

Three deliberate decisions worth calling out:

1. **Smoke test left unchanged.** The issue allowed either path. Recording a Polly cassette inside a spawned subprocess would need an env-var-controlled Polly init in the binary itself — disproportionate to the value here. The existing fresh-DB assertions (`items: []`, `evidence: []`, `freshness: []`) still pass because no tokens are connected in the test's `XDG_DATA_HOME` tmp dir. Populated-poller verification will land naturally in PR 3 (#46) when error-isolation is added.

2. **`FetchIdentityResult.username` added** to `packages/integrations/github/src/identity.ts`. The chain doc says "call `fetchIdentity` to resolve the username", but `fetchIdentity` previously returned only `{ canonicalId, externalId }` (where `externalId` is `String(user.id)`, not the login). The `user.login` value is already fetched from the API and written to `identity_graph` — this commit just additionally returns it so the caller doesn't need a second lookup or duplicate API call. `identity.test.ts:28` destructures only the two old fields, so it continues to pass.

3. **`docs/CODEBASE_MAP.md` had four "no pollers wired" caveats** (lines 148, 181, 575, 640) — the chain doc only referenced two (181, 640). All four are updated for consistency: the `runMcpServer` flow description, the `start_session` architecture section, the Gotchas entry, and the Repo State paragraph now describe the populated-pollers reality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Start session tool now supports live GitHub and Slack integration polling at startup
  * GitHub identity is resolved with graceful error handling; failures are logged and the app continues running without the GitHub poller

* **Documentation**
  * Updated codebase documentation to reflect live integration polling behavior in the start session tool

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slopweaver/slopweaver/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->