### PR TITLE
feat(mcp-server): isolate per-integration poller failures in start_session

### DIFF
--- a/packages/mcp-server/src/tools/composite/start-session.test.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.test.ts
@@ -317,6 +317,61 @@ describe('createStartSessionTool', () => {
     ]);
   });
 
+  it('isolates a throwing poller — successful integrations still produce items and stale-true signals through Freshness', async () => {
+    // Mute the stderr write under test; assert on it instead.
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const throwingPoller: StartSessionPoller = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const succeedingPoller: StartSessionPoller = vi.fn(async ({ db, now }) => {
+      db.insert(evidenceLog)
+        .values({
+          integration: 'slack',
+          externalId: 'msg-after-success',
+          kind: 'mention',
+          citationUrl: null,
+          title: 'Mention after a successful poll',
+          body: null,
+          payloadJson: '{}',
+          occurredAtMs: now - 1_000,
+          firstSeenAtMs: now,
+          lastSeenAtMs: now,
+          createdAtMs: now,
+          updatedAtMs: now,
+        })
+        .run();
+    });
+
+    // github has no integration_state row -> Freshness.stale = true (correct: poll didn't complete).
+    // slack is pre-seeded fresh -> Freshness.stale = false after the successful poll.
+    seedFreshIntegrationState('slack');
+
+    const tool = createStartSessionTool({
+      now: () => FIXED_NOW,
+      pollers: { github: throwingPoller, slack: succeedingPoller },
+    });
+    const raw = await callHandler(tool, { force_refresh: true });
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(throwingPoller).toHaveBeenCalledTimes(1);
+    expect(succeedingPoller).toHaveBeenCalledTimes(1);
+
+    // Successful integration's evidence appears in items[].
+    expect(parsed.items.map((i) => i.title)).toEqual(['Mention after a successful poll']);
+
+    // Freshness reflects per-integration outcome.
+    const githubFreshness = parsed.freshness.find((f) => f.integration === 'github');
+    const slackFreshness = parsed.freshness.find((f) => f.integration === 'slack');
+    expect(githubFreshness?.stale).toBe(true);
+    expect(slackFreshness?.stale).toBe(false);
+
+    // Stderr log format: human-readable, single line, includes slug + error message.
+    expect(stderrSpy).toHaveBeenCalledWith('slopweaver: github poller failed: Error: boom\n');
+
+    stderrSpy.mockRestore();
+  });
+
   it('skips rows with no usable title, downgrades malformed citation_url, tolerates bad payload_json', async () => {
     // Row 1: empty title and empty kind — must be skipped entirely.
     seedEvidence({

--- a/packages/mcp-server/src/tools/composite/start-session.test.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.test.ts
@@ -367,7 +367,41 @@ describe('createStartSessionTool', () => {
     expect(slackFreshness?.stale).toBe(false);
 
     // Stderr log format: human-readable, single line, includes slug + error message.
-    expect(stderrSpy).toHaveBeenCalledWith('slopweaver: github poller failed: Error: boom\n');
+    expect(stderrSpy).toHaveBeenCalledWith('slopweaver: github poller failed: boom\n');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('isolates a poller that rejects with a BaseError-shaped plain object — log surfaces the typed .message, not [object Object]', async () => {
+    // Real integration adapters (e.g. `createSlackPoller`) bridge from the
+    // Result world to the StartSessionPoller's Promise contract via
+    // `Promise.reject(slackError)`, where `slackError` is a plain
+    // `{ code, message, ... }` object — not a native Error instance. Guard
+    // against `String(error) === '[object Object]'` for that case.
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const baseErrorShape = {
+      code: 'SLACK_API_ERROR',
+      message: 'auth.test failed: invalid_auth',
+    };
+    const adapterStylePoller: StartSessionPoller = vi.fn(async () => {
+      return Promise.reject(baseErrorShape);
+    });
+
+    const tool = createStartSessionTool({
+      now: () => FIXED_NOW,
+      pollers: { slack: adapterStylePoller },
+    });
+    const raw = await callHandler(tool, { force_refresh: true });
+    const parsed = StartSessionResult.parse(raw);
+
+    expect(adapterStylePoller).toHaveBeenCalledTimes(1);
+    expect(parsed.items).toEqual([]);
+    expect(parsed.freshness).toEqual([{ integration: 'slack', last_polled_at: null, stale: true }]);
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'slopweaver: slack poller failed: auth.test failed: invalid_auth\n',
+    );
 
     stderrSpy.mockRestore();
   });

--- a/packages/mcp-server/src/tools/composite/start-session.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.ts
@@ -111,7 +111,9 @@ export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): T
             try {
               await poller({ db, now: nowMs });
             } catch (error) {
-              process.stderr.write(`slopweaver: ${integration} poller failed: ${String(error)}\n`);
+              process.stderr.write(
+                `slopweaver: ${integration} poller failed: ${describeError(error)}\n`,
+              );
             }
           }
         }
@@ -289,6 +291,22 @@ function tryParseJson(json: string): z.infer<typeof EvidenceLogEntry>['payload_j
   } catch {
     return null;
   }
+}
+
+/**
+ * Stringify an unknown caught value for stderr logs. Native `Error` instances
+ * expose `.message`; `Result`-pattern errors (BaseError-shaped plain objects)
+ * also carry a string `message` — extract it explicitly so the recovery-catch
+ * log line prints `…: <message>` instead of `[object Object]`. Mirrors the
+ * `asMessage()` helper at the CLI boundary in `apps/mcp-local/src/cli.ts`.
+ */
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === 'string') return message;
+  }
+  return String(error);
 }
 
 function humanAge(ageMs: number): string {

--- a/packages/mcp-server/src/tools/composite/start-session.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.ts
@@ -102,7 +102,17 @@ export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): T
         if (shouldPoll(db, integration, nowMs, staleThresholdMs, input.force_refresh === true)) {
           const poller = pollers[integration];
           if (poller) {
-            await poller({ db, now: nowMs });
+            // Recovery catch (see .claude/rules/error-handling.md "Legitimate
+            // recovery catches"): a single integration's poller throwing
+            // (revoked token, rate limit, transient 5xx) must not abort the
+            // whole tool call. The failing integration's `Freshness.stale`
+            // remains true because `markPollCompleted` was never called —
+            // that's the contract.
+            try {
+              await poller({ db, now: nowMs });
+            } catch (error) {
+              process.stderr.write(`slopweaver: ${integration} poller failed: ${String(error)}\n`);
+            }
           }
         }
       }


