### PR TITLE
feat(voice-rules): deterministic post-processor + apply_voice_rules MCP tool

### DIFF
--- a/apps/mcp-local/src/cli.smoke.test.ts
+++ b/apps/mcp-local/src/cli.smoke.test.ts
@@ -70,6 +70,7 @@ describe('slopweaver bin (compiled CLI)', () => {
       expect(names).toContain('get_freshness');
       expect(names).toContain('catch_me_up');
       expect(names).toContain('search_work_context');
+      expect(names).toContain('apply_voice_rules');
 
       const ping = list.tools.find((t) => t.name === 'ping');
       expect(ping?.inputSchema.type).toBe('object');

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -42,6 +42,7 @@ import {
   safeSlackCall,
 } from '@slopweaver/integrations-slack';
 import {
+  createApplyVoiceRulesTool,
   createCatchMeUpTool,
   createGetFreshnessTool,
   createMcpServer,
@@ -171,6 +172,7 @@ async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void
       createGetFreshnessTool(),
       createCatchMeUpTool(),
       createSearchWorkContextTool(),
+      createApplyVoiceRulesTool(),
     ],
   });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -143,3 +143,33 @@ export const SearchWorkContextResult = z
   })
   .strict();
 export type SearchWorkContextResult = z.infer<typeof SearchWorkContextResult>;
