### PR TITLE
feat(db): persist integration tokens in macOS Keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ Some things require a server: real-time webhooks instead of polling, mobile push
 
 ## Security
 
-See [SECURITY.md](SECURITY.md) for vulnerability disclosure.
+Integration tokens (GitHub PAT, Slack user token) are stored in the macOS Keychain under the entry `slopweaver / <integration>` — the local SQLite database holds only presence metadata (slug, account label, timestamps). Audit a stored token with `security find-generic-password -a github -s slopweaver -w`. On first write the v1 binary is unsigned, so macOS shows a "Keychain Access wants to use the slopweaver entry" prompt; clicking "Always Allow" trusts the binary's path. macOS is the only OS that's QA'd for v1 — Linux Secret Service and Windows Credential Manager work under the hood but are best-effort untested. For vulnerability disclosure see [SECURITY.md](SECURITY.md).

--- a/packages/db/migrations/0002_vengeful_slayback.sql
+++ b/packages/db/migrations/0002_vengeful_slayback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `integration_tokens` DROP COLUMN `token`;

--- a/packages/db/migrations/meta/0002_snapshot.json
+++ b/packages/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,353 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6a93538b-a64d-4a3e-8a58-7215b1718dae",
+  "prevId": "c8b886e0-0aef-45b1-b0f6-82a6686d86fa",
+  "tables": {
+    "evidence_log": {
+      "name": "evidence_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "citation_url": {
+          "name": "citation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at_ms": {
+          "name": "occurred_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at_ms": {
+          "name": "first_seen_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at_ms": {
+          "name": "last_seen_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at_ms": {
+          "name": "updated_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evidence_log_integration_kind_idx": {
+          "name": "evidence_log_integration_kind_idx",
+          "columns": ["integration", "kind"],
+          "isUnique": false
+        },
+        "evidence_log_integration_occurred_at_ms_idx": {
+          "name": "evidence_log_integration_occurred_at_ms_idx",
+          "columns": ["integration", "occurred_at_ms"],
+          "isUnique": false
+        },
+        "evidence_log_integration_external_id_unique": {
+          "name": "evidence_log_integration_external_id_unique",
+          "columns": ["integration", "external_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "identity_graph": {
+      "name": "identity_graph",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at_ms": {
+          "name": "updated_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "identity_graph_canonical_id_idx": {
+          "name": "identity_graph_canonical_id_idx",
+          "columns": ["canonical_id"],
+          "isUnique": false
+        },
+        "identity_graph_integration_external_id_unique": {
+          "name": "identity_graph_integration_external_id_unique",
+          "columns": ["integration", "external_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "integration_state": {
+      "name": "integration_state",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_poll_started_at_ms": {
+          "name": "last_poll_started_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_poll_completed_at_ms": {
+          "name": "last_poll_completed_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at_ms": {
+          "name": "updated_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "integration_tokens": {
+      "name": "integration_tokens",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_label": {
+          "name": "account_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at_ms": {
+          "name": "updated_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at_ms": {
+          "name": "updated_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "workspaces_single_row": {
+          "name": "workspaces_single_row",
+          "value": "\"workspaces\".\"id\" = 1"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1778074475311,
       "tag": "0001_solid_whirlwind",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1779012112501,
+      "tag": "0002_vengeful_slayback",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@napi-rs/keyring": "1.3.0",
     "@slopweaver/errors": "workspace:*",
     "better-sqlite3": "12.2.0",
     "drizzle-orm": "0.45.2"

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -16,6 +16,7 @@ import * as schema from './schema/index.ts';
 
 export * from './errors.ts';
 export * from './integration-tokens.ts';
+export * from './keychain.ts';
 export * from './path.ts';
 export * from './safe-query.ts';
 export * from './schema/index.ts';

--- a/packages/db/src/integration-tokens.test.ts
+++ b/packages/db/src/integration-tokens.test.ts
@@ -1,22 +1,43 @@
 /**
  * Unit tests for loadIntegrationToken / saveIntegrationToken.
  *
- * Pins the contracts the CLI subcommands and the future polling layer rely
- * on: missing rows surface as `null` (not Err), repeat saves upsert cleanly
- * without resetting `created_at_ms`, and writes are scoped per integration
- * slug. Result-based assertions per .claude/rules/error-handling.md.
+ * Pins the contracts the CLI subcommands and the polling layer rely on:
+ * missing rows surface as `null` (not Err), repeat saves upsert cleanly
+ * without resetting `created_at_ms`, writes are scoped per integration
+ * slug, and the secret is routed through the injected keychain adapter
+ * (so this suite stays deterministic on Linux CI without depending on
+ * libsecret). Result-based assertions per .claude/rules/error-handling.md.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createDb } from './index.ts';
 import { loadIntegrationToken, saveIntegrationToken } from './integration-tokens.ts';
+import type { KeychainAdapter } from './keychain.ts';
 import { integrationTokens } from './schema/integration-tokens.ts';
+
+function makeMemoryAdapter(): KeychainAdapter & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  const key = ({ service, account }: { service: string; account: string }) => `${service}:${account}`;
+  return {
+    store,
+    async setPassword({ service, account, password }) {
+      store.set(key({ service, account }), password);
+    },
+    async getPassword({ service, account }) {
+      return store.get(key({ service, account })) ?? null;
+    },
+    async deletePassword({ service, account }) {
+      return store.delete(key({ service, account }));
+    },
+  };
+}
 
 describe('loadIntegrationToken', () => {
   it('returns ok(null) when no row exists for the integration', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
-      const result = await loadIntegrationToken({ db: handle.db, integration: 'github' });
+      const keychainAdapter = makeMemoryAdapter();
+      const result = await loadIntegrationToken({ db: handle.db, integration: 'github', keychainAdapter });
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         expect(result.value).toBeNull();
@@ -29,16 +50,18 @@ describe('loadIntegrationToken', () => {
   it('returns ok with the stored token + account label after a save', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
+      const keychainAdapter = makeMemoryAdapter();
       const saveResult = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_test_value',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
+        keychainAdapter,
       });
       expect(saveResult.isOk()).toBe(true);
 
-      const loadResult = await loadIntegrationToken({ db: handle.db, integration: 'github' });
+      const loadResult = await loadIntegrationToken({ db: handle.db, integration: 'github', keychainAdapter });
       expect(loadResult.isOk()).toBe(true);
       if (loadResult.isOk()) {
         expect(loadResult.value).toEqual({
@@ -54,20 +77,57 @@ describe('loadIntegrationToken', () => {
   it('scopes lookups by integration slug', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
+      const keychainAdapter = makeMemoryAdapter();
       const saveResult = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_github',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
+        keychainAdapter,
       });
       expect(saveResult.isOk()).toBe(true);
 
-      const result = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+      const result = await loadIntegrationToken({ db: handle.db, integration: 'slack', keychainAdapter });
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         expect(result.value).toBeNull();
       }
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('returns ok(null) and writes a stderr hint when the row exists but the keychain entry is missing', async () => {
+    const handle = createDb({ path: ':memory:' });
+    try {
+      handle.db
+        .insert(integrationTokens)
+        .values({
+          integration: 'github',
+          accountLabel: 'octocat',
+          createdAtMs: 1_746_000_000_000,
+          updatedAtMs: 1_746_000_000_000,
+        })
+        .run();
+
+      const keychainAdapter = makeMemoryAdapter();
+      const stderr = { write: vi.fn() };
+
+      const result = await loadIntegrationToken({
+        db: handle.db,
+        integration: 'github',
+        keychainAdapter,
+        stderr,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBeNull();
+      }
+      expect(stderr.write).toHaveBeenCalledTimes(1);
+      expect(stderr.write).toHaveBeenCalledWith(
+        "slopweaver: github token missing from keychain — run 'slopweaver connect github' to migrate\n",
+      );
     } finally {
       handle.close();
     }
@@ -78,12 +138,14 @@ describe('saveIntegrationToken', () => {
   it('upserts: re-saving the same integration overwrites token + account label', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
+      const keychainAdapter = makeMemoryAdapter();
       const firstSave = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_old',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
+        keychainAdapter,
       });
       expect(firstSave.isOk()).toBe(true);
       const secondSave = await saveIntegrationToken({
@@ -92,10 +154,11 @@ describe('saveIntegrationToken', () => {
         token: 'ghp_new',
         accountLabel: 'octocat-renamed',
         now: () => 1_746_000_000_500,
+        keychainAdapter,
       });
       expect(secondSave.isOk()).toBe(true);
 
-      const loaded = await loadIntegrationToken({ db: handle.db, integration: 'github' });
+      const loaded = await loadIntegrationToken({ db: handle.db, integration: 'github', keychainAdapter });
       expect(loaded.isOk()).toBe(true);
       if (loaded.isOk()) {
         expect(loaded.value).toEqual({
@@ -112,12 +175,14 @@ describe('saveIntegrationToken', () => {
   it('preserves created_at_ms across re-saves and bumps updated_at_ms', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
+      const keychainAdapter = makeMemoryAdapter();
       const firstSave = await saveIntegrationToken({
         db: handle.db,
         integration: 'github',
         token: 'ghp_first',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_000,
+        keychainAdapter,
       });
       expect(firstSave.isOk()).toBe(true);
       const secondSave = await saveIntegrationToken({
@@ -126,6 +191,7 @@ describe('saveIntegrationToken', () => {
         token: 'ghp_second',
         accountLabel: 'octocat',
         now: () => 1_746_000_000_999,
+        keychainAdapter,
       });
       expect(secondSave.isOk()).toBe(true);
 
@@ -140,16 +206,18 @@ describe('saveIntegrationToken', () => {
   it('accepts a null account label', async () => {
     const handle = createDb({ path: ':memory:' });
     try {
+      const keychainAdapter = makeMemoryAdapter();
       const saveResult = await saveIntegrationToken({
         db: handle.db,
         integration: 'slack',
         token: 'xoxb-redacted',
         accountLabel: null,
         now: () => 1_746_000_000_000,
+        keychainAdapter,
       });
       expect(saveResult.isOk()).toBe(true);
 
-      const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack' });
+      const loaded = await loadIntegrationToken({ db: handle.db, integration: 'slack', keychainAdapter });
       expect(loaded.isOk()).toBe(true);
       if (loaded.isOk()) {
         expect(loaded.value).toEqual({
@@ -157,6 +225,35 @@ describe('saveIntegrationToken', () => {
           accountLabel: null,
         });
       }
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('propagates KEYCHAIN_WRITE_FAILED without creating a SQLite row', async () => {
+    const handle = createDb({ path: ':memory:' });
+    try {
+      const keychainAdapter: KeychainAdapter = {
+        setPassword: vi.fn().mockRejectedValue(new Error('user denied keychain prompt')),
+        getPassword: vi.fn(),
+        deletePassword: vi.fn(),
+      };
+
+      const result = await saveIntegrationToken({
+        db: handle.db,
+        integration: 'github',
+        token: 'ghp_never_written',
+        accountLabel: 'octocat',
+        now: () => 1_746_000_000_000,
+        keychainAdapter,
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe('KEYCHAIN_WRITE_FAILED');
+      }
+
+      const rows = handle.db.select().from(integrationTokens).all();
+      expect(rows).toHaveLength(0);
     } finally {
       handle.close();
     }

--- a/packages/db/src/integration-tokens.test.ts
+++ b/packages/db/src/integration-tokens.test.ts
@@ -258,4 +258,63 @@ describe('saveIntegrationToken', () => {
       handle.close();
     }
   });
+
+  it('cleans up the keychain entry when the SQLite upsert fails (no split-brain)', async () => {
+    // Close the connection before invoking save — the keychain write
+    // will succeed, then the SQLite upsert will fail, exercising the
+    // compensating-delete path.
+    const handle = createDb({ path: ':memory:' });
+    handle.close();
+    const keychainAdapter = makeMemoryAdapter();
+
+    const result = await saveIntegrationToken({
+      db: handle.db,
+      integration: 'github',
+      token: 'ghp_orphaned_no_more',
+      accountLabel: 'octocat',
+      now: () => 1_746_000_000_000,
+      keychainAdapter,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      // The original DB error is what the caller sees — NOT a keychain error.
+      expect(result.error.code).not.toBe('KEYCHAIN_DELETE_FAILED');
+    }
+    // The keychain entry was created during save but cleaned up after the DB fail.
+    expect(keychainAdapter.store.has('slopweaver:github')).toBe(false);
+  });
+
+  it('surfaces the original DB error even when the compensating keychain delete also fails', async () => {
+    const handle = createDb({ path: ':memory:' });
+    handle.close();
+    const writes = new Map<string, string>();
+    const keychainAdapter: KeychainAdapter = {
+      async setPassword({ service, account, password }) {
+        writes.set(`${service}:${account}`, password);
+      },
+      getPassword: vi.fn(),
+      async deletePassword() {
+        throw new Error('keychain delete failed after orphan');
+      },
+    };
+
+    const result = await saveIntegrationToken({
+      db: handle.db,
+      integration: 'github',
+      token: 'ghp_double_failure',
+      accountLabel: 'octocat',
+      now: () => 1_746_000_000_000,
+      keychainAdapter,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      // The original DB error is preserved; the keychain delete failure does NOT mask it.
+      expect(result.error.code).not.toBe('KEYCHAIN_DELETE_FAILED');
+      expect(result.error.code).not.toBe('KEYCHAIN_WRITE_FAILED');
+    }
+    // The keychain entry WAS written and the cleanup attempt happened (and failed) — verified via the writes map.
+    expect(writes.get('slopweaver:github')).toBe('ghp_double_failure');
+  });
 });

--- a/packages/db/src/integration-tokens.ts
+++ b/packages/db/src/integration-tokens.ts
@@ -18,10 +18,16 @@
  */
 
 import type { DatabaseError } from '@slopweaver/errors';
-import { okAsync, type ResultAsync } from '@slopweaver/errors';
+import { errAsync, okAsync, type ResultAsync } from '@slopweaver/errors';
 import { eq } from 'drizzle-orm';
 import type { SlopweaverDatabase } from './index.ts';
-import { type KeychainAdapter, type KeychainError, loadKeychainToken, saveKeychainToken } from './keychain.ts';
+import {
+  deleteKeychainToken,
+  type KeychainAdapter,
+  type KeychainError,
+  loadKeychainToken,
+  saveKeychainToken,
+} from './keychain.ts';
 import { safeQuery } from './safe-query.ts';
 import { integrationTokens } from './schema/integration-tokens.ts';
 
@@ -99,9 +105,13 @@ export type SaveIntegrationTokenArgs = {
 
 /**
  * Persists a connect-flow token. The secret is written to the keychain
- * first; only on success is the SQLite presence row upserted. This
- * ordering means a keychain failure leaves the world unchanged — the
- * SQLite row never points at a missing keychain entry.
+ * first; only on success is the SQLite presence row upserted. If the
+ * upsert then fails (disk full, file lock, corruption), a best-effort
+ * `deleteKeychainToken` cleans up the orphan so `loadIntegrationToken`
+ * doesn't end up in a split-brain "no row, but secret in keychain"
+ * state. Either branch of the cleanup re-surfaces the original DB
+ * error — a cleanup-side failure must not mask the actual problem the
+ * caller needs to see.
  *
  * On re-connect the existing `created_at_ms` is preserved (kept out of
  * the conflict-update set) while `account_label` and `updated_at_ms`
@@ -116,10 +126,10 @@ export function saveIntegrationToken({
   now = () => Date.now(),
   keychainAdapter,
 }: SaveIntegrationTokenArgs): ResultAsync<void, DatabaseError | KeychainError> {
+  const keychainArgs = { integration, ...(keychainAdapter ? { adapter: keychainAdapter } : {}) };
   return saveKeychainToken({
-    integration,
+    ...keychainArgs,
     token,
-    ...(keychainAdapter ? { adapter: keychainAdapter } : {}),
   }).andThen<void, DatabaseError | KeychainError>(() =>
     safeQuery({
       execute: () => {
@@ -140,6 +150,9 @@ export function saveIntegrationToken({
           })
           .run();
       },
+    }).orElse((dbError) => {
+      const surface = (): ResultAsync<void, DatabaseError | KeychainError> => errAsync(dbError);
+      return deleteKeychainToken(keychainArgs).andThen(surface).orElse(surface);
     }),
   );
 }

--- a/packages/db/src/integration-tokens.ts
+++ b/packages/db/src/integration-tokens.ts
@@ -1,26 +1,39 @@
 /**
- * Read/write helpers for the `integration_tokens` table — the single source
- * of truth for credentials supplied by `slopweaver connect`.
+ * Read/write helpers for integration credentials supplied via
+ * `slopweaver connect`. This module is the single source of truth for
+ * "is integration X connected, and what's its token?" — the CLI
+ * subcommands write here, the polling layer reads here.
  *
- * The CLI subcommands write here; the polling layer (and future `start_session`
- * tools) read here. Keeping this surface in @slopweaver/db rather than
- * apps/mcp-local means non-binary callers (smoke tests, future cloud tier)
- * can reuse the same helpers without depending on the CLI app.
+ * Storage split: the secret lives in the OS keychain (see
+ * `./keychain.ts`), keyed by `slopweaver / <integration>`. The
+ * `integration_tokens` SQLite row tracks *presence* (slug, account
+ * label, timestamps) and is the only thing `loadIntegrationToken`
+ * consults to answer "is X connected?". Keeping this helper in
+ * @slopweaver/db rather than apps/mcp-local means non-binary callers
+ * (smoke tests, future cloud tier) reuse the same surface.
  *
- * The integration slug is plain `string` here, matching `upsertEvidence` /
- * `markPollStarted` — the constraint to `'github' | 'slack'` is a CLI-level
- * boundary, not a storage one.
+ * The integration slug is plain `string` here, matching `upsertEvidence`
+ * / `markPollStarted` — the constraint to `'github' | 'slack'` is a
+ * CLI-level boundary, not a storage one.
  */
 
-import type { DatabaseError, ResultAsync } from '@slopweaver/errors';
+import type { DatabaseError } from '@slopweaver/errors';
+import { okAsync, type ResultAsync } from '@slopweaver/errors';
 import { eq } from 'drizzle-orm';
 import type { SlopweaverDatabase } from './index.ts';
+import { type KeychainAdapter, type KeychainError, loadKeychainToken, saveKeychainToken } from './keychain.ts';
 import { safeQuery } from './safe-query.ts';
 import { integrationTokens } from './schema/integration-tokens.ts';
+
+interface StderrWriter {
+  write(message: string): void;
+}
 
 export type LoadIntegrationTokenArgs = {
   db: SlopweaverDatabase;
   integration: string;
+  keychainAdapter?: KeychainAdapter;
+  stderr?: StderrWriter;
 };
 
 export type LoadIntegrationTokenResult = {
@@ -29,22 +42,28 @@ export type LoadIntegrationTokenResult = {
 };
 
 /**
- * Returns the stored token for `integration`, or `null` if no row exists.
+ * Returns the stored token for `integration`, or `null` if no row exists
+ * (not connected) or if the SQLite row exists but the keychain entry is
+ * missing (stale row from a pre-keychain install or a manually-deleted
+ * entry). In the stale-row case a one-line hint is written to `stderr`
+ * pointing at `slopweaver connect <integration>` as the recovery path —
+ * pre-alpha auto-migration is intentionally out of scope.
  *
- * Polling code must treat `null` as "not connected — skip this integration"
- * rather than treating it as an error, so the local binary can run
- * partially-configured (e.g. user has connected GitHub but not Slack yet).
- * `Err` is reserved for actual database failures.
+ * Polling code must treat `null` as "not connected — skip this
+ * integration" rather than as an error, so the local binary can run
+ * partially-configured. `Err` is reserved for actual database / keychain
+ * failures (not for "missing" semantics).
  */
 export function loadIntegrationToken({
   db,
   integration,
-}: LoadIntegrationTokenArgs): ResultAsync<LoadIntegrationTokenResult | null, DatabaseError> {
+  keychainAdapter,
+  stderr = process.stderr,
+}: LoadIntegrationTokenArgs): ResultAsync<LoadIntegrationTokenResult | null, DatabaseError | KeychainError> {
   return safeQuery({
     execute: () => {
       const row = db
         .select({
-          token: integrationTokens.token,
           accountLabel: integrationTokens.accountLabel,
         })
         .from(integrationTokens)
@@ -52,6 +71,20 @@ export function loadIntegrationToken({
         .get();
       return row ?? null;
     },
+  }).andThen<LoadIntegrationTokenResult | null, DatabaseError | KeychainError>((row) => {
+    if (row === null) return okAsync(null);
+    return loadKeychainToken({
+      integration,
+      ...(keychainAdapter ? { adapter: keychainAdapter } : {}),
+    }).map((kcToken) => {
+      if (kcToken === null) {
+        stderr.write(
+          `slopweaver: ${integration} token missing from keychain — run 'slopweaver connect ${integration}' to migrate\n`,
+        );
+        return null;
+      }
+      return { token: kcToken, accountLabel: row.accountLabel };
+    });
   });
 }
 
@@ -61,12 +94,18 @@ export type SaveIntegrationTokenArgs = {
   token: string;
   accountLabel: string | null;
   now?: () => number;
+  keychainAdapter?: KeychainAdapter;
 };
 
 /**
- * Upserts a token row. On re-connect the existing `created_at_ms` is preserved
- * (kept out of the conflict-update set) while `token`, `account_label`, and
- * `updated_at_ms` are refreshed. Mirrors the `markPollStarted` pattern in
+ * Persists a connect-flow token. The secret is written to the keychain
+ * first; only on success is the SQLite presence row upserted. This
+ * ordering means a keychain failure leaves the world unchanged — the
+ * SQLite row never points at a missing keychain entry.
+ *
+ * On re-connect the existing `created_at_ms` is preserved (kept out of
+ * the conflict-update set) while `account_label` and `updated_at_ms`
+ * are refreshed. Mirrors the `markPollStarted` pattern in
  * @slopweaver/integrations-core.
  */
 export function saveIntegrationToken({
@@ -75,27 +114,32 @@ export function saveIntegrationToken({
   token,
   accountLabel,
   now = () => Date.now(),
-}: SaveIntegrationTokenArgs): ResultAsync<void, DatabaseError> {
-  return safeQuery({
-    execute: () => {
-      const stamp = now();
-      db.insert(integrationTokens)
-        .values({
-          integration,
-          token,
-          accountLabel,
-          createdAtMs: stamp,
-          updatedAtMs: stamp,
-        })
-        .onConflictDoUpdate({
-          target: integrationTokens.integration,
-          set: {
-            token,
+  keychainAdapter,
+}: SaveIntegrationTokenArgs): ResultAsync<void, DatabaseError | KeychainError> {
+  return saveKeychainToken({
+    integration,
+    token,
+    ...(keychainAdapter ? { adapter: keychainAdapter } : {}),
+  }).andThen<void, DatabaseError | KeychainError>(() =>
+    safeQuery({
+      execute: () => {
+        const stamp = now();
+        db.insert(integrationTokens)
+          .values({
+            integration,
             accountLabel,
+            createdAtMs: stamp,
             updatedAtMs: stamp,
-          },
-        })
-        .run();
-    },
-  });
+          })
+          .onConflictDoUpdate({
+            target: integrationTokens.integration,
+            set: {
+              accountLabel,
+              updatedAtMs: stamp,
+            },
+          })
+          .run();
+      },
+    }),
+  );
 }

--- a/packages/db/src/keychain.test.ts
+++ b/packages/db/src/keychain.test.ts
@@ -114,6 +114,33 @@ describe('keychain error surfacing', () => {
     }
   });
 
+  it('load classifies NoEntry-shaped throws as Ok(null) rather than KEYCHAIN_READ_FAILED', async () => {
+    // The current macOS binding returns null on missing entry, but the
+    // lib's TS doc says "Returns a NoEntry error if there isn't one" —
+    // future versions or other platforms may throw. The .orElse layer in
+    // loadKeychainToken should recover to Ok(null) for any error whose
+    // message looks like the Rust NoEntry variant.
+    const noEntryMessages = [
+      'No matching entry found in secure storage',
+      'no entry in secure store matched the search',
+      'credential does not exist',
+      'not found',
+    ];
+    for (const msg of noEntryMessages) {
+      const adapter: KeychainAdapter = {
+        setPassword: vi.fn(),
+        getPassword: vi.fn().mockRejectedValue(new Error(msg)),
+        deletePassword: vi.fn(),
+      };
+
+      const result = await loadKeychainToken({ integration: 'github', adapter });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBeNull();
+      }
+    }
+  });
+
   it('delete surfaces KEYCHAIN_DELETE_FAILED when the adapter rejects', async () => {
     const adapter: KeychainAdapter = {
       setPassword: vi.fn(),

--- a/packages/db/src/keychain.test.ts
+++ b/packages/db/src/keychain.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the keychain bridge. Uses an in-memory `KeychainAdapter`
+ * so the suite runs deterministically on Linux CI without depending on
+ * libsecret / dbus availability. The real adapter is exercised by hand
+ * (the smoke step in the PR description) on macOS.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { type KeychainAdapter, deleteKeychainToken, loadKeychainToken, saveKeychainToken } from './keychain.ts';
+
+function makeMemoryAdapter(): KeychainAdapter & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  const key = ({ service, account }: { service: string; account: string }) => `${service}:${account}`;
+  return {
+    store,
+    async setPassword({ service, account, password }) {
+      store.set(key({ service, account }), password);
+    },
+    async getPassword({ service, account }) {
+      return store.get(key({ service, account })) ?? null;
+    },
+    async deletePassword({ service, account }) {
+      return store.delete(key({ service, account }));
+    },
+  };
+}
+
+describe('saveKeychainToken / loadKeychainToken', () => {
+  it('round-trips a token via the same service/account', async () => {
+    const adapter = makeMemoryAdapter();
+
+    const saved = await saveKeychainToken({ integration: 'github', token: 'ghp_round_trip', adapter });
+    expect(saved.isOk()).toBe(true);
+
+    const loaded = await loadKeychainToken({ integration: 'github', adapter });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toBe('ghp_round_trip');
+    }
+
+    expect(adapter.store.get('slopweaver:github')).toBe('ghp_round_trip');
+  });
+
+  it('returns Ok(null) when no entry exists for the integration', async () => {
+    const adapter = makeMemoryAdapter();
+
+    const loaded = await loadKeychainToken({ integration: 'slack', adapter });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toBeNull();
+    }
+  });
+
+  it('scopes lookups by integration slug', async () => {
+    const adapter = makeMemoryAdapter();
+
+    const saved = await saveKeychainToken({ integration: 'github', token: 'ghp_only_github', adapter });
+    expect(saved.isOk()).toBe(true);
+
+    const loaded = await loadKeychainToken({ integration: 'slack', adapter });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toBeNull();
+    }
+  });
+});
+
+describe('deleteKeychainToken', () => {
+  it('removes the entry so subsequent loads return Ok(null)', async () => {
+    const adapter = makeMemoryAdapter();
+
+    const saved = await saveKeychainToken({ integration: 'github', token: 'ghp_to_delete', adapter });
+    expect(saved.isOk()).toBe(true);
+
+    const deleted = await deleteKeychainToken({ integration: 'github', adapter });
+    expect(deleted.isOk()).toBe(true);
+
+    const loaded = await loadKeychainToken({ integration: 'github', adapter });
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isOk()) {
+      expect(loaded.value).toBeNull();
+    }
+  });
+});
+
+describe('keychain error surfacing', () => {
+  it('save surfaces KEYCHAIN_WRITE_FAILED when the adapter rejects', async () => {
+    const adapter: KeychainAdapter = {
+      setPassword: vi.fn().mockRejectedValue(new Error('user denied keychain prompt')),
+      getPassword: vi.fn(),
+      deletePassword: vi.fn(),
+    };
+
+    const result = await saveKeychainToken({ integration: 'github', token: 'ghp_x', adapter });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('KEYCHAIN_WRITE_FAILED');
+      expect(result.error.message).toContain('user denied keychain prompt');
+    }
+  });
+
+  it('load surfaces KEYCHAIN_READ_FAILED when the adapter rejects', async () => {
+    const adapter: KeychainAdapter = {
+      setPassword: vi.fn(),
+      getPassword: vi.fn().mockRejectedValue(new Error('keychain locked')),
+      deletePassword: vi.fn(),
+    };
+
+    const result = await loadKeychainToken({ integration: 'github', adapter });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('KEYCHAIN_READ_FAILED');
+      expect(result.error.message).toContain('keychain locked');
+    }
+  });
+
+  it('delete surfaces KEYCHAIN_DELETE_FAILED when the adapter rejects', async () => {
+    const adapter: KeychainAdapter = {
+      setPassword: vi.fn(),
+      getPassword: vi.fn(),
+      deletePassword: vi.fn().mockRejectedValue(new Error('ambiguous credential')),
+    };
+
+    const result = await deleteKeychainToken({ integration: 'github', adapter });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('KEYCHAIN_DELETE_FAILED');
+      expect(result.error.message).toContain('ambiguous credential');
+    }
+  });
+});

--- a/packages/db/src/keychain.ts
+++ b/packages/db/src/keychain.ts
@@ -1,0 +1,146 @@
+/**
+ * OS keychain bridge for integration access tokens.
+ *
+ * Tokens for `slopweaver connect github` / `connect slack` live in the
+ * macOS Keychain (and equivalents on Linux/Windows via libsecret /
+ * Credential Manager). The `integration_tokens` SQLite row tracks
+ * *presence* (slug, account label, timestamps); the secret itself never
+ * touches disk in plaintext. See `.claude/rules/error-handling.md` —
+ * `packages/db/src/**` is service-boundary scanned, so every keychain
+ * call is wrapped with `ResultAsync.fromPromise` rather than `try/catch`.
+ *
+ * The `KeychainAdapter` indirection exists so tests can swap in a memory
+ * fake without depending on libsecret / dbus availability in CI. The
+ * `realKeychainAdapter` default wraps `@napi-rs/keyring`'s `AsyncEntry`,
+ * which catches the underlying Rust `NoEntry` error and returns
+ * `undefined` on a miss — we normalize that to `null` so callers see a
+ * uniform `string | null`.
+ */
+
+import { AsyncEntry } from '@napi-rs/keyring';
+import type { BaseError } from '@slopweaver/errors';
+import { ResultAsync } from '@slopweaver/errors';
+
+const KEYCHAIN_SERVICE = 'slopweaver';
+
+export interface KeychainWriteFailedError extends BaseError {
+  readonly code: 'KEYCHAIN_WRITE_FAILED';
+  readonly cause: unknown;
+}
+
+export interface KeychainReadFailedError extends BaseError {
+  readonly code: 'KEYCHAIN_READ_FAILED';
+  readonly cause: unknown;
+}
+
+export interface KeychainDeleteFailedError extends BaseError {
+  readonly code: 'KEYCHAIN_DELETE_FAILED';
+  readonly cause: unknown;
+}
+
+export type KeychainError = KeychainWriteFailedError | KeychainReadFailedError | KeychainDeleteFailedError;
+
+function describe(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === 'string') return cause;
+  return 'unknown keychain failure';
+}
+
+export const KeychainErrors = {
+  writeFailed: (cause: unknown): KeychainWriteFailedError => ({
+    code: 'KEYCHAIN_WRITE_FAILED',
+    message: `Failed to write token to keychain: ${describe(cause)}`,
+    cause,
+  }),
+  readFailed: (cause: unknown): KeychainReadFailedError => ({
+    code: 'KEYCHAIN_READ_FAILED',
+    message: `Failed to read token from keychain: ${describe(cause)}`,
+    cause,
+  }),
+  deleteFailed: (cause: unknown): KeychainDeleteFailedError => ({
+    code: 'KEYCHAIN_DELETE_FAILED',
+    message: `Failed to delete token from keychain: ${describe(cause)}`,
+    cause,
+  }),
+} as const;
+
+export interface KeychainAdapter {
+  setPassword(args: { service: string; account: string; password: string }): Promise<void>;
+  getPassword(args: { service: string; account: string }): Promise<string | null>;
+  deletePassword(args: { service: string; account: string }): Promise<boolean>;
+}
+
+export const realKeychainAdapter: KeychainAdapter = {
+  async setPassword({ service, account, password }) {
+    const entry = new AsyncEntry(service, account);
+    await entry.setPassword(password);
+  },
+  async getPassword({ service, account }) {
+    const entry = new AsyncEntry(service, account);
+    const value = await entry.getPassword();
+    return value ?? null;
+  },
+  async deletePassword({ service, account }) {
+    const entry = new AsyncEntry(service, account);
+    return entry.deleteCredential();
+  },
+};
+
+/**
+ * Stores `token` under the keychain entry `slopweaver / <integration>`,
+ * overwriting any previous value. Returns Err if the underlying keychain
+ * call rejects (typically: user denied Keychain Access, locked keychain
+ * with no UI to prompt, or a platform-side `Ambiguous` credential).
+ */
+export function saveKeychainToken({
+  integration,
+  token,
+  adapter = realKeychainAdapter,
+}: {
+  integration: string;
+  token: string;
+  adapter?: KeychainAdapter;
+}): ResultAsync<void, KeychainWriteFailedError> {
+  return ResultAsync.fromPromise(
+    adapter.setPassword({ service: KEYCHAIN_SERVICE, account: integration, password: token }),
+    KeychainErrors.writeFailed,
+  );
+}
+
+/**
+ * Reads the token from the keychain entry `slopweaver / <integration>`.
+ * Returns `Ok(null)` when no entry exists — callers should treat that as
+ * "not connected" (same convention as `loadIntegrationToken`'s
+ * missing-row case). Returns Err only when the keychain call itself
+ * fails (denied prompt, locked keychain, etc.).
+ */
+export function loadKeychainToken({
+  integration,
+  adapter = realKeychainAdapter,
+}: {
+  integration: string;
+  adapter?: KeychainAdapter;
+}): ResultAsync<string | null, KeychainReadFailedError> {
+  return ResultAsync.fromPromise(
+    adapter.getPassword({ service: KEYCHAIN_SERVICE, account: integration }),
+    KeychainErrors.readFailed,
+  );
+}
+
+/**
+ * Removes the keychain entry for `integration`. Returning `Ok` for a
+ * missing entry vs an actually-deleted entry is intentionally not
+ * distinguished — the boolean from the underlying lib is discarded.
+ */
+export function deleteKeychainToken({
+  integration,
+  adapter = realKeychainAdapter,
+}: {
+  integration: string;
+  adapter?: KeychainAdapter;
+}): ResultAsync<void, KeychainDeleteFailedError> {
+  return ResultAsync.fromPromise(
+    adapter.deletePassword({ service: KEYCHAIN_SERVICE, account: integration }),
+    KeychainErrors.deleteFailed,
+  ).map(() => undefined);
+}

--- a/packages/db/src/keychain.ts
+++ b/packages/db/src/keychain.ts
@@ -11,15 +11,17 @@
  *
  * The `KeychainAdapter` indirection exists so tests can swap in a memory
  * fake without depending on libsecret / dbus availability in CI. The
- * `realKeychainAdapter` default wraps `@napi-rs/keyring`'s `AsyncEntry`,
- * which catches the underlying Rust `NoEntry` error and returns
- * `undefined` on a miss — we normalize that to `null` so callers see a
- * uniform `string | null`.
+ * `realKeychainAdapter` default wraps `@napi-rs/keyring`'s `AsyncEntry`.
+ * The macOS binding (verified at v1.3.0) resolves `getPassword()` to
+ * `undefined`/`null` on a missing entry; we normalize that to `null`.
+ * Other backends — and the lib's own TS doc — say `NoEntry` surfaces as
+ * a thrown error instead, so `loadKeychainToken` also classifies
+ * NoEntry-shaped throws into `Ok(null)` (see `looksLikeNoEntry`).
  */
 
 import { AsyncEntry } from '@napi-rs/keyring';
 import type { BaseError } from '@slopweaver/errors';
-import { ResultAsync } from '@slopweaver/errors';
+import { errAsync, okAsync, ResultAsync } from '@slopweaver/errors';
 
 const KEYCHAIN_SERVICE = 'slopweaver';
 
@@ -44,6 +46,32 @@ function describe(cause: unknown): string {
   if (cause instanceof Error) return cause.message;
   if (typeof cause === 'string') return cause;
   return 'unknown keychain failure';
+}
+
+/**
+ * Heuristic: does this error look like the Rust `keyring` crate's `NoEntry`
+ * variant (i.e. "credential does not exist") rather than a real failure?
+ *
+ * The `@napi-rs/keyring 1.3.0` binding on macOS resolves `AsyncEntry.getPassword()`
+ * to `undefined`/`null` on a missing entry — verified empirically before
+ * landing this code. Its TypeScript doc comment, however, says "Returns a
+ * NoEntry error if there isn't one", and Linux Secret Service / Windows
+ * Credential Manager backends or future binding versions may bubble the
+ * Rust error up instead. This classifier defends against that: any error
+ * whose message includes one of the canonical `NoEntry` phrases is mapped
+ * to `Ok(null)` so the stale-row contract in `loadIntegrationToken` still
+ * holds. Genuine keychain failures (locked, denied, ambiguous) carry
+ * different messages and continue to surface as `KEYCHAIN_READ_FAILED`.
+ */
+function looksLikeNoEntry(cause: unknown): boolean {
+  const message = cause instanceof Error ? cause.message : typeof cause === 'string' ? cause : '';
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('no entry') ||
+    normalized.includes('no matching') ||
+    normalized.includes('not found') ||
+    normalized.includes('does not exist')
+  );
 }
 
 export const KeychainErrors = {
@@ -112,7 +140,11 @@ export function saveKeychainToken({
  * Returns `Ok(null)` when no entry exists — callers should treat that as
  * "not connected" (same convention as `loadIntegrationToken`'s
  * missing-row case). Returns Err only when the keychain call itself
- * fails (denied prompt, locked keychain, etc.).
+ * fails (denied prompt, locked keychain, ambiguous credential, etc.).
+ *
+ * The `.orElse` step classifies the lib's `NoEntry` shape and recovers
+ * to `Ok(null)` so callers don't have to special-case it — see
+ * `looksLikeNoEntry` above for the rationale.
  */
 export function loadKeychainToken({
   integration,
@@ -124,6 +156,8 @@ export function loadKeychainToken({
   return ResultAsync.fromPromise(
     adapter.getPassword({ service: KEYCHAIN_SERVICE, account: integration }),
     KeychainErrors.readFailed,
+  ).orElse((err) =>
+    looksLikeNoEntry(err.cause) ? okAsync<string | null, KeychainReadFailedError>(null) : errAsync(err),
   );
 }
 

--- a/packages/db/src/safe-query.test.ts
+++ b/packages/db/src/safe-query.test.ts
@@ -36,7 +36,6 @@ describe('safeQuery', () => {
       .insert(integrationTokens)
       .values({
         integration: 'github',
-        token: 'gh_xxx',
         accountLabel: null,
         createdAtMs: 1,
         updatedAtMs: 1,
@@ -49,7 +48,6 @@ describe('safeQuery', () => {
           .insert(integrationTokens)
           .values({
             integration: 'github',
-            token: 'gh_yyy',
             accountLabel: null,
             createdAtMs: 2,
             updatedAtMs: 2,

--- a/packages/db/src/schema/integration-tokens.ts
+++ b/packages/db/src/schema/integration-tokens.ts
@@ -1,14 +1,17 @@
 /**
- * `integration_tokens` table — credentials supplied via `slopweaver connect`.
+ * `integration_tokens` table — presence record for credentials supplied via
+ * `slopweaver connect`. One row per integration; the integration slug is
+ * the primary key.
  *
- * One row per integration; the integration slug is the primary key. v1 stores
- * the raw token verbatim — encryption-at-rest, multi-account-per-integration,
- * and rotation are explicit follow-ups, not v1 scope.
+ * The secret itself lives in the OS keychain (`slopweaver / <integration>`,
+ * see `packages/db/src/keychain.ts`). This row tracks *whether* a token
+ * exists, plus the display metadata needed to answer "which account?"
+ * without round-tripping to the upstream API. Multi-account-per-integration
+ * and token rotation are explicit follow-ups, not v1 scope.
  *
  * `account_label` is a human-readable identifier captured at connect time
  * (e.g. the GitHub login or the Slack workspace name) so subsequent CLI
- * surfaces — `doctor`, future `status` — can show *which* account is wired up
- * without needing to round-trip back to the upstream API.
+ * surfaces — `doctor`, future `status` — can show *which* account is wired up.
  */
 
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
@@ -16,8 +19,6 @@ import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 export const integrationTokens = sqliteTable('integration_tokens', {
   /** Integration slug — primary key, one row per integration. */
   integration: text('integration').primaryKey(),
-  /** Raw token as supplied by the user. Plaintext for v1; encryption-at-rest is future work. */
-  token: text('token').notNull(),
   /** Display label captured at connect time (github login, slack workspace name); null if validation didn't yield one. */
   accountLabel: text('account_label'),
   /** Epoch ms when this row was first inserted. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
 
   packages/db:
     dependencies:
+      '@napi-rs/keyring':
+        specifier: 1.3.0
+        version: 1.3.0
       '@slopweaver/errors':
         specifier: workspace:*
         version: link:../errors
@@ -1162,6 +1165,82 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -4276,6 +4355,57 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:


### PR DESCRIPTION
## What this PR does

Move integration access tokens (`slopweaver connect github` / `connect slack`) out of the plaintext SQLite column and into the OS keychain via `@napi-rs/keyring`. The `integration_tokens` SQLite row continues to track *presence* (`integration`, `accountLabel`, timestamps) while the secret itself lives under the keychain entry `slopweaver / <integration>`. Caller signatures stay stable (`saveIntegrationToken` / `loadIntegrationToken` keep their existing named-object-params shape) — only the error union widens from `DatabaseError` to `DatabaseError | KeychainError`, which the existing `if (result.isErr())` branches in `apps/mcp-local/src/connect/{github,slack}.ts` and `cli.ts` handle transparently.

## Why

closes #37 · refs #2 — public-launch blocker per the security decision recorded on the issue. Keychain protects against stolen-laptop-without-FileVault, Time Machine / iCloud backup leaks, and cross-app reads — failure modes that plaintext-on-disk and AES-on-disk both lose to identically. macOS-first for v1; Linux Secret Service and Windows Credential Manager work under the lib but are best-effort untested.

**Key implementation choices**

- New module `packages/db/src/keychain.ts` owns `KeychainError` (union of `KEYCHAIN_WRITE_FAILED` / `_READ_FAILED` / `_DELETE_FAILED`), the `KeychainErrors` factory namespace, and three helpers (`save` / `load` / `deleteKeychainToken`) wrapped with `ResultAsync.fromPromise` — no literal `throw` (service-boundary scanned).
- The `KeychainAdapter` interface (`setPassword` / `getPassword` / `deletePassword`) lets tests swap a Map-backed fake for the `AsyncEntry`-backed `realKeychainAdapter`. CI on Linux doesn't need libsecret / dbus.
- `saveIntegrationToken` writes to keychain **first**, then upserts the SQLite row — `andThen` short-circuits on Err so a keychain failure leaves the world unchanged.
- `loadIntegrationToken` returns `Ok(null)` on three cases: missing SQLite row (not connected), or SQLite row exists but keychain entry missing (stale). The stale case writes a one-line hint to `stderr` (`"slopweaver: <integration> token missing from keychain — run 'slopweaver connect <integration>' to migrate"`); `stderr` is injectable via a named param so tests assert on a spy. Per-alpha auto-migration is intentionally out of scope.
- Drizzle migration `0002_vengeful_slayback.sql` (`ALTER TABLE integration_tokens DROP COLUMN token`) generated verbatim by `pnpm --filter @slopweaver/db drizzle-kit generate` from clean main — not hand-edited (per memory rule `feedback_drizzle_migrations.md`).
- `@napi-rs/keyring 1.3.0` pinned exactly, matching the repo convention (`better-sqlite3 12.2.0`, `drizzle-orm 0.45.2`).

## Test plan

- [x] Tests added: `packages/db/src/keychain.test.ts` (7 cases — roundtrip, missing, scope, delete, three error-surfacing paths) and `packages/db/src/integration-tokens.test.ts` (now 8 cases — original 6 routed through the memory adapter, plus stale-row stderr-hint and KEYCHAIN_WRITE_FAILED-doesn't-create-row cases).
- [x] `packages/db/src/safe-query.test.ts` updated to drop the now-removed `token` field from its sample inserts.
- [x] `pnpm validate` green locally — all eight gates: `format:check`, `lint` (biome+oxlint+eslint zero-warning), `compile`, `check-service-boundaries`, `check-error-code-preservation`, `check-cassette-quality`, `test`, `knip`.
- [x] Manual sanity: `grep -n "throw " packages/db/src/keychain.ts packages/db/src/integration-tokens.ts` returns no matches (service-boundary cross-check).
- [ ] Manual macOS smoke (maintainer, post-review): wipe `~/.slopweaver/slopweaver.db`; `slopweaver connect github` with a fresh PAT; approve the Keychain Access prompt; `sqlite3 ~/.slopweaver/slopweaver.db "SELECT integration, accountLabel FROM integration_tokens"` shows no `token` column; `security find-generic-password -a github -s slopweaver -w` prints the PAT; `start_session` still returns ranked items.

## Breaking changes

None for callers — `saveIntegrationToken` / `loadIntegrationToken` keep their exported names and named-object-params signatures. The error union widens from `DatabaseError` to `DatabaseError | KeychainError`; existing `if (result.isErr())` call sites accept either transparently because both shapes expose `.message`.

End-user impact: pre-alpha plaintext rows are not auto-migrated. Re-run `slopweaver connect <integration>` after upgrading.

## Notes for the reviewer

- `CONTRIBUTING.md` is intentionally unchanged — the existing "Secret scanning" section is about gitleaks, not about how tokens are stored.
- `README.md` "Security" section is now a single paragraph (≤6 sentences) covering: keychain entry naming, the audit command, the first-write "Always Allow" prompt for the unsigned v1 binary, and the macOS-only-for-v1 framing.
- The `KeychainAdapter` is exported from `@slopweaver/db` so downstream test authors (any future caller of `saveIntegrationToken` / `loadIntegrationToken`) can inject the same memory-backed fake the tests in this PR use.
- The `realKeychainAdapter` creates a fresh `AsyncEntry` per call rather than reusing instances — the underlying lib doesn't promise instance reuse safety across awaits.
- Branched off `eb1f61d` (latest main after #49 merged), so the new code conforms to the bumped tsconfig flags, Biome + Oxlint + ESLint stack, and both new scanners (`check-error-code-preservation`, `check-cassette-quality`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Integration tokens now stored in OS keychain instead of the database for improved security
  * README updated with keychain storage documentation and macOS audit procedures
  * Clarified OS support status and noted initial keychain trust prompt for macOS

* **Documentation**
  * Enhanced security guidance regarding token storage location and audit processes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slopweaver/slopweaver/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->