### PR DESCRIPTION
## What this PR does

Wraps the per-integration `await poller(...)` call in `packages/mcp-server/src/tools/composite/start-session.ts` in `try/catch` so a single failing integration (revoked token, rate limit, transient 5xx) doesn't abort the whole `start_session` MCP tool call. On catch, logs a single human-readable line to stderr (`slopweaver: <integration> poller failed: <error>\n`) and continues to the next integration.

The failing integration's `Freshness.stale` remains `true` because `markPollCompleted` was never called — that's the existing contract and the right signal. No shape changes to `Freshness` or `StartSessionResult`, no new error variants in `@slopweaver/errors`.

## Why

Third of three "v1-wire" chains (after #47 and #48). Closes the per-platform isolation gap explicitly flagged in `docs/CODEBASE_MAP.md:179` and `:574` ("v1 has NO try/catch around individual poller invocations"). Without this, a single revoked GitHub PAT would also wipe out Slack results — a poor dogfood experience.

closes #46
refs #2

## Test plan

- [x] Tests added / updated — new isolation test in `start-session.test.ts` provides two pollers (one throws `Error('boom')`, one writes an evidence row to slack), asserts `items[]` contains the successful integration's row, `Freshness.stale` is `true` for the throwing integration and `false` for the succeeding one, and the stderr line has the expected `slopweaver: github poller failed: Error: boom\n` format. Uses strong assertions (`.toBe(true)`, exact `.toHaveBeenCalledWith`) per `.claude/rules/testing.md`.
- [x] Manually verified — `pnpm validate` green locally (all six gates).
- [x] CI green — `pnpm validate` covers check-service-boundaries / format / lint / compile / test / knip.

```
pnpm validate
# OK: no `throw` statements in service-boundary files.
# format:check ✓ (after one auto-fix to inline the stderr.write call)
# lint ✓
# compile ✓ (20 tasks, 13 cached)
# test ✓ (mcp-server 20/20 — was 19/19; all other packages unchanged)
# knip ✓
```

Service-boundary scanner: the new code is in `packages/mcp-server/src/tools/composite/start-session.ts`, which IS in the scanned directory list, but the scanner inspects `throw` statements only. A `try/catch` that swallows an error is invisible to it; no new throws are introduced by this PR.

## Breaking changes

None. The MCP wire shape for `start_session` (`StartSessionResult`) is unchanged. Stderr output gains one new line shape — observable but additive.

## Notes for the reviewer

Three deliberate decisions worth calling out:

1. **The try scope is exactly `await poller(...)` — nothing else.** `shouldPoll(...)` is a pure local DB read with no network; `pollers[integration]` is a plain object lookup. Both stay outside the try so the catch only fires for genuine poller failures, not for unrelated bugs.

2. **The catch comment cites `.claude/rules/error-handling.md` "Legitimate recovery catches"** so the next reviewer (human or scanner) sees the intent without re-deriving it. Same shape as the carve-out the doc lists for this file.

3. **`docs/CODEBASE_MAP.md:179` and `:574` are *not* updated in this PR.** Those two lines describe the gap this PR closes, but the issue's locked scope lists doc updates as something to defer to a batch-docs PR (like commit `2272160` did for the previous wave). Keeping the diff minimal here; the doc refresh will batch with whatever else lands in this wave.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling so a failure in one integration no longer aborts the whole session; other integrations continue processing. Errors are now reliably reported for visibility.

* **Tests**
  * Added tests covering multi-integration error scenarios, including handling of non-standard error objects and confirming meaningful error reporting and continued processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slopweaver/slopweaver/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->