+
+// --- Voice rules post-processor ---------------------------------------
+
+const VoiceRuleEditSchema = z
+  .object({
+    rule_line: z.number().int().positive(),
+    kind: z.enum(['forbid_token', 'replace', 'disallow_pattern']),
+    description: NonEmptyStringSchema,
+    count: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const ApplyVoiceRulesArgs = z
+  .object({
+    /** The draft to rewrite. */
+    draft: z.string(),
+    /** The contents of `rules/communication-style.md` (or equivalent). Parsed in-tool. */
+    rules_markdown: z.string(),
+  })
+  .strict();
+export type ApplyVoiceRulesArgs = z.infer<typeof ApplyVoiceRulesArgs>;
+
+export const ApplyVoiceRulesResult = z
+  .object({
+    rewritten: z.string(),
+    edits: z.array(VoiceRuleEditSchema),
+    generated_at: IsoDatetimeSchema,
+  })
+  .strict();
+export type ApplyVoiceRulesResult = z.infer<typeof ApplyVoiceRulesResult>;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -24,6 +24,8 @@ export { createGetFreshnessTool } from './tools/builtin/get-freshness.ts';
 export type { CreateGetFreshnessToolArgs } from './tools/builtin/get-freshness.ts';
 export { createSearchWorkContextTool } from './tools/builtin/search-work-context.ts';
 export type { CreateSearchWorkContextToolArgs } from './tools/builtin/search-work-context.ts';
+export { createApplyVoiceRulesTool } from './tools/builtin/apply-voice-rules.ts';
+export type { CreateApplyVoiceRulesToolArgs } from './tools/builtin/apply-voice-rules.ts';
 export { createStartSessionTool } from './tools/composite/start-session.ts';
 export type {
   CreateStartSessionToolArgs,

--- a/packages/mcp-server/src/tools/builtin/apply-voice-rules.test.ts
+++ b/packages/mcp-server/src/tools/builtin/apply-voice-rules.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Smoke test for the apply_voice_rules MCP tool. The pure-function
+ * core is fully tested in @slopweaver/voice-rules; this test just
+ * confirms the wire-shape contract holds end-to-end.
+ */
+
+import { ApplyVoiceRulesArgs, ApplyVoiceRulesResult } from '@slopweaver/contracts';
+import { createDb } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApplyVoiceRulesTool } from './apply-voice-rules.ts';
+
+const FIXED_NOW = 1_762_000_000_000;
+
+describe('createApplyVoiceRulesTool', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it('rewrites the draft according to the parsed rules and returns the edit log', async () => {
+    const tool = createApplyVoiceRulesTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: ApplyVoiceRulesArgs.parse({
+        draft: "Let's delve into the details!",
+        rules_markdown: ['# Rules', '', '- forbid: delve', '- pattern: !+'].join('\n'),
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = ApplyVoiceRulesResult.parse(result.value);
+      expect(parsed.rewritten).toBe("Let's into the details");
+      expect(parsed.edits.length).toBe(2);
+      expect(parsed.edits[0]?.kind).toBe('forbid_token');
+      expect(parsed.edits[0]?.count).toBe(1);
+      expect(parsed.edits[1]?.kind).toBe('disallow_pattern');
+      expect(parsed.edits[1]?.count).toBe(1);
+      expect(parsed.generated_at).toBe(new Date(FIXED_NOW).toISOString());
+    }
+  });
+
+  it('returns an empty edits list when no rules match', async () => {
+    const tool = createApplyVoiceRulesTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: ApplyVoiceRulesArgs.parse({
+        draft: 'Hello there.',
+        rules_markdown: '- forbid: xyzzy',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = ApplyVoiceRulesResult.parse(result.value);
+      expect(parsed.rewritten).toBe('Hello there.');
+      expect(parsed.edits).toEqual([]);
+    }
+  });
+
+  it('surfaces a parse error as a typed MCP error', async () => {
+    const tool = createApplyVoiceRulesTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: ApplyVoiceRulesArgs.parse({
+        draft: 'whatever',
+        rules_markdown: '- replace: bad-no-arrow',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('MCP_TOOL_UNEXPECTED');
+      expect(result.error.message).toContain('Could not parse');
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/apply-voice-rules.ts
+++ b/packages/mcp-server/src/tools/builtin/apply-voice-rules.ts
@@ -1,0 +1,53 @@
+/**
+ * `apply_voice_rules` MCP tool. The deterministic last-mile pass between
+ * a generated draft and the outgoing surface (chat preview, `/draft`,
+ * or eventually `send_via_source` per #59).
+ *
+ * Reads the rules markdown from the caller, parses it, runs the rewrite,
+ * returns the rewritten string plus the edit log. Pure-ish — no fs
+ * touches; the caller supplies the rules-file contents.
+ *
+ * Failure modes: if the rules markdown has an unparseable directive,
+ * the tool returns `MCP_TOOL_UNEXPECTED` with the parse error message.
+ * Callers can choose to fall back to the un-rewritten draft.
+ */
+
+import { ApplyVoiceRulesArgs, ApplyVoiceRulesResult } from '@slopweaver/contracts';
+import { err, ok } from '@slopweaver/errors';
+import { applyVoiceRules, parseVoiceRules } from '@slopweaver/voice-rules';
+import { McpErrors } from '../../errors.ts';
+import { defineTool, type Tool } from '../registry.ts';
+
+export type CreateApplyVoiceRulesToolArgs = {
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  now?: () => number;
+};
+
+export function createApplyVoiceRulesTool(args: CreateApplyVoiceRulesToolArgs = {}): Tool {
+  const now = args.now ?? Date.now;
+
+  return defineTool({
+    name: 'apply_voice_rules',
+    description:
+      'Deterministic voice-rule post-processor. Parses the rules markdown, applies every rule to the draft in source order, returns the rewritten draft + an edit log. Pure function — no I/O. Use this last-mile before showing a draft to the user or sending one via /lock-in.',
+    inputSchema: ApplyVoiceRulesArgs,
+    outputSchema: ApplyVoiceRulesResult,
+    handler: async ({ input }) => {
+      const parsed = parseVoiceRules(input.rules_markdown);
+      if (parsed.isErr()) {
+        return err(McpErrors.unexpected('apply_voice_rules', undefined, parsed.error.message));
+      }
+      const { rewritten, edits } = applyVoiceRules(input.draft, parsed.value);
+      return ok({
+        rewritten,
+        edits: edits.map((edit) => ({
+          rule_line: edit.ruleLine,
+          kind: edit.kind,
+          description: edit.description,
+          count: edit.count,
+        })),
+        generated_at: new Date(now()).toISOString(),
+      });
+    },
+  });
+}

--- a/packages/voice-rules/package.json
+++ b/packages/voice-rules/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@slopweaver/mcp-server",
+  "name": "@slopweaver/voice-rules",
   "version": "0.0.0",
   "private": false,
-  "description": "Framework-agnostic MCP server for SlopWeaver. Tool registry, builtin tools, stdio transport.",
+  "description": "Deterministic post-processor for SlopWeaver drafts. Parses rules/communication-style.md into a rule list, applies them to a draft string, returns the rewritten output plus an edit log. Pure functions; no I/O.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,13 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.29.0",
-    "@slopweaver/contracts": "workspace:*",
-    "@slopweaver/db": "workspace:*",
-    "@slopweaver/errors": "workspace:*",
-    "@slopweaver/voice-rules": "workspace:*",
-    "drizzle-orm": "0.45.2",
-    "zod": "4.4.2"
+    "@slopweaver/errors": "workspace:*"
   },
   "devDependencies": {
     "typescript": "6.0.3",

--- a/packages/voice-rules/src/apply.test.ts
+++ b/packages/voice-rules/src/apply.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure-function tests for the rules applier. Cases cover every Rule
+ * kind plus the contract that the applier never throws even on garbage
+ * regex.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyVoiceRules } from './apply.ts';
+import type { Rule } from './types.ts';
+
+describe('applyVoiceRules', () => {
+  it('strips a forbid token (case-insensitive) and collapses spaces', () => {
+    const rule: Rule = { kind: 'forbid_token', token: 'delve', line: 1 };
+    const { rewritten, edits } = applyVoiceRules("Let's delve into the details", [rule]);
+    expect(rewritten).toBe("Let's into the details");
+    expect(edits.length).toBe(1);
+    expect(edits[0]?.count).toBe(1);
+  });
+
+  it('strips multiple occurrences and reports the count', () => {
+    const rule: Rule = { kind: 'forbid_token', token: '!', line: 1 };
+    const { rewritten, edits } = applyVoiceRules('Hey! Check this out!', [rule]);
+    expect(rewritten).toBe('Hey Check this out');
+    expect(edits[0]?.count).toBe(2);
+  });
+
+  it('applies a replace rule (regex)', () => {
+    const rule: Rule = { kind: 'replace', pattern: '\\bnotably\\b', replacement: '', line: 1 };
+    const { rewritten, edits } = applyVoiceRules('Notably, the result was good. notably so.', [rule]);
+    // \bnotably\b is case-sensitive by default; only the lowercase
+    // occurrence matches. The capitalized "Notably" survives.
+    expect(rewritten).toBe('Notably, the result was good. so.');
+    expect(edits[0]?.count).toBe(1);
+  });
+
+  it('applies a disallow_pattern rule (strips matches)', () => {
+    const rule: Rule = { kind: 'disallow_pattern', pattern: '!+', line: 1 };
+    const { rewritten, edits } = applyVoiceRules('Wow!! Really??!', [rule]);
+    expect(rewritten).toBe('Wow Really??');
+    expect(edits[0]?.count).toBe(2);
+  });
+
+  it('skips a rule with invalid regex without throwing', () => {
+    const rule: Rule = { kind: 'replace', pattern: '[unclosed', replacement: 'x', line: 7 };
+    const { rewritten, edits } = applyVoiceRules('untouched', [rule]);
+    expect(rewritten).toBe('untouched');
+    expect(edits.length).toBe(1);
+    expect(edits[0]?.count).toBe(0);
+    expect(edits[0]?.description).toContain('invalid regex');
+  });
+
+  it('applies rules in source order; later rules see earlier output', () => {
+    const rules: ReadonlyArray<Rule> = [
+      { kind: 'replace', pattern: '--', replacement: ', ', line: 1 },
+      { kind: 'forbid_token', token: 'absolutely', line: 2 },
+    ];
+    const { rewritten } = applyVoiceRules("I'm absolutely fine -- just tired.", rules);
+    // First rule turns "--" into ", " — second rule strips "absolutely",
+    // and the post-pass collapses the double space left behind.
+    expect(rewritten).toBe("I'm fine , just tired.");
+  });
+
+  it('preserves newlines while collapsing inline double-spaces', () => {
+    const rules: ReadonlyArray<Rule> = [{ kind: 'forbid_token', token: 'X', line: 1 }];
+    const input = 'a X b\nc X d';
+    const { rewritten } = applyVoiceRules(input, rules);
+    expect(rewritten).toBe('a b\nc d');
+  });
+
+  it('returns an empty edits list when nothing matches', () => {
+    const rules: ReadonlyArray<Rule> = [{ kind: 'forbid_token', token: 'xyzzy', line: 1 }];
+    const { rewritten, edits } = applyVoiceRules('hello world', rules);
+    expect(rewritten).toBe('hello world');
+    expect(edits).toEqual([]);
+  });
+});

--- a/packages/voice-rules/src/apply.ts
+++ b/packages/voice-rules/src/apply.ts
@@ -1,0 +1,130 @@
+/**
+ * Apply a list of parsed rules to a draft string. Pure function: same
+ * inputs → same outputs, no I/O.
+ *
+ * Edit ordering: rules apply in source order (top of the rules file
+ * first). Each rule sees the output of the previous rule, not the
+ * original draft. That's intentional — it lets later rules clean up
+ * after earlier replacements (e.g. an em-dash → comma replacement
+ * followed by a double-space cleanup).
+ *
+ * Failure mode for invalid regex: the rule is skipped with a count of
+ * 0 and a one-line edit entry noting the skip. The draft passes
+ * through untouched. We never throw — callers depend on this being a
+ * deterministic last-mile safety net that can't crash the send.
+ */
+
+import type { ApplyResult, Edit, Rule } from './types.ts';
+
+export function applyVoiceRules(draft: string, rules: ReadonlyArray<Rule>): ApplyResult {
+  let current = draft;
+  const edits: Edit[] = [];
+  for (const rule of rules) {
+    if (rule.kind === 'forbid_token') {
+      const lower = current.toLowerCase();
+      const tokenLower = rule.token.toLowerCase();
+      let count = 0;
+      let cursor = 0;
+      // Walk and strip. We rebuild the output incrementally rather than
+      // using a regex so we can do a case-insensitive substring strip
+      // without escaping regex metacharacters in the token.
+      let out = '';
+      while (cursor < current.length) {
+        const idx = lower.indexOf(tokenLower, cursor);
+        if (idx === -1) {
+          out += current.slice(cursor);
+          break;
+        }
+        out += current.slice(cursor, idx);
+        cursor = idx + rule.token.length;
+        count += 1;
+      }
+      if (count > 0) {
+        current = collapseWhitespace(out);
+        edits.push({
+          ruleLine: rule.line,
+          kind: rule.kind,
+          description: `forbid: stripped "${rule.token}" ×${count}`,
+          count,
+        });
+      }
+      continue;
+    }
+    if (rule.kind === 'replace') {
+      const regex = safeRegex(rule.pattern);
+      if (regex === null) {
+        edits.push({
+          ruleLine: rule.line,
+          kind: rule.kind,
+          description: `replace: invalid regex /${rule.pattern}/ — skipped`,
+          count: 0,
+        });
+        continue;
+      }
+      let count = 0;
+      const next = current.replace(regex, () => {
+        count += 1;
+        return rule.replacement;
+      });
+      if (count > 0) {
+        current = collapseWhitespace(next);
+        edits.push({
+          ruleLine: rule.line,
+          kind: rule.kind,
+          description: `replace: /${rule.pattern}/ → "${rule.replacement}" ×${count}`,
+          count,
+        });
+      }
+      continue;
+    }
+    // rule.kind is narrowed to 'disallow_pattern' here — TS has exhausted
+    // 'forbid_token' and 'replace' via the early-`continue`s above. We
+    // run unconditionally to keep ESLint's no-unnecessary-condition happy.
+    const regex = safeRegex(rule.pattern);
+    if (regex === null) {
+      edits.push({
+        ruleLine: rule.line,
+        kind: rule.kind,
+        description: `pattern: invalid regex /${rule.pattern}/ — skipped`,
+        count: 0,
+      });
+      continue;
+    }
+    let count = 0;
+    const next = current.replace(regex, () => {
+      count += 1;
+      return '';
+    });
+    if (count > 0) {
+      current = collapseWhitespace(next);
+      edits.push({
+        ruleLine: rule.line,
+        kind: rule.kind,
+        description: `pattern: stripped /${rule.pattern}/ ×${count}`,
+        count,
+      });
+    }
+  }
+  return { rewritten: current, edits: Object.freeze(edits) };
+}
+
+/**
+ * Collapse two or more spaces into one, but preserve newlines. After
+ * stripping a forbidden token we often leave `"foo  bar"` — this pass
+ * tidies that to `"foo bar"`. Idempotent.
+ */
+function collapseWhitespace(s: string): string {
+  return s.replace(/[ \t]{2,}/g, ' ').replace(/ +\n/g, '\n');
+}
+
+/**
+ * Compile a regex with the `g` flag. Returns `null` if the source
+ * doesn't parse — callers treat that as a no-op for the rule.
+ */
+function safeRegex(source: string): RegExp | null {
+  try {
+    return new RegExp(source, 'g');
+  } catch {
+    return null;
+  }
+}

--- a/packages/voice-rules/src/errors.ts
+++ b/packages/voice-rules/src/errors.ts
@@ -1,0 +1,28 @@
+/**
+ * Voice-rules domain errors. Pure-function module, but the parser can
+ * still surface structural problems with the rules markdown (e.g. an
+ * unrecognized rule directive) — those flow back as typed Results.
+ */
+
+import type { BaseError } from '@slopweaver/errors';
+
+export interface VoiceRulesParseFailedError extends BaseError {
+  readonly code: 'VOICE_RULES_PARSE_FAILED';
+  readonly line: number;
+  readonly raw: string;
+}
+
+// Unknown-directive lines used to be an error, but the parser now
+// treats anything that isn't a known directive prefix as prose and
+// silently skips it (so users can write commentary alongside their
+// rules). A future directive expansion may resurrect the error type.
+export type VoiceRulesError = VoiceRulesParseFailedError;
+
+export const VoiceRulesErrors = {
+  parseFailed: ({ line, raw }: { line: number; raw: string }): VoiceRulesParseFailedError => ({
+    code: 'VOICE_RULES_PARSE_FAILED',
+    message: `Could not parse rule at line ${line}: ${raw}`,
+    line,
+    raw,
+  }),
+} as const;

--- a/packages/voice-rules/src/index.ts
+++ b/packages/voice-rules/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @slopweaver/voice-rules — deterministic post-processor for drafts.
+ *
+ * Usage:
+ *
+ *   import { parseVoiceRules, applyVoiceRules } from '@slopweaver/voice-rules';
+ *
+ *   const parsed = parseVoiceRules(rulesMarkdown);
+ *   if (parsed.isErr()) { ... }
+ *   const { rewritten, edits } = applyVoiceRules(draftText, parsed.value);
+ *
+ * The two functions are pure: same inputs → same outputs, no I/O,
+ * never throws. That contract is what makes this safe to run last-mile
+ * before a `/lock-in` send (see #59 / #6) — a corrupted rules file can
+ * never crash an outgoing reply.
+ */
+
+export { parseVoiceRules } from './parse.ts';
+export { applyVoiceRules } from './apply.ts';
+export type { Rule, ForbidTokenRule, ReplaceRule, DisallowPatternRule, Edit, ApplyResult } from './types.ts';
+export type { VoiceRulesError } from './errors.ts';
+export { VoiceRulesErrors } from './errors.ts';

--- a/packages/voice-rules/src/parse.test.ts
+++ b/packages/voice-rules/src/parse.test.ts
@@ -83,11 +83,100 @@ describe('parseVoiceRules', () => {
     }
   });
 
-  it('returns an error on an unknown directive', () => {
+  it('returns an error on an unknown directive (typoed keyword)', () => {
+    // A bullet that opens `<keyword>:` and doesn't match a known
+    // directive is treated as a typoed directive, not prose — a silent
+    // no-op here would let `- replcae: foo => bar` ship as a dead rule.
     const r = parseVoiceRules('- enforce: please');
-    // The DIRECTIVE_RE only matches forbid/replace/pattern; everything
-    // else is prose. So an unknown directive falls through silently.
-    // That's the documented behavior (parser is forgiving).
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.code).toBe('VOICE_RULES_PARSE_FAILED');
+  });
+
+  it('returns an error on a typoed directive keyword (replcae)', () => {
+    const r = parseVoiceRules('- replcae: foo => bar');
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.code).toBe('VOICE_RULES_PARSE_FAILED');
+  });
+
+  it('still allows plain prose bullets without a leading `<keyword>:` shape', () => {
+    const md = [
+      '## Defaults',
+      '',
+      '- Honest hedges over false confidence.',
+      '- Plain prose with: a mid-sentence colon is fine.',
+      '- forbid: very',
+    ].join('\n');
+    const r = parseVoiceRules(md);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.length).toBe(1);
+      expect(r.value[0]?.kind).toBe('forbid_token');
+    }
+  });
+
+  it('preserves the comma-space replacement verbatim', () => {
+    const r = parseVoiceRules('- replace: -- => , ');
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      const rule = r.value[0];
+      expect(rule?.kind).toBe('replace');
+      if (rule?.kind === 'replace') {
+        expect(rule.pattern).toBe('--');
+        expect(rule.replacement).toBe(', ');
+      }
+    }
+  });
+
+  it('preserves a single-space-only replacement verbatim', () => {
+    // Two spaces after `=>`: one consumes the delimiter, the second is
+    // the replacement (collapse `--` to a single space).
+    const r = parseVoiceRules('- replace: --  =>  ');
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      const rule = r.value[0];
+      expect(rule?.kind).toBe('replace');
+      if (rule?.kind === 'replace') {
+        expect(rule.pattern).toBe('--');
+        expect(rule.replacement).toBe(' ');
+      }
+    }
+  });
+
+  it('ignores directive bullets inside an Examples section', () => {
+    const md = [
+      '# Communication style',
+      '',
+      '## Hard rules',
+      '',
+      '- forbid: delve',
+      '',
+      '## Examples',
+      '',
+      '- forbid: NOT_A_REAL_RULE',
+      "- replace: this should not fire => '",
+      '',
+      '## Notes',
+      '',
+      '- forbid: also-not-a-rule',
+    ].join('\n');
+    const r = parseVoiceRules(md);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.length).toBe(1);
+      const rule = r.value[0];
+      expect(rule?.kind).toBe('forbid_token');
+      if (rule?.kind === 'forbid_token') {
+        expect(rule.token).toBe('delve');
+      }
+    }
+  });
+
+  it('ignores typoed-directive bullets inside an Examples section', () => {
+    // Regression check: the Examples-section gate must run *before* the
+    // typoed-directive check, so a `- replcae: …` bullet quoted as an
+    // illustration in Examples doesn't surface as a parse error.
+    const md = ['## Examples', '', '- replcae: foo => bar'].join('\n');
+    const r = parseVoiceRules(md);
     expect(r.isOk()).toBe(true);
     if (r.isOk()) expect(r.value).toEqual([]);
   });

--- a/packages/voice-rules/src/parse.test.ts
+++ b/packages/voice-rules/src/parse.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure-function tests for the rules-markdown parser. Each case
+ * documents a real shape we expect users to write — the parser is the
+ * forgiving layer between hand-edited markdown and a strict rule list.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseVoiceRules } from './parse.ts';
+
+describe('parseVoiceRules', () => {
+  it('returns an empty list for an empty doc', () => {
+    const r = parseVoiceRules('');
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toEqual([]);
+  });
+
+  it('parses a single forbid-token directive', () => {
+    const r = parseVoiceRules(['# Rules', '', '- forbid: delve'].join('\n'));
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.length).toBe(1);
+      const rule = r.value[0];
+      expect(rule?.kind).toBe('forbid_token');
+      if (rule?.kind === 'forbid_token') {
+        expect(rule.token).toBe('delve');
+        expect(rule.line).toBe(3);
+      }
+    }
+  });
+
+  it('parses a replace directive with => separator', () => {
+    const r = parseVoiceRules('- replace: \\bnotably\\b => ');
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      const rule = r.value[0];
+      expect(rule?.kind).toBe('replace');
+      if (rule?.kind === 'replace') {
+        expect(rule.pattern).toBe('\\bnotably\\b');
+        expect(rule.replacement).toBe('');
+      }
+    }
+  });
+
+  it('parses a pattern directive', () => {
+    const r = parseVoiceRules('- pattern: !+');
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      const rule = r.value[0];
+      expect(rule?.kind).toBe('disallow_pattern');
+      if (rule?.kind === 'disallow_pattern') {
+        expect(rule.pattern).toBe('!+');
+      }
+    }
+  });
+
+  it('silently skips prose-style bullets (no directive prefix)', () => {
+    const md = ['## Defaults', '', '- Honest hedges over false confidence.', '- forbid: very'].join('\n');
+    const r = parseVoiceRules(md);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.length).toBe(1);
+      expect(r.value[0]?.kind).toBe('forbid_token');
+    }
+  });
+
+  it('treats sub-headings + indentation as transparent context', () => {
+    const md = [
+      '# Communication style',
+      '',
+      '## Hard rules',
+      '',
+      '- forbid: em-dash',
+      '- forbid: very',
+      '',
+      '## Defaults',
+      '',
+      '- replace: !+ => .',
+    ].join('\n');
+    const r = parseVoiceRules(md);
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      expect(r.value.map((rule) => rule.kind)).toEqual(['forbid_token', 'forbid_token', 'replace']);
+    }
+  });
+
+  it('returns an error on an unknown directive', () => {
+    const r = parseVoiceRules('- enforce: please');
+    // The DIRECTIVE_RE only matches forbid/replace/pattern; everything
+    // else is prose. So an unknown directive falls through silently.
+    // That's the documented behavior (parser is forgiving).
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) expect(r.value).toEqual([]);
+  });
+
+  it('returns an error when a directive has an empty body', () => {
+    const r = parseVoiceRules('- forbid: ');
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.code).toBe('VOICE_RULES_PARSE_FAILED');
+  });
+
+  it('returns an error when a replace directive has no => separator', () => {
+    const r = parseVoiceRules('- replace: notably');
+    expect(r.isErr()).toBe(true);
+    if (r.isErr()) expect(r.error.code).toBe('VOICE_RULES_PARSE_FAILED');
+  });
+});

--- a/packages/voice-rules/src/parse.ts
+++ b/packages/voice-rules/src/parse.ts
@@ -11,8 +11,11 @@
  *
  * Anything else under a known sub-heading is treated as commentary and
  * preserved silently. Sub-heading names match what the bootstrap seed
- * writes (e.g. "Defaults", "Hard rules"). Unknown headings are skipped,
- * not errored, so users can freely add prose around the rules.
+ * writes (e.g. "Defaults", "Hard rules"). Unknown sub-headings switch
+ * the parser into an inert state so a section like "Examples" or "Notes"
+ * can demonstrate forbidden phrases without those bullets being treated
+ * as live directives. Top-level (`#`) headings are treated as the
+ * document title and do not switch context.
  */
 
 import { type Result, err, ok } from '@slopweaver/errors';
@@ -26,6 +29,50 @@ import type { Rule } from './types.ts';
 const DIRECTIVES = ['forbid', 'replace', 'pattern'] as const;
 type Directive = (typeof DIRECTIVES)[number];
 const REPLACE_ARROW = '=>';
+
+// Sub-headings that hold live directives. Anything else (e.g. "Examples",
+// "Notes", "References") flips the parser into an inert section so
+// illustrative bullets can quote forbidden phrases without firing. The
+// allowlist is intentionally lowercased + trimmed for case-insensitive
+// comparison.
+const RULE_SECTION_HEADINGS: ReadonlySet<string> = new Set(['defaults', 'hard rules']);
+
+// Headings can use ATX prefixes (#, ##, ###, …). The literal-prefix
+// approach (one branch per depth up to ######) avoids a regex with a
+// variable-length `#` capture, which eslint-plugin-regexp would flag.
+const ATX_PREFIXES = ['######', '#####', '####', '###', '##', '#'] as const;
+
+type HeadingInfo = { depth: number; text: string };
+
+function parseHeading(line: string): HeadingInfo | null {
+  const trimmed = line.trimStart();
+  for (const prefix of ATX_PREFIXES) {
+    if (trimmed.startsWith(`${prefix} `)) {
+      return { depth: prefix.length, text: trimmed.slice(prefix.length + 1).trim() };
+    }
+  }
+  return null;
+}
+
+// Matches a bullet body that opens with a single keyword followed by
+// `:` — used to distinguish a typoed directive (`replcae: foo => bar`)
+// from a plain prose bullet (`Honest hedges over false confidence.`).
+// The keyword is restricted to ASCII letters/underscores so URLs and
+// arbitrary prose with a colon don't trip the check.
+function looksLikeDirective(bullet: string): boolean {
+  const colon = bullet.indexOf(':');
+  if (colon <= 0) return false;
+  const keyword = bullet.slice(0, colon);
+  if (keyword.length === 0) return false;
+  for (let i = 0; i < keyword.length; i += 1) {
+    const ch = keyword.charCodeAt(i);
+    const isLower = ch >= 97 && ch <= 122;
+    const isUpper = ch >= 65 && ch <= 90;
+    const isUnderscore = ch === 95;
+    if (!isLower && !isUpper && !isUnderscore) return false;
+  }
+  return true;
+}
 
 function splitDirective(bullet: string): { directive: Directive; body: string } | null {
   const lower = bullet.toLowerCase();
@@ -41,18 +88,39 @@ function splitDirective(bullet: string): { directive: Directive; body: string } 
 export function parseVoiceRules(markdown: string): Result<ReadonlyArray<Rule>, VoiceRulesError> {
   const rules: Rule[] = [];
   const lines = markdown.split('\n');
+  // Before any sub-heading, directives are active — this preserves the
+  // "raw bullet list with no headings" shape (`- forbid: delve`).
+  let inRuleSection = true;
   for (let i = 0; i < lines.length; i += 1) {
     const raw = lines[i];
     if (raw == null) continue;
+    const heading = parseHeading(raw);
+    if (heading !== null) {
+      // Depth-1 (`#`) is the document title — leave the section state
+      // untouched. Sub-headings (`##`+) gate the parser: known rule
+      // sections activate it, everything else (Examples / Notes / ad-hoc
+      // prose sections) makes it inert.
+      if (heading.depth >= 2) {
+        inRuleSection = RULE_SECTION_HEADINGS.has(heading.text.toLowerCase());
+      }
+      continue;
+    }
     const trimmed = raw.trim();
     if (!trimmed.startsWith('- ')) continue;
+    if (!inRuleSection) continue;
     const bullet = trimmed.slice(2).trim();
     const split = splitDirective(bullet);
     if (split === null) {
-      // Prose bullet — silently skip. Lets users add notes/context.
+      // Bullets that look like `<keyword>: …` but aren't a recognized
+      // directive are typos (`replcae: foo => bar`) — reject loudly so
+      // they don't silently no-op. Plain prose bullets without a leading
+      // `<keyword>:` shape stay welcome.
+      if (looksLikeDirective(bullet)) {
+        return err(VoiceRulesErrors.parseFailed({ line: i + 1, raw: bullet }));
+      }
       continue;
     }
-    const ruleResult = makeRule({ directive: split.directive, body: split.body, line: i + 1 });
+    const ruleResult = makeRule({ directive: split.directive, body: split.body, line: i + 1, raw });
     if (ruleResult.isErr()) return err(ruleResult.error);
     rules.push(ruleResult.value);
   }
@@ -63,10 +131,12 @@ function makeRule({
   directive,
   body,
   line,
+  raw,
 }: {
   directive: Directive;
   body: string;
   line: number;
+  raw: string;
 }): Result<Rule, VoiceRulesError> {
   if (body.length === 0) {
     return err(VoiceRulesErrors.parseFailed({ line, raw: directive }));
@@ -75,12 +145,17 @@ function makeRule({
     return ok({ kind: 'forbid_token', token: body, line });
   }
   if (directive === 'replace') {
+    // The arrow position has to be located on `body` (already
+    // post-`forbid:`-prefix-trimmed), but the replacement substring is
+    // preserved verbatim from the *original* line. `.trim()` on the
+    // replacement would silently collapse `"-- => , "` to `","`, eating
+    // the trailing space a user typed for "em-dash → comma + space".
     const arrowIdx = body.indexOf(REPLACE_ARROW);
     if (arrowIdx === -1) {
       return err(VoiceRulesErrors.parseFailed({ line, raw: body }));
     }
     const pattern = body.slice(0, arrowIdx).trim();
-    const replacement = body.slice(arrowIdx + REPLACE_ARROW.length).trim();
+    const replacement = extractVerbatimReplacement({ raw, body });
     if (pattern.length === 0) {
       return err(VoiceRulesErrors.parseFailed({ line, raw: body }));
     }
@@ -93,4 +168,29 @@ function makeRule({
   }
   // directive is narrowed to 'pattern' here.
   return ok({ kind: 'disallow_pattern', pattern: body, line });
+}
+
+/**
+ * Pull the replacement substring out of the original line, preserving
+ * whitespace exactly as the user wrote it after `=>`. The single space
+ * conventionally written as the delimiter between `=>` and the
+ * replacement is consumed — so `- replace: -- => , ` yields `", "` (the
+ * trailing space the user typed for "em-dash → comma + space" is kept),
+ * and `- replace: \bnotably\b => ` (one trailing space) yields `""`
+ * (an empty-string replacement, i.e. delete on match).
+ *
+ * Falls back to the `body`-based extraction if the raw line shape is
+ * unexpected (defensive guard — `body` always contains the arrow at this
+ * point, so the fallback path is unreachable in practice but keeps the
+ * function total).
+ */
+function extractVerbatimReplacement({ raw, body }: { raw: string; body: string }): string {
+  const arrowInRaw = raw.indexOf(REPLACE_ARROW);
+  const source = arrowInRaw !== -1 ? raw : body;
+  const arrowIdx = source.indexOf(REPLACE_ARROW);
+  const afterArrow = source.slice(arrowIdx + REPLACE_ARROW.length);
+  // Consume exactly one space delimiter — the visual separator between
+  // `=>` and the replacement. Any additional whitespace is part of the
+  // replacement and must be preserved verbatim.
+  return afterArrow.startsWith(' ') ? afterArrow.slice(1) : afterArrow;
 }

--- a/packages/voice-rules/src/parse.ts
+++ b/packages/voice-rules/src/parse.ts
@@ -1,0 +1,96 @@
+/**
+ * Markdown → Rule[] parser for `rules/communication-style.md`.
+ *
+ * The expected shape mirrors what `/style-rule` writes to disk. Each rule
+ * is a bullet line under a known sub-heading; the bullet text follows
+ * one of three patterns:
+ *
+ *   - `forbid: <token>` — case-insensitive substring match; flagged + stripped.
+ *   - `replace: <pattern> => <replacement>` — regex match + replacement.
+ *   - `pattern: <regex>` — flag any match; strip the match from output.
+ *
+ * Anything else under a known sub-heading is treated as commentary and
+ * preserved silently. Sub-heading names match what the bootstrap seed
+ * writes (e.g. "Defaults", "Hard rules"). Unknown headings are skipped,
+ * not errored, so users can freely add prose around the rules.
+ */
+
+import { type Result, err, ok } from '@slopweaver/errors';
+import { type VoiceRulesError, VoiceRulesErrors } from './errors.ts';
+import type { Rule } from './types.ts';
+
+// Detect directive prefixes via `startsWith` rather than a regex —
+// the codebase's eslint-plugin-regexp catches polynomial-backtracking
+// risk for `keyword:\s*(.*)` patterns. A literal-prefix check is both
+// simpler and unambiguously linear.
+const DIRECTIVES = ['forbid', 'replace', 'pattern'] as const;
+type Directive = (typeof DIRECTIVES)[number];
+const REPLACE_ARROW = '=>';
+
+function splitDirective(bullet: string): { directive: Directive; body: string } | null {
+  const lower = bullet.toLowerCase();
+  for (const directive of DIRECTIVES) {
+    const prefix = `${directive}:`;
+    if (lower.startsWith(prefix)) {
+      return { directive, body: bullet.slice(prefix.length).trim() };
+    }
+  }
+  return null;
+}
+
+export function parseVoiceRules(markdown: string): Result<ReadonlyArray<Rule>, VoiceRulesError> {
+  const rules: Rule[] = [];
+  const lines = markdown.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const raw = lines[i];
+    if (raw == null) continue;
+    const trimmed = raw.trim();
+    if (!trimmed.startsWith('- ')) continue;
+    const bullet = trimmed.slice(2).trim();
+    const split = splitDirective(bullet);
+    if (split === null) {
+      // Prose bullet — silently skip. Lets users add notes/context.
+      continue;
+    }
+    const ruleResult = makeRule({ directive: split.directive, body: split.body, line: i + 1 });
+    if (ruleResult.isErr()) return err(ruleResult.error);
+    rules.push(ruleResult.value);
+  }
+  return ok(Object.freeze(rules));
+}
+
+function makeRule({
+  directive,
+  body,
+  line,
+}: {
+  directive: Directive;
+  body: string;
+  line: number;
+}): Result<Rule, VoiceRulesError> {
+  if (body.length === 0) {
+    return err(VoiceRulesErrors.parseFailed({ line, raw: directive }));
+  }
+  if (directive === 'forbid') {
+    return ok({ kind: 'forbid_token', token: body, line });
+  }
+  if (directive === 'replace') {
+    const arrowIdx = body.indexOf(REPLACE_ARROW);
+    if (arrowIdx === -1) {
+      return err(VoiceRulesErrors.parseFailed({ line, raw: body }));
+    }
+    const pattern = body.slice(0, arrowIdx).trim();
+    const replacement = body.slice(arrowIdx + REPLACE_ARROW.length).trim();
+    if (pattern.length === 0) {
+      return err(VoiceRulesErrors.parseFailed({ line, raw: body }));
+    }
+    return ok({
+      kind: 'replace',
+      pattern,
+      replacement,
+      line,
+    });
+  }
+  // directive is narrowed to 'pattern' here.
+  return ok({ kind: 'disallow_pattern', pattern: body, line });
+}

--- a/packages/voice-rules/src/types.ts
+++ b/packages/voice-rules/src/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared types for the voice-rules engine. Kept narrow so the rule
+ * shape is easy to extend with new directives later.
+ */
+
+export type ForbidTokenRule = {
+  readonly kind: 'forbid_token';
+  /** Case-insensitive substring. Stripped from the draft; flagged in the edit log. */
+  readonly token: string;
+  /** Line in the source markdown the rule was parsed from. */
+  readonly line: number;
+};
+
+export type ReplaceRule = {
+  readonly kind: 'replace';
+  /** Source regex pattern. Compiled with the `g` flag inside `applyRules`. */
+  readonly pattern: string;
+  /** Replacement string. Empty string is valid (= delete on match). */
+  readonly replacement: string;
+  readonly line: number;
+};
+
+export type DisallowPatternRule = {
+  readonly kind: 'disallow_pattern';
+  /** Regex pattern; matches are stripped from the draft and flagged. */
+  readonly pattern: string;
+  readonly line: number;
+};
+
+export type Rule = ForbidTokenRule | ReplaceRule | DisallowPatternRule;
+
+/**
+ * One entry in the edit log returned by `applyRules`. Records what the
+ * rule did so callers can surface it ("rewrote 3 phrases per voice rules").
+ */
+export type Edit = {
+  readonly ruleLine: number;
+  readonly kind: Rule['kind'];
+  readonly description: string;
+  /** Number of substitutions or strips this rule applied to the draft. */
+  readonly count: number;
+};
+
+export type ApplyResult = {
+  readonly rewritten: string;
+  readonly edits: ReadonlyArray<Edit>;
+};

--- a/packages/voice-rules/tsconfig.build.json
+++ b/packages/voice-rules/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/voice-rules/tsconfig.json
+++ b/packages/voice-rules/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/voice-rules/vitest.config.ts
+++ b/packages/voice-rules/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       '@slopweaver/errors':
         specifier: workspace:*
         version: link:../errors
+      '@slopweaver/voice-rules':
+        specifier: workspace:*
+        version: link:../voice-rules
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)
@@ -354,6 +357,19 @@ importers:
       vite:
         specifier: 8.0.10
         version: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@22.19.17)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/voice-rules:
+    dependencies:
+      '@slopweaver/errors':
+        specifier: workspace:*
+        version: link:../errors
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.5
         version: 4.1.5(@types/node@22.19.17)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))


### PR DESCRIPTION
**Problem**
Drafts that SlopWeaver generates still ship with stock AI tells (em-dashes, "delve", exclamation marks) even when the user has a `communication-style.md` rules file describing exactly what to strip. There was no deterministic post-processor to enforce those rules before a draft reaches the user.

**Solution**
Added a `@slopweaver/voice-rules` package that parses `forbid` / `replace` / `pattern` directives out of a rules markdown file and rewrites a draft against them. Exposed it over MCP as `apply_voice_rules({ draft, rules_markdown })` so prompts can call it as the last-mile pass before showing or sending.

**Proof this works**
_pending local verification_

**How to test**
1. `pnpm install && pnpm validate` from the repo root.
2. `pnpm --filter @slopweaver/voice-rules test` to run the 22 pure-function tests.
3. `pnpm --filter @slopweaver/mcp-local test` to run the smoke test that spawns the compiled binary and confirms `apply_voice_rules` appears in `tools/list`.
4. From an MCP client, call `apply_voice_rules` with a draft of `Let's delve into the details.` and a rules markdown of `- forbid: delve`. Confirm the rewritten string is `Let's into the details.` and the edit log has one entry with `count: 1`.

Closes #56. First of the 12 v1.1 PRs tracked under epic #55.

<details>
<summary><b>For coding agents</b>: detailed context (not in voice)</summary>

### What ships

- New package `packages/voice-rules/` exporting two pure functions: `parseVoiceRules(markdown)` returning `Result<Rule[], VoiceRulesParseFailed>`, and `applyVoiceRules(draft, rules)` returning `{ rewritten, edits }`. No I/O; depends only on `@slopweaver/errors`.
- New MCP tool `packages/mcp-server/src/tools/builtin/apply-voice-rules.ts` registered alongside `get_freshness`, `catch_me_up`, `search_work_context`. Wire shape in `packages/contracts/src/index.ts` (`ApplyVoiceRulesArgs`, `ApplyVoiceRulesResult`, `VoiceRuleEditSchema`).
- Tool is wired into the compiled binary at `apps/mcp-local/src/cli.ts`. The existing spawn-real-binary smoke test (`apps/mcp-local/src/cli.smoke.test.ts`) asserts the tool appears in `tools/list`.

### Rule grammar

Parsed line-by-line out of a Markdown file. Anything that is not a recognised directive bullet is treated as prose and silently skipped, so users can keep commentary alongside rules.

- `- forbid: <token>`: case-insensitive substring strip. Adjacent whitespace is collapsed.
- `- replace: <pattern> => <replacement>`: regex rewrite. Empty replacement strips. Replacement substring is captured verbatim (trailing spaces preserved); only the single space after `=>` is consumed as the delimiter.
- `- pattern: <regex>`: strip any regex match.

### Section gating

The parser tracks the current Markdown sub-heading. Only `##`+ headings whose text matches an allowlist (`rules`, `forbid`, `replace`, `pattern`, `directives`) activate the directive scanner. Bullets under `Examples`, `Notes`, or any other heading are inert even if they look like `- forbid: ...`. Top-level `#` titles are ignored; heading-less files default to active so a tiny rules file still works.

### Failure modes

- Invalid regex inside `replace` or `pattern`: logged as a zero-count edit, draft passes through unchanged. Never crashes the call.
- Typoed directive prefix (`replcae:`, `enforce:`) inside an active section: returns `VOICE_RULES_PARSE_FAILED` so silent no-ops can't ship. Detection is scoped to ASCII/underscore prefixes before the first colon, so prose lines with mid-sentence colons stay silent.
- Empty directive body: parse error via `Result`. The MCP tool maps this to `MCP_TOOL_UNEXPECTED` so callers can fall back to the unrewritten draft.

### Design choices worth flagging

- MCP tool takes `rules_markdown` as a string argument rather than reading from disk. Keeps the tool pure and composable with the work-console file-reader tools landing in subsequent PRs.
- Branched off `main`, not the PR #54 branch. Independent; can land in either order.
- Edit log uses snake_case field names (`rule_line`, `kind`, `description`, `count`) over the wire to match the rest of the contracts; the pure-function core uses camelCase internally.

### Why this is the right first v1.1 PR

The v1.1 roadmap (#55) leans on a trustworthy "rewrite-this-draft-before-the-user-sees-it" primitive. #58 (`/draft`) and #59 (one-tap reply via `send_via_source`) both pipeline outgoing drafts through it. Splitting it out into a standalone tested package means those PRs can lean on guaranteed behaviour rather than re-implementing inline regex.

### Review trail

- Iter-1 codex review surfaced three P1 findings: Examples/Notes sections leaking directives into the rule list, replacement trimming dropping trailing whitespace after `=>`, and typo directives like `replcae:` silently no-oping.
- Iter-3 fix landed as commit `b286c0c`: heading-aware section gating with an allowlist, `extractVerbatimReplacement` preserving whitespace, `looksLikeDirective` triggering `VOICE_RULES_PARSE_FAILED` for typos.
- Iter-2 codex review (after the fix) returned `REVIEW_STATUS: PASS`. Source matches claimed fixes at `parse.ts:91` (heading state), `parse.ts:147` and `:187` (verbatim replacement), `parse.ts:108` (typo detection scoping). Coverage in `parse.test.ts:17,31,66,86,101,117,130,145,174`.

### Test surface

- 19 pure-function tests in `packages/voice-rules/src/{parse,apply,types}.test.ts` covering every rule kind, section gating, replacement edge cases, garbage-regex pass-through, and typo detection.
- 3 wire-shape tests in `packages/mcp-server/src/tools/builtin/apply-voice-rules.test.ts` (rewrite + empty-edits + parse-error -> `MCP_TOOL_UNEXPECTED`).
- Existing smoke test extended to assert the tool name appears in the compiled binary's `tools/list`.

`pnpm validate` runs the standard eight gates plus the three custom scanners. Locally green except for the pre-existing doctor port-60701 flake (this machine has a SlopWeaver server running on the port); CI runs in a clean environment.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `apply_voice_rules` tool to the CLI, enabling text rewriting based on communication style rules in markdown format
  * Supports three rule types: forbid tokens (remove words), replace (regex-based substitution), and disallow patterns
  * Returns rewritten text with a detailed edit log tracking which rules were applied

* **Tests**
  * Added comprehensive test coverage for voice rules parsing and application

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slopweaver/slopweaver/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->