### PR TITLE
feat(mega-audit): start_mega_audit + record_audit_progress tools

### DIFF
--- a/apps/mcp-local/src/cli.smoke.test.ts
+++ b/apps/mcp-local/src/cli.smoke.test.ts
@@ -70,6 +70,8 @@ describe('slopweaver bin (compiled CLI)', () => {
       expect(names).toContain('get_freshness');
       expect(names).toContain('catch_me_up');
       expect(names).toContain('search_work_context');
+      expect(names).toContain('start_mega_audit');
+      expect(names).toContain('record_audit_progress');
 
       const ping = list.tools.find((t) => t.name === 'ping');
       expect(ping?.inputSchema.type).toBe('object');

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -46,7 +46,9 @@ import {
   createGetFreshnessTool,
   createMcpServer,
   createPingTool,
+  createRecordAuditProgressTool,
   createSearchWorkContextTool,
+  createStartMegaAuditTool,
   createStartSessionTool,
   type StartSessionPoller,
   startStdio,
@@ -171,6 +173,8 @@ async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void
       createGetFreshnessTool(),
       createCatchMeUpTool(),
       createSearchWorkContextTool(),
+      createStartMegaAuditTool(),
+      createRecordAuditProgressTool(),
     ],
   });
 

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   Freshness,
   PingArgs,
   PingResult,
+  RecordAuditProgressArgs,
   Reference,
   StartSessionArgs,
   StartSessionResult,
@@ -141,5 +142,52 @@ describe('EvidenceLogEntry', () => {
       citation_url: null,
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe('RecordAuditProgressArgs', () => {
+  it('accepts a polling event with a source', () => {
+    const result = RecordAuditProgressArgs.safeParse({
+      audit_id: 'audit_x',
+      phase: 'polling',
+      source: 'slack',
+      message: 'polling slack mentions',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a polling event without a source', () => {
+    // The refinement makes `source` required for polling events
+    // specifically. Other phases (inventory, aggregating, etc.)
+    // still permit omitting it.
+    const result = RecordAuditProgressArgs.safeParse({
+      audit_id: 'audit_x',
+      phase: 'polling',
+      message: 'polling but forgot to name a source',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const sourceIssue = result.error.issues.find((i) => i.path[0] === 'source');
+      expect(sourceIssue?.message).toBe('source is required when phase is "polling"');
+    }
+  });
+
+  it('accepts non-polling phases without a source', () => {
+    const result = RecordAuditProgressArgs.safeParse({
+      audit_id: 'audit_x',
+      phase: 'inventory',
+      message: 'detected 3 MCP servers: slack, github, linear',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty-string source on a polling event', () => {
+    const result = RecordAuditProgressArgs.safeParse({
+      audit_id: 'audit_x',
+      phase: 'polling',
+      source: '',
+      message: 'polling with empty source',
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -210,7 +210,6 @@ export type RecordAuditProgressArgs = z.infer<typeof RecordAuditProgressArgs>;
 export const RecordAuditProgressResult = z
   .object({
     log_path: NonEmptyStringSchema,
-    line_number: z.number().int().positive(),
     bytes_appended: z.number().int().nonnegative(),
   })
   .strict();

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -189,14 +189,22 @@ export const RecordAuditProgressArgs = z
     /** Audit run identifier. Generate once at the top of the audit; reuse for every progress event. */
     audit_id: NonEmptyStringSchema,
     phase: AuditPhaseSchema,
-    /** Optional MCP-server slug (e.g. "slack", "github") associated with this event. */
+    /** MCP-server slug (e.g. "slack", "github") associated with this event. Required when `phase === 'polling'` — every polling event must name the source it polled. */
     source: NonEmptyStringSchema.optional(),
     /** Free-form human-readable message. Surfaced verbatim in the UI tail. */
     message: NonEmptyStringSchema,
     /** Optional 0-100 progress hint for the current phase. */
     pct: z.number().int().min(0).max(100).optional(),
   })
-  .strict();
+  .strict()
+  .refine((value) => value.phase !== 'polling' || (value.source !== undefined && value.source.length > 0), {
+    // Polling events fan out per MCP server, so the live UI tails them
+    // grouped by source. A polling event with no `source` is a bug —
+    // reject it at the schema boundary so the bug fails loudly instead
+    // of silently rendering as "(unknown source)" in the UI.
+    message: 'source is required when phase is "polling"',
+    path: ['source'],
+  });
 export type RecordAuditProgressArgs = z.infer<typeof RecordAuditProgressArgs>;
 
 export const RecordAuditProgressResult = z

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -143,3 +143,67 @@ export const SearchWorkContextResult = z
   })
   .strict();
 export type SearchWorkContextResult = z.infer<typeof SearchWorkContextResult>;
+
+// --- Mega-audit ------------------------------------------------------
+
+export const StartMegaAuditArgs = z
+  .object({
+    /** ISO date — start of the lookback window. Defaults to today minus 90 days. */
+    since: z.iso.date().optional(),
+    /** Override the per-source token budget for the aggregate context. Default: 90_000 tokens per source. */
+    per_source_token_budget: z.number().int().positive().max(200_000).optional(),
+  })
+  .strict();
+export type StartMegaAuditArgs = z.infer<typeof StartMegaAuditArgs>;
+
+export const StartMegaAuditResult = z
+  .object({
+    /** Stable id the caller should pass to every `record_audit_progress` call during this run. */
+    audit_id: NonEmptyStringSchema,
+    /** Instructional body the model should follow to execute the audit. */
+    instructions: NonEmptyStringSchema,
+    /** Effective lookback window in ISO date. */
+    since: z.iso.date(),
+    /** Effective per-source token budget the model should respect when batching. */
+    per_source_token_budget: z.number().int().positive(),
+    generated_at: IsoDatetimeSchema,
+  })
+  .strict();
+export type StartMegaAuditResult = z.infer<typeof StartMegaAuditResult>;
+
+// --- Mega-audit progress streaming -----------------------------------
+
+const AuditPhaseSchema = z.enum([
+  'starting',
+  'inventory',
+  'polling',
+  'aggregating',
+  'synthesizing',
+  'writing',
+  'completed',
+  'failed',
+]);
+
+export const RecordAuditProgressArgs = z
+  .object({
+    /** Audit run identifier. Generate once at the top of the audit; reuse for every progress event. */
+    audit_id: NonEmptyStringSchema,
+    phase: AuditPhaseSchema,
+    /** Optional MCP-server slug (e.g. "slack", "github") associated with this event. */
+    source: NonEmptyStringSchema.optional(),
+    /** Free-form human-readable message. Surfaced verbatim in the UI tail. */
+    message: NonEmptyStringSchema,
+    /** Optional 0-100 progress hint for the current phase. */
+    pct: z.number().int().min(0).max(100).optional(),
+  })
+  .strict();
+export type RecordAuditProgressArgs = z.infer<typeof RecordAuditProgressArgs>;
+
+export const RecordAuditProgressResult = z
+  .object({
+    log_path: NonEmptyStringSchema,
+    line_number: z.number().int().positive(),
+    bytes_appended: z.number().int().nonnegative(),
+  })
+  .strict();
+export type RecordAuditProgressResult = z.infer<typeof RecordAuditProgressResult>;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -24,6 +24,16 @@ export { createGetFreshnessTool } from './tools/builtin/get-freshness.ts';
 export type { CreateGetFreshnessToolArgs } from './tools/builtin/get-freshness.ts';
 export { createSearchWorkContextTool } from './tools/builtin/search-work-context.ts';
 export type { CreateSearchWorkContextToolArgs } from './tools/builtin/search-work-context.ts';
+export {
+  createStartMegaAuditTool,
+  createRecordAuditProgressTool,
+  MEGA_AUDIT_INSTRUCTIONS,
+  renderInstructions,
+} from './tools/builtin/mega-audit/index.ts';
+export type {
+  CreateStartMegaAuditToolArgs,
+  CreateRecordAuditProgressToolArgs,
+} from './tools/builtin/mega-audit/index.ts';
 export { createStartSessionTool } from './tools/composite/start-session.ts';
 export type {
   CreateStartSessionToolArgs,

--- a/packages/mcp-server/src/tools/builtin/mega-audit/index.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Mega-audit barrel. Two tools: `start_mega_audit` (returns the
+ * instructional body the model follows) and `record_audit_progress`
+ * (JSONL streaming for the live UI tail in PR #61).
+ */
+
+export { createStartMegaAuditTool } from './start-mega-audit.ts';
+export type { CreateStartMegaAuditToolArgs } from './start-mega-audit.ts';
+export { createRecordAuditProgressTool } from './record-audit-progress.ts';
+export type { CreateRecordAuditProgressToolArgs } from './record-audit-progress.ts';
+export { MEGA_AUDIT_INSTRUCTIONS, renderInstructions } from './instructions.ts';

--- a/packages/mcp-server/src/tools/builtin/mega-audit/instructions.test.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/instructions.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression test for the mega-audit instructional body. Every tool
+ * the prompt tells the model to call must be either (a) actually
+ * registered in the server build that ships `start_mega_audit`, or
+ * (b) explicitly marked optional with a concrete fallback path.
+ *
+ * If a future PR adds a new tool reference to the prompt without
+ * either wiring it up or marking it optional, this test fails and the
+ * reviewer is forced to make the dependency explicit.
+ *
+ * What "registered" means here: present in the tool list that the
+ * production `slopweaver` CLI passes to `createMcpServer` (see
+ * `apps/mcp-local/src/cli.ts`'s `runMcpServer`). This test maintains a
+ * snapshot of that list locally rather than importing the CLI module
+ * — the CLI module is the wiring layer and pulls in heavy deps; the
+ * goal is to validate the prompt content, not exercise the wiring.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { MEGA_AUDIT_INSTRUCTIONS } from './instructions.ts';
+
+/**
+ * The tool names registered by `apps/mcp-local/src/cli.ts`'s
+ * `runMcpServer` (see `createMcpServer({ tools: [...] })`). Keep in
+ * sync if a new builtin is added.
+ */
+const REGISTERED_TOOLS: readonly string[] = [
+  'ping',
+  'start_session',
+  'get_freshness',
+  'catch_me_up',
+  'search_work_context',
+  'start_mega_audit',
+  'record_audit_progress',
+] as const;
+
+/**
+ * Tools the prompt references but knows aren't necessarily wired in
+ * every server build. Each entry must appear in the prompt body with
+ * a phrase that signals the dependency is optional (e.g. "if
+ * available", "if wired up", "if registered", "if present"). The test
+ * below enforces that signal.
+ */
+const OPTIONAL_TOOLS: readonly string[] = [
+  'ensure_work_console_branch',
+  'bootstrap_work_console',
+  'list_available_mcp_servers',
+  'apply_voice_rules',
+] as const;
+
+/**
+ * Phrases that mark a tool reference as optional. The test checks
+ * that within ~200 characters of an OPTIONAL_TOOLS mention, at least
+ * one of these phrases appears.
+ */
+const OPTIONAL_MARKERS: readonly string[] = [
+  'if available',
+  'if wired up',
+  'if registered',
+  'if present',
+  'wired up in this server build',
+  'registered in this server build',
+  "isn't wired up",
+  "aren't wired up",
+  "aren't available",
+  "isn't available",
+];
+
+/**
+ * Pull every backticked tool-like identifier out of the prompt body.
+ * A "tool-like" identifier is a snake_case bareword (no dots, no
+ * slashes) — the same shape MCP tool names use.
+ */
+function extractReferencedTools(body: string): string[] {
+  const matches: string[] = [];
+  const pattern = /`([a-z][a-z0-9_]*)`/g;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(body)) !== null) {
+    const name = m[1];
+    if (name === undefined) continue;
+    if (name.includes('_') && !matches.includes(name)) matches.push(name);
+  }
+  return matches;
+}
+
+describe('MEGA_AUDIT_INSTRUCTIONS', () => {
+  it('only references tools that are registered or explicitly optional', () => {
+    const referenced = extractReferencedTools(MEGA_AUDIT_INSTRUCTIONS);
+
+    // Drop anything that is obviously not a tool name: phase labels
+    // ('starting', 'inventory', etc), schema field names ('audit_id',
+    // 'per_source_token_budget'), filenames, etc. The simple test:
+    // tool names exist in REGISTERED_TOOLS or OPTIONAL_TOOLS.
+    const known = new Set<string>([...REGISTERED_TOOLS, ...OPTIONAL_TOOLS]);
+
+    // The set of identifiers in the prompt that *look like* tools
+    // (snake_case bareword in backticks) and aren't in the known set.
+    // Schema field names like `audit_id`, `per_source_token_budget`,
+    // `payload_json`, phase enum values, etc. are filtered by the
+    // allowlist below — they are deliberately scoped, not tool calls.
+    const SCHEMA_FIELDS_ALLOWLIST = new Set<string>([
+      'audit_id',
+      'per_source_token_budget',
+      'payload_json',
+      'from_self',
+    ]);
+
+    const unknown = referenced.filter((name) => !known.has(name) && !SCHEMA_FIELDS_ALLOWLIST.has(name));
+
+    // Anything left must be flagged: the prompt references an
+    // identifier this test doesn't recognise as either a registered
+    // tool, an optional tool, or an allowlisted schema field. Fail
+    // with a precise message so the contributor can choose:
+    // (1) add it to REGISTERED_TOOLS + register it in cli.ts,
+    // (2) add it to OPTIONAL_TOOLS + mark it optional in the prompt, or
+    // (3) add it to SCHEMA_FIELDS_ALLOWLIST if it's a schema field.
+    expect(unknown, `unknown identifiers referenced in prompt: ${unknown.join(', ')}`).toEqual([]);
+  });
+
+  it('marks every optional tool reference with an "if available"-style qualifier', () => {
+    for (const tool of OPTIONAL_TOOLS) {
+      // Find every occurrence of the tool name and check there's an
+      // optional-marker phrase within ~400 chars on either side. The
+      // window must cover the typical sentence-or-two that documents
+      // the optional fallback — sentences in this prompt run long.
+      const occurrences: number[] = [];
+      let idx = MEGA_AUDIT_INSTRUCTIONS.indexOf(tool);
+      while (idx !== -1) {
+        occurrences.push(idx);
+        idx = MEGA_AUDIT_INSTRUCTIONS.indexOf(tool, idx + 1);
+      }
+
+      expect(occurrences.length, `optional tool "${tool}" must appear in the prompt`).toBeGreaterThan(0);
+
+      for (const at of occurrences) {
+        const window = MEGA_AUDIT_INSTRUCTIONS.slice(Math.max(0, at - 400), at + tool.length + 400).toLowerCase();
+        const marked = OPTIONAL_MARKERS.some((marker) => window.includes(marker));
+        expect(
+          marked,
+          `optional tool "${tool}" referenced near char ${at} without an "if available"-style qualifier within 400 chars`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('disallows references to optional tools without a fallback path', () => {
+    // Sanity: the prompt must also describe the fallback for every
+    // optional tool. We approximate "fallback described" by looking
+    // for keywords that signal a fallback path within ~500 chars of
+    // any mention of the tool. The fallback for Phase 0's pair of
+    // optional tools is documented in a sentence at the end of that
+    // phase covering both, so the window has to be wide enough to
+    // cross sentence boundaries.
+    const FALLBACK_KEYWORDS = [
+      'fall back',
+      'fallback',
+      'otherwise',
+      'skip',
+      "isn't present",
+      "aren't wired",
+      'continue with',
+      'transcript-only',
+    ];
+    for (const tool of OPTIONAL_TOOLS) {
+      let idx = MEGA_AUDIT_INSTRUCTIONS.indexOf(tool);
+      let sawFallback = false;
+      while (idx !== -1) {
+        const window = MEGA_AUDIT_INSTRUCTIONS.slice(Math.max(0, idx - 500), idx + tool.length + 500).toLowerCase();
+        if (FALLBACK_KEYWORDS.some((kw) => window.includes(kw))) {
+          sawFallback = true;
+          break;
+        }
+        idx = MEGA_AUDIT_INSTRUCTIONS.indexOf(tool, idx + 1);
+      }
+      expect(sawFallback, `optional tool "${tool}" referenced without a documented fallback path`).toBe(true);
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/mega-audit/instructions.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/instructions.ts
@@ -1,0 +1,107 @@
+/**
+ * The instructional body returned by `start_mega_audit`. The model
+ * receives this as the tool's structured output and follows the steps
+ * inline. Lives in its own file so the prompt text is reviewable
+ * independently of the tool plumbing.
+ *
+ * Keep the body purely instructional. Never include the user's own
+ * identifiers, employer names, or stakeholder names — the audit is
+ * supposed to extract those from the user's connected MCP servers, not
+ * be hand-coded with them.
+ */
+
+export const MEGA_AUDIT_INSTRUCTIONS = `# Cold-start mega-audit
+
+You are running a one-shot deep ingest of the user's last \`SINCE_DATE\` through today across every MCP server they have connected. The end state is a populated AI work console — \`contexts/core-profile.md\`, \`contexts/team-directory.md\`, one \`work/<topic>.md\` per detected programme, and a populated voice-rules file derived from the user's own messages.
+
+Treat this as a single 1M-context pass. Batch aggressively. Don't loop incrementally.
+
+## Phase 0 — Branch + bootstrap
+
+Before any reads, call \`ensure_work_console_branch\` (if available) and \`bootstrap_work_console\` (if available). The audit writes a lot — it must land on the work-console branch, never a PR branch.
+
+If those tools aren't wired up in this server build, surface a one-line note ("work-console plumbing not present in this server; audit output will be transcript-only") and continue with the reads + synthesis. The reviewer will rebase this PR onto the branch with the plumbing.
+
+## Phase 1 — Inventory
+
+Call \`list_available_mcp_servers\` to get the catalog of namespaces SlopWeaver knows about. Cross-reference against the tools advertised in the current session's \`tools/list\` (\`mcp__*__*\`). Record the set of *actually-connected* servers.
+
+Call \`record_audit_progress({ audit_id, phase: 'inventory', message: 'detected N MCP servers: a, b, c' })\`.
+
+## Phase 2 — Polling (parallel)
+
+For each detected MCP server, issue a tight, scope-bounded read over the lookback window. Suggested budgets per source (adjust based on \`per_source_token_budget\`):
+
+- **Slack**: own \`@mentions\` + DMs since \`SINCE_DATE\`, plus the top 3 channels by message volume in the last 30 days. Search for \`from:<self>\` to recover threads the user authored.
+- **GitHub**: \`gh pr list --author @me --state all --search "updated:>=SINCE_DATE"\` plus issues + mentions on the same window. Also recent reviews requested of the user.
+- **Linear/Jira**: assigned + mentioned tickets updated since \`SINCE_DATE\`, plus the current cycle's open items.
+- **Gmail**: \`is:important newer_than:90d\` + recent threads with replies authored by the user.
+- **Calendar**: events in the last 90 days. Heavy weight on recurring 1:1s + people the user dedicates focused time to.
+- **Notion/Confluence**: pages the user authored or edited recently.
+- **HubSpot/Stripe/Mixpanel/etc.**: light reads only — not on the daily-fan-out path; surface only if the user is a primary owner of records there.
+
+Call \`record_audit_progress({ phase: 'polling', source: <slug>, pct: ... })\` periodically so the UI can show a live tail.
+
+## Phase 3 — Aggregate
+
+Once the reads complete, build a single structured input that fits inside the 1M-context budget. Schema:
+
+\`\`\`
+{
+  "identity": { "platform": "...", "id": "...", "email": "..." }[],
+  "messages_from_user": { "platform", "channel_or_thread", "ts", "body" }[],  // ~500 of the user's own messages
+  "messages_to_user": { ... }[],  // mentions + DMs
+  "threads": { "platform", "id", "participants", "snippet" }[],
+  "tickets": { "platform", "id", "status", "title", "assignee", "updated" }[],
+  "prs": { "repo", "number", "title", "state", "reviewer_decision" }[],
+  "calendar_events": { "summary", "attendees", "recurring", "last_attended" }[],
+  "decisions": { "platform", "ts", "snippet" }[]  // anything that smells like a decision (merged PR title, ticket marked Done, etc.)
+}
+\`\`\`
+
+Call \`record_audit_progress({ phase: 'aggregating' })\`.
+
+## Phase 4 — Synthesize
+
+Reason over the aggregate input. Extract:
+
+1. **Identity.** Confirm platform IDs already known from \`identities.md\`. Add anything new.
+2. **Ranked priorities.** Inspect the user's own messages + tickets + PRs for recurring themes. Score by recency × frequency × interaction-load. Output 4–8 priorities, each with a 1-line description + the supporting anchors (hyperlinked).
+3. **Top stakeholders.** People the user interacts with most by combined message-volume + meeting-attendance + PR-review-overlap. Cap at top 25. For each: name, primary platform IDs, one-line role inference, sample interactions.
+4. **Voice patterns.** Read 200+ of the user's own messages. Extract regularities: typical sentence length, em-dash usage, exclamation marks, sentence-initial words, banned consultant-speak tokens. Write these as \`forbid:\`/\`replace:\`/\`pattern:\` directives suitable for the rules-markdown format consumed by \`apply_voice_rules\` (PR #68). Don't editorialise — just observed patterns.
+5. **Open loops.** Anything that smells like "the user owes someone a reply" or "a long-running ask hasn't moved". One bullet per loop, hyperlinked anchor.
+6. **Programme detection.** Clusters of related anchors → one \`work/<slug>.md\` per cluster. The slug is generic ("authentication", "infra", "billing") — never include personal identifiers in the filename.
+
+Call \`record_audit_progress({ phase: 'synthesizing' })\`.
+
+## Phase 5 — Write
+
+Use the work-console write tools (if present) to drop:
+
+- \`contexts/identities.md\` — table from §1.
+- \`contexts/team-directory.md\` — table from §3.
+- \`contexts/core-profile.md\` — §1 + §2 + §5 + §6 stitched per the existing template.
+- \`rules/communication-style.md\` — voice directives from §4.
+- \`work/<slug>.md\` — one per cluster, with \`## Programme state (open items only)\` and \`## Key decisions\` seeded.
+- \`daily/<today>.md\` — a one-paragraph audit summary noting what was learned.
+
+If the write tools aren't available, output the full synthesized package as a single chat message so the user can pipe it manually.
+
+Call \`record_audit_progress({ phase: 'writing', pct: 100 })\` then \`record_audit_progress({ phase: 'completed', message: 'audit complete' })\`.
+
+## Hard rules
+
+- Never include personal identifiers in code, comments, or any committed-prose surface. The audit synthesises the user's own context from their connected MCP servers; that synthesis goes only into the per-user \`.claude/personal/\` tree (gitignored where slopweaver dogfoods itself).
+- If an MCP server isn't connected, skip it silently. Don't suggest the user install anything mid-audit.
+- One-pass synthesis. Don't loop incrementally trying to "improve" each section — the 1M-context window is the budget; one pass is the design.
+- Use the voice-rules MCP tool (\`apply_voice_rules\`, PR #68) to lint the synthesized core-profile against the just-derived voice rules before writing.
+`;
+
+/**
+ * Replace the template placeholder with the resolved date. The
+ * instruction body is otherwise immutable — keep the substitution
+ * surface tight so reviewers can see exactly what flows through.
+ */
+export function renderInstructions(args: { since: string }): string {
+  return MEGA_AUDIT_INSTRUCTIONS.replaceAll('SINCE_DATE', args.since);
+}

--- a/packages/mcp-server/src/tools/builtin/mega-audit/instructions.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/instructions.ts
@@ -24,7 +24,7 @@ If those tools aren't wired up in this server build, surface a one-line note ("w
 
 ## Phase 1 — Inventory
 
-Call \`list_available_mcp_servers\` to get the catalog of namespaces SlopWeaver knows about. Cross-reference against the tools advertised in the current session's \`tools/list\` (\`mcp__*__*\`). Record the set of *actually-connected* servers.
+If \`list_available_mcp_servers\` is wired up in this server build, call it to get the catalog of namespaces SlopWeaver knows about. Otherwise, fall back to enumerating the tools advertised in the current session's \`tools/list\` and grouping by the \`mcp__<server>__*\` prefix — every connected MCP server contributes at least one tool under that namespace, so the prefix set is the connected-server set. Record the resulting list.
 
 Call \`record_audit_progress({ audit_id, phase: 'inventory', message: 'detected N MCP servers: a, b, c' })\`.
 
@@ -40,7 +40,7 @@ For each detected MCP server, issue a tight, scope-bounded read over the lookbac
 - **Notion/Confluence**: pages the user authored or edited recently.
 - **HubSpot/Stripe/Mixpanel/etc.**: light reads only — not on the daily-fan-out path; surface only if the user is a primary owner of records there.
 
-Call \`record_audit_progress({ phase: 'polling', source: <slug>, pct: ... })\` periodically so the UI can show a live tail.
+Call \`record_audit_progress({ audit_id, phase: 'polling', source: <slug>, message: '<one-line status>', pct: ... })\` periodically so the UI can show a live tail. The \`audit_id\`, \`phase\`, \`source\`, and \`message\` fields are required for the polling phase; \`pct\` is optional.
 
 ## Phase 3 — Aggregate
 
@@ -59,7 +59,7 @@ Once the reads complete, build a single structured input that fits inside the 1M
 }
 \`\`\`
 
-Call \`record_audit_progress({ phase: 'aggregating' })\`.
+Call \`record_audit_progress({ audit_id, phase: 'aggregating', message: 'aggregated inputs across N sources' })\`.
 
 ## Phase 4 — Synthesize
 
@@ -68,11 +68,11 @@ Reason over the aggregate input. Extract:
 1. **Identity.** Confirm platform IDs already known from \`identities.md\`. Add anything new.
 2. **Ranked priorities.** Inspect the user's own messages + tickets + PRs for recurring themes. Score by recency × frequency × interaction-load. Output 4–8 priorities, each with a 1-line description + the supporting anchors (hyperlinked).
 3. **Top stakeholders.** People the user interacts with most by combined message-volume + meeting-attendance + PR-review-overlap. Cap at top 25. For each: name, primary platform IDs, one-line role inference, sample interactions.
-4. **Voice patterns.** Read 200+ of the user's own messages. Extract regularities: typical sentence length, em-dash usage, exclamation marks, sentence-initial words, banned consultant-speak tokens. Write these as \`forbid:\`/\`replace:\`/\`pattern:\` directives suitable for the rules-markdown format consumed by \`apply_voice_rules\` (PR #68). Don't editorialise — just observed patterns.
+4. **Voice patterns.** Read 200+ of the user's own messages. Extract regularities: typical sentence length, em-dash usage, exclamation marks, sentence-initial words, banned consultant-speak tokens. Write these as \`forbid:\`/\`replace:\`/\`pattern:\` directives in the rules-markdown format. If a voice-rules linter tool (e.g. \`apply_voice_rules\`) is wired up in this server build, use it in Phase 5 to lint the synthesized core-profile; otherwise just record the directives in \`rules/communication-style.md\` for later linting. Don't editorialise — just observed patterns.
 5. **Open loops.** Anything that smells like "the user owes someone a reply" or "a long-running ask hasn't moved". One bullet per loop, hyperlinked anchor.
 6. **Programme detection.** Clusters of related anchors → one \`work/<slug>.md\` per cluster. The slug is generic ("authentication", "infra", "billing") — never include personal identifiers in the filename.
 
-Call \`record_audit_progress({ phase: 'synthesizing' })\`.
+Call \`record_audit_progress({ audit_id, phase: 'synthesizing', message: 'synthesizing identity, priorities, stakeholders, voice, open loops, programmes' })\`.
 
 ## Phase 5 — Write
 
@@ -87,14 +87,14 @@ Use the work-console write tools (if present) to drop:
 
 If the write tools aren't available, output the full synthesized package as a single chat message so the user can pipe it manually.
 
-Call \`record_audit_progress({ phase: 'writing', pct: 100 })\` then \`record_audit_progress({ phase: 'completed', message: 'audit complete' })\`.
+Call \`record_audit_progress({ audit_id, phase: 'writing', message: 'writing console files', pct: 100 })\` then \`record_audit_progress({ audit_id, phase: 'completed', message: 'audit complete' })\`.
 
 ## Hard rules
 
 - Never include personal identifiers in code, comments, or any committed-prose surface. The audit synthesises the user's own context from their connected MCP servers; that synthesis goes only into the per-user \`.claude/personal/\` tree (gitignored where slopweaver dogfoods itself).
 - If an MCP server isn't connected, skip it silently. Don't suggest the user install anything mid-audit.
 - One-pass synthesis. Don't loop incrementally trying to "improve" each section — the 1M-context window is the budget; one pass is the design.
-- Use the voice-rules MCP tool (\`apply_voice_rules\`, PR #68) to lint the synthesized core-profile against the just-derived voice rules before writing.
+- If a voice-rules linter MCP tool (e.g. \`apply_voice_rules\`) is registered in this server build, run the synthesized core-profile through it before writing; otherwise skip that step and write the file as-is. The audit must still complete when the linter tool is absent.
 `;
 
 /**

--- a/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.test.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.test.ts
@@ -1,6 +1,11 @@
 /**
  * Tests for the audit-progress JSONL append. Uses a real temp dir +
- * logPathOverride so we don't touch the user's actual data dir.
+ * logDirOverride so we don't touch the user's actual data dir.
+ *
+ * Layout under test: one file per `audit_id` at
+ * `<logDir>/<audit_id>.jsonl`. Concurrent audits write to distinct
+ * files, so the race between read-modify-write that the previous
+ * shared-file layout had is gone by construction.
  */
 
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
@@ -16,12 +21,10 @@ const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
 describe('createRecordAuditProgressTool', () => {
   let dbHandle: ReturnType<typeof createDb>;
   let tempDir: string;
-  let logPath: string;
 
   beforeEach(() => {
     dbHandle = createDb({ path: ':memory:' });
     tempDir = mkdtempSync(join(tmpdir(), 'slop-mega-audit-'));
-    logPath = join(tempDir, 'audit-progress.jsonl');
   });
 
   afterEach(() => {
@@ -30,7 +33,7 @@ describe('createRecordAuditProgressTool', () => {
   });
 
   it('creates the log file on first call and reports line_number=1', async () => {
-    const tool = createRecordAuditProgressTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const tool = createRecordAuditProgressTool({ logDirOverride: tempDir, now: () => FIXED_NOW });
     const result = await tool.handler({
       input: RecordAuditProgressArgs.parse({
         audit_id: 'audit_x',
@@ -42,11 +45,11 @@ describe('createRecordAuditProgressTool', () => {
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       const parsed = RecordAuditProgressResult.parse(result.value);
-      expect(parsed.log_path).toBe(logPath);
+      expect(parsed.log_path).toBe(join(tempDir, 'audit_x.jsonl'));
       expect(parsed.line_number).toBe(1);
       expect(parsed.bytes_appended).toBeGreaterThan(0);
     }
-    const onDisk = readFileSync(logPath, 'utf-8');
+    const onDisk = readFileSync(join(tempDir, 'audit_x.jsonl'), 'utf-8');
     const lines = onDisk.split('\n').filter((l) => l.length > 0);
     expect(lines.length).toBe(1);
     const parsed = JSON.parse(lines[0]!) as Record<string, unknown>;
@@ -57,7 +60,7 @@ describe('createRecordAuditProgressTool', () => {
   });
 
   it('appends subsequent events with incrementing line numbers', async () => {
-    const tool = createRecordAuditProgressTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const tool = createRecordAuditProgressTool({ logDirOverride: tempDir, now: () => FIXED_NOW });
     for (let i = 1; i <= 3; i += 1) {
       const r = await tool.handler({
         input: RecordAuditProgressArgs.parse({
@@ -70,9 +73,9 @@ describe('createRecordAuditProgressTool', () => {
         ctx: { db: dbHandle.db },
       });
       expect(r.isOk()).toBe(true);
-      if (r.isOk()) expect(r.value.line_number).toBe(i);
+      if (r.isOk()) expect(r.value['line_number']).toBe(i);
     }
-    const onDisk = readFileSync(logPath, 'utf-8');
+    const onDisk = readFileSync(join(tempDir, 'audit_x.jsonl'), 'utf-8');
     const lines = onDisk.split('\n').filter((l) => l.length > 0);
     expect(lines.length).toBe(3);
     const last = JSON.parse(lines[2]!) as Record<string, unknown>;
@@ -81,7 +84,7 @@ describe('createRecordAuditProgressTool', () => {
   });
 
   it('omits optional fields when not supplied', async () => {
-    const tool = createRecordAuditProgressTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const tool = createRecordAuditProgressTool({ logDirOverride: tempDir, now: () => FIXED_NOW });
     await tool.handler({
       input: RecordAuditProgressArgs.parse({
         audit_id: 'audit_x',
@@ -90,9 +93,76 @@ describe('createRecordAuditProgressTool', () => {
       }),
       ctx: { db: dbHandle.db },
     });
-    const onDisk = readFileSync(logPath, 'utf-8');
+    const onDisk = readFileSync(join(tempDir, 'audit_x.jsonl'), 'utf-8');
     const parsed = JSON.parse(onDisk.trim()) as Record<string, unknown>;
     expect(parsed).not.toHaveProperty('source');
     expect(parsed).not.toHaveProperty('pct');
+  });
+
+  it('isolates concurrent audits into distinct files', async () => {
+    // Two audits, interleaved appends, must not corrupt each other's
+    // line numbers — the read-modify-write bug in the previous
+    // implementation would scramble these.
+    const tool = createRecordAuditProgressTool({ logDirOverride: tempDir, now: () => FIXED_NOW });
+
+    const writeEvent = async (auditId: string, i: number) =>
+      tool.handler({
+        input: RecordAuditProgressArgs.parse({
+          audit_id: auditId,
+          phase: 'aggregating',
+          message: `${auditId} step ${i}`,
+        }),
+        ctx: { db: dbHandle.db },
+      });
+
+    // Interleaved concurrent appends — the test asserts each audit's
+    // own line numbers are dense (1..N) regardless of interleaving.
+    const all = await Promise.all([
+      writeEvent('audit_a', 1),
+      writeEvent('audit_b', 1),
+      writeEvent('audit_a', 2),
+      writeEvent('audit_b', 2),
+      writeEvent('audit_a', 3),
+      writeEvent('audit_b', 3),
+    ]);
+    for (const r of all) expect(r.isOk()).toBe(true);
+
+    const aLines = readFileSync(join(tempDir, 'audit_a.jsonl'), 'utf-8')
+      .split('\n')
+      .filter((l) => l.length > 0);
+    const bLines = readFileSync(join(tempDir, 'audit_b.jsonl'), 'utf-8')
+      .split('\n')
+      .filter((l) => l.length > 0);
+    expect(aLines.length).toBe(3);
+    expect(bLines.length).toBe(3);
+    // Every line in audit_a's file carries audit_id "audit_a" (no
+    // bleed from audit_b), and vice versa.
+    for (const l of aLines) {
+      const parsed = JSON.parse(l) as Record<string, unknown>;
+      expect(parsed['audit_id']).toBe('audit_a');
+    }
+    for (const l of bLines) {
+      const parsed = JSON.parse(l) as Record<string, unknown>;
+      expect(parsed['audit_id']).toBe('audit_b');
+    }
+  });
+
+  it('rejects audit_id values that could escape the audit-progress directory', async () => {
+    const tool = createRecordAuditProgressTool({ logDirOverride: tempDir, now: () => FIXED_NOW });
+    // Zod schema only enforces non-empty + string; the file-system
+    // safety check lives in the handler. Use the parser-bypass shape
+    // (raw object) to confirm the handler-level guard fires.
+    const result = await tool.handler({
+      // Zod's RecordAuditProgressArgs would already reject this, but
+      // the handler-level guard is the actual defense — pass through
+      // the literal so the handler runs the check itself.
+      input: {
+        audit_id: '../escape',
+        phase: 'starting',
+        message: 'attempt path traversal',
+      },
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
   });
 });

--- a/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.test.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the audit-progress JSONL append. Uses a real temp dir +
+ * logPathOverride so we don't touch the user's actual data dir.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RecordAuditProgressArgs, RecordAuditProgressResult } from '@slopweaver/contracts';
+import { createDb } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRecordAuditProgressTool } from './record-audit-progress.ts';
+
+const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
+
+describe('createRecordAuditProgressTool', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+  let tempDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+    tempDir = mkdtempSync(join(tmpdir(), 'slop-mega-audit-'));
+    logPath = join(tempDir, 'audit-progress.jsonl');
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates the log file on first call and reports line_number=1', async () => {
+    const tool = createRecordAuditProgressTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecordAuditProgressArgs.parse({
+        audit_id: 'audit_x',
+        phase: 'starting',
+        message: 'audit kicked off',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = RecordAuditProgressResult.parse(result.value);
+      expect(parsed.log_path).toBe(logPath);
+      expect(parsed.line_number).toBe(1);
+      expect(parsed.bytes_appended).toBeGreaterThan(0);
+    }
+    const onDisk = readFileSync(logPath, 'utf-8');
+    const lines = onDisk.split('\n').filter((l) => l.length > 0);
+    expect(lines.length).toBe(1);
+    const parsed = JSON.parse(lines[0]!) as Record<string, unknown>;
+    expect(parsed['audit_id']).toBe('audit_x');
+    expect(parsed['phase']).toBe('starting');
+    expect(parsed['message']).toBe('audit kicked off');
+    expect(parsed['ts']).toBe(new Date(FIXED_NOW).toISOString());
+  });
+
+  it('appends subsequent events with incrementing line numbers', async () => {
+    const tool = createRecordAuditProgressTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    for (let i = 1; i <= 3; i += 1) {
+      const r = await tool.handler({
+        input: RecordAuditProgressArgs.parse({
+          audit_id: 'audit_x',
+          phase: 'polling',
+          source: 'slack',
+          message: `iter ${i}`,
+          pct: i * 25,
+        }),
+        ctx: { db: dbHandle.db },
+      });
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) expect(r.value.line_number).toBe(i);
+    }
+    const onDisk = readFileSync(logPath, 'utf-8');
+    const lines = onDisk.split('\n').filter((l) => l.length > 0);
+    expect(lines.length).toBe(3);
+    const last = JSON.parse(lines[2]!) as Record<string, unknown>;
+    expect(last['pct']).toBe(75);
+    expect(last['source']).toBe('slack');
+  });
+
+  it('omits optional fields when not supplied', async () => {
+    const tool = createRecordAuditProgressTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    await tool.handler({
+      input: RecordAuditProgressArgs.parse({
+        audit_id: 'audit_x',
+        phase: 'inventory',
+        message: 'no source, no pct',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    const onDisk = readFileSync(logPath, 'utf-8');
+    const parsed = JSON.parse(onDisk.trim()) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty('source');
+    expect(parsed).not.toHaveProperty('pct');
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.test.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.test.ts
@@ -32,7 +32,7 @@ describe('createRecordAuditProgressTool', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('creates the log file on first call and reports line_number=1', async () => {
+  it('creates the log file on first call and appends the event to the file', async () => {
     const tool = createRecordAuditProgressTool({ logDirOverride: tempDir, now: () => FIXED_NOW });
     const result = await tool.handler({
       input: RecordAuditProgressArgs.parse({
@@ -46,9 +46,12 @@ describe('createRecordAuditProgressTool', () => {
     if (result.isOk()) {
       const parsed = RecordAuditProgressResult.parse(result.value);
       expect(parsed.log_path).toBe(join(tempDir, 'audit_x.jsonl'));
-      expect(parsed.line_number).toBe(1);
       expect(parsed.bytes_appended).toBeGreaterThan(0);
     }
+    // Verify the appended row is present in the file. The tool no
+    // longer returns a line index (that's racy under same-audit
+    // parallel calls); the contract is just "the row landed in the
+    // file." Locate it by audit_id + ts.
     const onDisk = readFileSync(join(tempDir, 'audit_x.jsonl'), 'utf-8');
     const lines = onDisk.split('\n').filter((l) => l.length > 0);
     expect(lines.length).toBe(1);
@@ -59,7 +62,7 @@ describe('createRecordAuditProgressTool', () => {
     expect(parsed['ts']).toBe(new Date(FIXED_NOW).toISOString());
   });
 
-  it('appends subsequent events with incrementing line numbers', async () => {
+  it('appends subsequent events to the same file in call order', async () => {
     const tool = createRecordAuditProgressTool({ logDirOverride: tempDir, now: () => FIXED_NOW });
     for (let i = 1; i <= 3; i += 1) {
       const r = await tool.handler({
@@ -73,14 +76,18 @@ describe('createRecordAuditProgressTool', () => {
         ctx: { db: dbHandle.db },
       });
       expect(r.isOk()).toBe(true);
-      if (r.isOk()) expect(r.value['line_number']).toBe(i);
     }
     const onDisk = readFileSync(join(tempDir, 'audit_x.jsonl'), 'utf-8');
     const lines = onDisk.split('\n').filter((l) => l.length > 0);
     expect(lines.length).toBe(3);
+    // Sequential awaited calls land in order — concurrent ones aren't
+    // guaranteed to (see "appends every event under same-audit
+    // parallel calls" below), but this loop awaits each.
     const last = JSON.parse(lines[2]!) as Record<string, unknown>;
     expect(last['pct']).toBe(75);
     expect(last['source']).toBe('slack');
+    const first = JSON.parse(lines[0]!) as Record<string, unknown>;
+    expect(first['message']).toBe('iter 1');
   });
 
   it('omits optional fields when not supplied', async () => {
@@ -101,8 +108,8 @@ describe('createRecordAuditProgressTool', () => {
 
   it('isolates concurrent audits into distinct files', async () => {
     // Two audits, interleaved appends, must not corrupt each other's
-    // line numbers — the read-modify-write bug in the previous
-    // implementation would scramble these.
+    // files. Per-audit_id filename means there's no shared file to
+    // race on.
     const tool = createRecordAuditProgressTool({ logDirOverride: tempDir, now: () => FIXED_NOW });
 
     const writeEvent = async (auditId: string, i: number) =>
@@ -115,8 +122,6 @@ describe('createRecordAuditProgressTool', () => {
         ctx: { db: dbHandle.db },
       });
 
-    // Interleaved concurrent appends — the test asserts each audit's
-    // own line numbers are dense (1..N) regardless of interleaving.
     const all = await Promise.all([
       writeEvent('audit_a', 1),
       writeEvent('audit_b', 1),
@@ -145,6 +150,49 @@ describe('createRecordAuditProgressTool', () => {
       const parsed = JSON.parse(l) as Record<string, unknown>;
       expect(parsed['audit_id']).toBe('audit_b');
     }
+  });
+
+  it('appends every event under same-audit parallel calls', async () => {
+    // Same-audit fan-out: ~10 callers append concurrently to the same
+    // <audit_id>.jsonl. O_APPEND guarantees each event's bytes land
+    // contiguously at end-of-file (writes are <PIPE_BUF), so the file
+    // must contain exactly 10 rows after all promises settle. This is
+    // the regression the iter-2 audit caught: a previous version
+    // returned a `line_number` derived from a post-write read of the
+    // file, which two concurrent appenders could observe identically.
+    // Dropping `line_number` from the contract removes the racy
+    // observation; the per-call promise still resolves once its own
+    // O_APPEND write has landed.
+    const tool = createRecordAuditProgressTool({ logDirOverride: tempDir, now: () => FIXED_NOW });
+    const N = 10;
+    const results = await Promise.all(
+      Array.from({ length: N }, (_unused, i) =>
+        tool.handler({
+          input: RecordAuditProgressArgs.parse({
+            audit_id: 'audit_parallel',
+            phase: 'polling',
+            source: 'slack',
+            message: `parallel ${i}`,
+          }),
+          ctx: { db: dbHandle.db },
+        }),
+      ),
+    );
+    for (const r of results) expect(r.isOk()).toBe(true);
+
+    const onDisk = readFileSync(join(tempDir, 'audit_parallel.jsonl'), 'utf-8');
+    const lines = onDisk.split('\n').filter((l) => l.length > 0);
+    expect(lines.length).toBe(N);
+    // Every line is a complete, parseable JSON object — no torn writes.
+    const messages = new Set<string>();
+    for (const l of lines) {
+      const parsed = JSON.parse(l) as Record<string, unknown>;
+      expect(parsed['audit_id']).toBe('audit_parallel');
+      expect(typeof parsed['message']).toBe('string');
+      messages.add(parsed['message'] as string);
+    }
+    // All 10 distinct messages are present (none lost, none duplicated).
+    expect(messages.size).toBe(N);
   });
 
   it('rejects audit_id values that could escape the audit-progress directory', async () => {

--- a/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.ts
@@ -1,0 +1,129 @@
+/**
+ * `record_audit_progress` — append a JSONL progress event for the
+ * current mega-audit run. The file lives at
+ * `<data-dir>/audit-progress.jsonl` (where `<data-dir>` is the path
+ * resolved by `@slopweaver/db`'s `resolveDataDir` — typically
+ * `~/.slopweaver/`). The live UI from PR #61 tails this file.
+ *
+ * Tool stays standalone — the JSONL location is outside the work
+ * console so this PR doesn't depend on the work-console plumbing in
+ * PR #54.
+ */
+
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { RecordAuditProgressArgs, RecordAuditProgressResult } from '@slopweaver/contracts';
+import { resolveDataDir } from '@slopweaver/db';
+import { err, ok } from '@slopweaver/errors';
+import { McpErrors } from '../../../errors.ts';
+import { defineTool, type Tool } from '../../registry.ts';
+
+const PROGRESS_FILENAME = 'audit-progress.jsonl';
+
+export type CreateRecordAuditProgressToolArgs = {
+  /** Override the JSONL path (tests + non-default data dirs). */
+  logPathOverride?: string;
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  now?: () => number;
+};
+
+export function createRecordAuditProgressTool(args: CreateRecordAuditProgressToolArgs = {}): Tool {
+  const now = args.now ?? Date.now;
+  const logPathOverride = args.logPathOverride;
+
+  return defineTool({
+    name: 'record_audit_progress',
+    description:
+      'Append one progress event to the mega-audit JSONL log at <data-dir>/audit-progress.jsonl. Call from inside a mega-audit run for each phase transition so the live UI can tail the file. Cheap and idempotent at the file level (one append per call).',
+    inputSchema: RecordAuditProgressArgs,
+    outputSchema: RecordAuditProgressResult,
+    handler: async ({ input }) => {
+      const resolved =
+        logPathOverride != null ? ok(logPathOverride) : resolveDataDir().map((dir) => join(dir, PROGRESS_FILENAME));
+      if (resolved.isErr()) {
+        return err(McpErrors.unexpected('record_audit_progress', undefined, resolved.error.message));
+      }
+      const logPath = resolved.value;
+
+      const line: Record<string, unknown> = {
+        ts: new Date(now()).toISOString(),
+        audit_id: input.audit_id,
+        phase: input.phase,
+        message: input.message,
+      };
+      if (input.source !== undefined) line['source'] = input.source;
+      if (input.pct !== undefined) line['pct'] = input.pct;
+      const encoded = `${JSON.stringify(line)}\n`;
+
+      // Count existing lines for the 1-based line-number return value.
+      // Identical pattern to log_walk_feedback / append_daily_journal —
+      // read-then-append. Read failure (ENOENT) is treated as 0.
+      let existingLines = 0;
+      try {
+        const content = await readFile(logPath, 'utf-8');
+        existingLines = content.split('\n').filter((l) => l.trim().length > 0).length;
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+          return err(
+            McpErrors.unexpected(
+              'record_audit_progress',
+              undefined,
+              `failed to read ${logPath}: ${e instanceof Error ? e.message : String(e)}`,
+            ),
+          );
+        }
+      }
+
+      // Ensure parent dir + append. We use writeFile with the 'a' flag
+      // via `appendFile`, but to keep behaviour explicit + testable we
+      // append by read-then-write (same pattern as the walk-feedback
+      // log helper). On a fresh log, that's a single write.
+      const parent = dirname(logPath);
+      try {
+        await mkdir(parent, { recursive: true });
+      } catch (e) {
+        return err(
+          McpErrors.unexpected(
+            'record_audit_progress',
+            undefined,
+            `failed to mkdir ${parent}: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+      }
+      let next = encoded;
+      try {
+        const existing = await stat(logPath);
+        if (existing.isFile()) {
+          const prev = await readFile(logPath, 'utf-8');
+          next = prev.endsWith('\n') || prev.length === 0 ? `${prev}${encoded}` : `${prev}\n${encoded}`;
+        }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+          return err(
+            McpErrors.unexpected(
+              'record_audit_progress',
+              undefined,
+              `failed to stat ${logPath}: ${e instanceof Error ? e.message : String(e)}`,
+            ),
+          );
+        }
+      }
+      try {
+        await writeFile(logPath, next, { encoding: 'utf-8', mode: 0o644 });
+      } catch (e) {
+        return err(
+          McpErrors.unexpected(
+            'record_audit_progress',
+            undefined,
+            `failed to write ${logPath}: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+      }
+      return ok({
+        log_path: logPath,
+        line_number: existingLines + 1,
+        bytes_appended: Buffer.byteLength(encoded, 'utf-8'),
+      });
+    },
+  });
+}

--- a/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.ts
@@ -1,16 +1,23 @@
 /**
  * `record_audit_progress` — append a JSONL progress event for the
- * current mega-audit run. The file lives at
- * `<data-dir>/audit-progress.jsonl` (where `<data-dir>` is the path
- * resolved by `@slopweaver/db`'s `resolveDataDir` — typically
- * `~/.slopweaver/`). The live UI from PR #61 tails this file.
+ * current mega-audit run. One file per `audit_id` lives under
+ * `<data-dir>/audit-progress/<audit_id>.jsonl` (where `<data-dir>` is
+ * the path resolved by `@slopweaver/db`'s `resolveDataDir` — typically
+ * `~/.slopweaver/`). The live UI from PR #61 tails the matching file.
+ *
+ * The per-`audit_id` layout is deliberate: it lets us use true append
+ * semantics (`O_APPEND`) without races between concurrent audits, and
+ * it lets us count lines from the file's own size without coordinating
+ * with other audits' writes. A shared file would force a
+ * read-modify-write that races on every concurrent call.
  *
  * Tool stays standalone — the JSONL location is outside the work
  * console so this PR doesn't depend on the work-console plumbing in
  * PR #54.
  */
 
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { mkdir, open } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { RecordAuditProgressArgs, RecordAuditProgressResult } from '@slopweaver/contracts';
 import { resolveDataDir } from '@slopweaver/db';
@@ -18,32 +25,58 @@ import { err, ok } from '@slopweaver/errors';
 import { McpErrors } from '../../../errors.ts';
 import { defineTool, type Tool } from '../../registry.ts';
 
-const PROGRESS_FILENAME = 'audit-progress.jsonl';
+const PROGRESS_DIRNAME = 'audit-progress';
 
 export type CreateRecordAuditProgressToolArgs = {
-  /** Override the JSONL path (tests + non-default data dirs). */
-  logPathOverride?: string;
+  /** Override the JSONL directory (tests + non-default data dirs). */
+  logDirOverride?: string;
   /** Clock injection for tests. Defaults to `Date.now`. */
   now?: () => number;
 };
 
+/**
+ * Reject any audit_id containing path separators or path-traversal
+ * segments. The id flows straight into a filename; treat it as
+ * adversarial input and refuse anything that could escape the audit
+ * directory.
+ */
+function isSafeAuditId(auditId: string): boolean {
+  if (auditId.length === 0 || auditId.length > 128) return false;
+  if (auditId.includes('/') || auditId.includes('\\')) return false;
+  if (auditId === '.' || auditId === '..') return false;
+  // Conservative whitelist: alphanumerics, `_`, `-`, `.` (date prefix +
+  // UUID is the only shape the start_mega_audit generator produces).
+  return /^[A-Za-z0-9._-]+$/.test(auditId);
+}
+
 export function createRecordAuditProgressTool(args: CreateRecordAuditProgressToolArgs = {}): Tool {
   const now = args.now ?? Date.now;
-  const logPathOverride = args.logPathOverride;
+  const logDirOverride = args.logDirOverride;
 
   return defineTool({
     name: 'record_audit_progress',
     description:
-      'Append one progress event to the mega-audit JSONL log at <data-dir>/audit-progress.jsonl. Call from inside a mega-audit run for each phase transition so the live UI can tail the file. Cheap and idempotent at the file level (one append per call).',
+      'Append one progress event to the per-audit JSONL log at <data-dir>/audit-progress/<audit_id>.jsonl. Call from inside a mega-audit run for each phase transition so the live UI can tail the file. Uses O_APPEND for race-free concurrent appends; the per-audit_id layout means concurrent audits never contend on the same file.',
     inputSchema: RecordAuditProgressArgs,
     outputSchema: RecordAuditProgressResult,
     handler: async ({ input }) => {
-      const resolved =
-        logPathOverride != null ? ok(logPathOverride) : resolveDataDir().map((dir) => join(dir, PROGRESS_FILENAME));
-      if (resolved.isErr()) {
-        return err(McpErrors.unexpected('record_audit_progress', undefined, resolved.error.message));
+      if (!isSafeAuditId(input.audit_id)) {
+        return err(
+          McpErrors.unexpected(
+            'record_audit_progress',
+            undefined,
+            `audit_id must be 1-128 chars of [A-Za-z0-9._-]; got "${input.audit_id}"`,
+          ),
+        );
       }
-      const logPath = resolved.value;
+
+      const dirResult =
+        logDirOverride != null ? ok(logDirOverride) : resolveDataDir().map((dir) => join(dir, PROGRESS_DIRNAME));
+      if (dirResult.isErr()) {
+        return err(McpErrors.unexpected('record_audit_progress', undefined, dirResult.error.message));
+      }
+      const logDir = dirResult.value;
+      const logPath = join(logDir, `${input.audit_id}.jsonl`);
 
       const line: Record<string, unknown> = {
         ts: new Date(now()).toISOString(),
@@ -54,76 +87,94 @@ export function createRecordAuditProgressTool(args: CreateRecordAuditProgressToo
       if (input.source !== undefined) line['source'] = input.source;
       if (input.pct !== undefined) line['pct'] = input.pct;
       const encoded = `${JSON.stringify(line)}\n`;
+      const encodedBytes = Buffer.from(encoded, 'utf-8');
 
-      // Count existing lines for the 1-based line-number return value.
-      // Identical pattern to log_walk_feedback / append_daily_journal —
-      // read-then-append. Read failure (ENOENT) is treated as 0.
-      let existingLines = 0;
+      // Ensure parent dir before the open(O_APPEND | O_CREAT) below.
+      // `dirname(logPath)` is always `logDir` in the happy path but the
+      // explicit dirname call keeps this robust if the layout changes.
       try {
-        const content = await readFile(logPath, 'utf-8');
-        existingLines = content.split('\n').filter((l) => l.trim().length > 0).length;
-      } catch (e) {
-        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-          return err(
-            McpErrors.unexpected(
-              'record_audit_progress',
-              undefined,
-              `failed to read ${logPath}: ${e instanceof Error ? e.message : String(e)}`,
-            ),
-          );
-        }
-      }
-
-      // Ensure parent dir + append. We use writeFile with the 'a' flag
-      // via `appendFile`, but to keep behaviour explicit + testable we
-      // append by read-then-write (same pattern as the walk-feedback
-      // log helper). On a fresh log, that's a single write.
-      const parent = dirname(logPath);
-      try {
-        await mkdir(parent, { recursive: true });
+        await mkdir(dirname(logPath), { recursive: true });
       } catch (e) {
         return err(
           McpErrors.unexpected(
             'record_audit_progress',
             undefined,
-            `failed to mkdir ${parent}: ${e instanceof Error ? e.message : String(e)}`,
+            `failed to mkdir ${dirname(logPath)}: ${e instanceof Error ? e.message : String(e)}`,
           ),
         );
       }
-      let next = encoded;
+
+      // True append: O_APPEND guarantees atomic positioning for writes
+      // up to PIPE_BUF (4KB on Linux, 512B on macOS). Progress events
+      // are tens of bytes, so a single write is atomic and lock-free
+      // against concurrent appenders to the same file. Combined with
+      // the per-audit_id filename, this is race-free across concurrent
+      // audits too.
+      //
+      // O_RDWR (not O_WRONLY) so we can read back the file on the same
+      // descriptor to derive `line_number`. O_APPEND still forces every
+      // write to land at end-of-file regardless of the read offset, so
+      // the read side doesn't perturb the append semantics.
+      const fh = await open(logPath, fsConstants.O_RDWR | fsConstants.O_APPEND | fsConstants.O_CREAT, 0o644).catch(
+        (e: unknown) => {
+          return new Error(`failed to open ${logPath}: ${e instanceof Error ? e.message : String(e)}`);
+        },
+      );
+      if (fh instanceof Error) {
+        return err(McpErrors.unexpected('record_audit_progress', undefined, fh.message));
+      }
+
       try {
-        const existing = await stat(logPath);
-        if (existing.isFile()) {
-          const prev = await readFile(logPath, 'utf-8');
-          next = prev.endsWith('\n') || prev.length === 0 ? `${prev}${encoded}` : `${prev}\n${encoded}`;
-        }
-      } catch (e) {
-        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+        const writeResult = await fh.write(encodedBytes);
+        if (writeResult.bytesWritten !== encodedBytes.length) {
           return err(
             McpErrors.unexpected(
               'record_audit_progress',
               undefined,
-              `failed to stat ${logPath}: ${e instanceof Error ? e.message : String(e)}`,
+              `short write to ${logPath}: wrote ${writeResult.bytesWritten} of ${encodedBytes.length} bytes`,
             ),
           );
         }
+        // Now stat the file to derive line_number. Counting bytes
+        // ÷ "lines" doesn't work because event sizes vary; instead,
+        // re-read the file and count newlines. The per-audit_id
+        // layout means this read is bounded to one audit's events
+        // (tens to low hundreds in practice), and the file handle is
+        // still open so any other appenders won't shrink it under us.
+        const stat = await fh.stat();
+        if (stat.size === 0) {
+          // Shouldn't happen — we just wrote — but treat as a defensive guard.
+          return err(
+            McpErrors.unexpected('record_audit_progress', undefined, `unexpected empty log after write: ${logPath}`),
+          );
+        }
+        const buf = Buffer.alloc(stat.size);
+        const readResult = await fh.read(buf, 0, stat.size, 0);
+        if (readResult.bytesRead !== stat.size) {
+          return err(
+            McpErrors.unexpected(
+              'record_audit_progress',
+              undefined,
+              `short read of ${logPath}: read ${readResult.bytesRead} of ${stat.size} bytes`,
+            ),
+          );
+        }
+        const content = buf.toString('utf-8');
+        const lineNumber = content.split('\n').filter((l) => l.trim().length > 0).length;
+
+        return ok({
+          log_path: logPath,
+          line_number: lineNumber,
+          bytes_appended: encodedBytes.length,
+        });
+      } finally {
+        await fh.close().catch(() => {
+          // Close errors are non-fatal — the write already succeeded
+          // and the OS reclaims the descriptor on process exit. We
+          // can't surface a typed error from a finally block without
+          // overriding the actual return value, so swallow.
+        });
       }
-      try {
-        await writeFile(logPath, next, { encoding: 'utf-8', mode: 0o644 });
-      } catch (e) {
-        return err(
-          McpErrors.unexpected(
-            'record_audit_progress',
-            undefined,
-            `failed to write ${logPath}: ${e instanceof Error ? e.message : String(e)}`,
-          ),
-        );
-      }
-      return ok({
-        log_path: logPath,
-        line_number: existingLines + 1,
-        bytes_appended: Buffer.byteLength(encoded, 'utf-8'),
-      });
     },
   });
 }

--- a/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/record-audit-progress.ts
@@ -109,13 +109,16 @@ export function createRecordAuditProgressTool(args: CreateRecordAuditProgressToo
       // are tens of bytes, so a single write is atomic and lock-free
       // against concurrent appenders to the same file. Combined with
       // the per-audit_id filename, this is race-free across concurrent
-      // audits too.
+      // audits too — and crucially, same-audit parallel callers also
+      // appear in arbitrary order without corrupting each other's bytes.
       //
-      // O_RDWR (not O_WRONLY) so we can read back the file on the same
-      // descriptor to derive `line_number`. O_APPEND still forces every
-      // write to land at end-of-file regardless of the read offset, so
-      // the read side doesn't perturb the append semantics.
-      const fh = await open(logPath, fsConstants.O_RDWR | fsConstants.O_APPEND | fsConstants.O_CREAT, 0o644).catch(
+      // We deliberately do not derive a `line_number` after the write.
+      // A read-then-count from the same descriptor would observe other
+      // concurrent appenders' lines, so two parallel callers could see
+      // the same final length and report the same line number — the
+      // returned value would no longer identify the caller's own event.
+      // The caller doesn't need it; the live UI tails the file directly.
+      const fh = await open(logPath, fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT, 0o644).catch(
         (e: unknown) => {
           return new Error(`failed to open ${logPath}: ${e instanceof Error ? e.message : String(e)}`);
         },
@@ -135,36 +138,8 @@ export function createRecordAuditProgressTool(args: CreateRecordAuditProgressToo
             ),
           );
         }
-        // Now stat the file to derive line_number. Counting bytes
-        // ÷ "lines" doesn't work because event sizes vary; instead,
-        // re-read the file and count newlines. The per-audit_id
-        // layout means this read is bounded to one audit's events
-        // (tens to low hundreds in practice), and the file handle is
-        // still open so any other appenders won't shrink it under us.
-        const stat = await fh.stat();
-        if (stat.size === 0) {
-          // Shouldn't happen — we just wrote — but treat as a defensive guard.
-          return err(
-            McpErrors.unexpected('record_audit_progress', undefined, `unexpected empty log after write: ${logPath}`),
-          );
-        }
-        const buf = Buffer.alloc(stat.size);
-        const readResult = await fh.read(buf, 0, stat.size, 0);
-        if (readResult.bytesRead !== stat.size) {
-          return err(
-            McpErrors.unexpected(
-              'record_audit_progress',
-              undefined,
-              `short read of ${logPath}: read ${readResult.bytesRead} of ${stat.size} bytes`,
-            ),
-          );
-        }
-        const content = buf.toString('utf-8');
-        const lineNumber = content.split('\n').filter((l) => l.trim().length > 0).length;
-
         return ok({
           log_path: logPath,
-          line_number: lineNumber,
           bytes_appended: encodedBytes.length,
         });
       } finally {

--- a/packages/mcp-server/src/tools/builtin/mega-audit/start-mega-audit.test.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/start-mega-audit.test.ts
@@ -74,7 +74,21 @@ describe('createStartMegaAuditTool', () => {
     expect(a.isOk()).toBe(true);
     expect(b.isOk()).toBe(true);
     if (a.isOk() && b.isOk()) {
-      expect(a.value.audit_id).not.toBe(b.value.audit_id);
+      expect(a.value['audit_id']).not.toBe(b.value['audit_id']);
+    }
+  });
+
+  it('defaults to a UUID-suffixed id with a date prefix', async () => {
+    // The default generator uses crypto.randomUUID() for the suffix
+    // (122 bits of entropy) instead of Math.random(). Assert the
+    // shape: `audit_YYYYMMDD_<32-hex-chars>`. The 32-hex shape
+    // matches a UUID-without-dashes; if the implementation regresses
+    // to a 6-char Math.random suffix this test fails on length.
+    const tool = createStartMegaAuditTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({ input: StartMegaAuditArgs.parse({}), ctx: { db: dbHandle.db } });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value['audit_id']).toMatch(/^audit_\d{8}_[0-9a-f]{32}$/);
     }
   });
 });

--- a/packages/mcp-server/src/tools/builtin/mega-audit/start-mega-audit.test.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/start-mega-audit.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure-function tests for `start_mega_audit`. Verifies that the
+ * instructional body is the expected immutable template (modulo the
+ * SINCE_DATE substitution), that defaulting works as documented, and
+ * that the wire-contract holds via Zod.
+ */
+
+import { StartMegaAuditArgs, StartMegaAuditResult } from '@slopweaver/contracts';
+import { createDb } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createStartMegaAuditTool } from './start-mega-audit.ts';
+
+const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0); // 2026-05-21T10:00:00Z
+const NINETY_DAYS_BACK = '2026-02-20';
+
+describe('createStartMegaAuditTool', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it('defaults the lookback window to 90 days back and supplies a budget', async () => {
+    const tool = createStartMegaAuditTool({
+      now: () => FIXED_NOW,
+      generateAuditId: () => 'audit_fixed_demo',
+    });
+    const result = await tool.handler({
+      input: StartMegaAuditArgs.parse({}),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = StartMegaAuditResult.parse(result.value);
+      expect(parsed.audit_id).toBe('audit_fixed_demo');
+      expect(parsed.since).toBe(NINETY_DAYS_BACK);
+      expect(parsed.per_source_token_budget).toBe(90_000);
+      expect(parsed.generated_at).toBe(new Date(FIXED_NOW).toISOString());
+      expect(parsed.instructions).toContain(NINETY_DAYS_BACK);
+      expect(parsed.instructions).toContain('Phase 0 — Branch + bootstrap');
+      expect(parsed.instructions).toContain('Phase 5 — Write');
+    }
+  });
+
+  it('honours an explicit `since` and `per_source_token_budget`', async () => {
+    const tool = createStartMegaAuditTool({
+      now: () => FIXED_NOW,
+      generateAuditId: () => 'audit_custom',
+    });
+    const result = await tool.handler({
+      input: StartMegaAuditArgs.parse({
+        since: '2025-12-01',
+        per_source_token_budget: 50_000,
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = StartMegaAuditResult.parse(result.value);
+      expect(parsed.since).toBe('2025-12-01');
+      expect(parsed.per_source_token_budget).toBe(50_000);
+      expect(parsed.instructions).toContain('2025-12-01');
+    }
+  });
+
+  it('generates distinct audit_ids by default', async () => {
+    const tool = createStartMegaAuditTool({ now: () => FIXED_NOW });
+    const a = await tool.handler({ input: StartMegaAuditArgs.parse({}), ctx: { db: dbHandle.db } });
+    const b = await tool.handler({ input: StartMegaAuditArgs.parse({}), ctx: { db: dbHandle.db } });
+    expect(a.isOk()).toBe(true);
+    expect(b.isOk()).toBe(true);
+    if (a.isOk() && b.isOk()) {
+      expect(a.value.audit_id).not.toBe(b.value.audit_id);
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/mega-audit/start-mega-audit.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/start-mega-audit.ts
@@ -1,0 +1,66 @@
+/**
+ * `start_mega_audit` — the v1.1 headliner. Returns a fresh
+ * `audit_id`, the resolved lookback window, and the full instructional
+ * body the model should follow to execute the deep audit. The tool
+ * itself is light: ID generation + clock math + a body template.
+ *
+ * Designed as a tool (not an MCP prompt) so it can ship on `main`
+ * before the prompt-registry plumbing (PR #54) merges. When that PR
+ * lands, a thin `/mega-audit` prompt shim will call this tool and
+ * inline the returned instructions.
+ */
+
+import { StartMegaAuditArgs, StartMegaAuditResult } from '@slopweaver/contracts';
+import { ok } from '@slopweaver/errors';
+import { defineTool, type Tool } from '../../registry.ts';
+import { renderInstructions } from './instructions.ts';
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+const DEFAULT_PER_SOURCE_TOKEN_BUDGET = 90_000;
+
+export type CreateStartMegaAuditToolArgs = {
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** ID generator for tests. Defaults to a date + random shortid pair. */
+  generateAuditId?: (nowMs: number) => string;
+};
+
+export function createStartMegaAuditTool(args: CreateStartMegaAuditToolArgs = {}): Tool {
+  const now = args.now ?? Date.now;
+  const generateAuditId = args.generateAuditId ?? defaultGenerator;
+
+  return defineTool({
+    name: 'start_mega_audit',
+    description:
+      'Returns the instructional body for a cold-start mega-audit: a 1M-context-friendly orchestration that pulls 90 days of history from every connected MCP server in one pass and populates the AI work console (core-profile, team-directory, work files, voice rules). Pair with `record_audit_progress` for live UI streaming.',
+    inputSchema: StartMegaAuditArgs,
+    outputSchema: StartMegaAuditResult,
+    handler: async ({ input }) => {
+      const nowMs = now();
+      const sinceMs = input.since != null ? Date.parse(`${input.since}T00:00:00Z`) : nowMs - NINETY_DAYS_MS;
+      const since = formatDate(new Date(sinceMs));
+      const budget = input.per_source_token_budget ?? DEFAULT_PER_SOURCE_TOKEN_BUDGET;
+      const auditId = generateAuditId(nowMs);
+      return ok({
+        audit_id: auditId,
+        instructions: renderInstructions({ since }),
+        since,
+        per_source_token_budget: budget,
+        generated_at: new Date(nowMs).toISOString(),
+      });
+    },
+  });
+}
+
+function defaultGenerator(nowMs: number): string {
+  const datePart = formatDate(new Date(nowMs)).replaceAll('-', '');
+  const randomPart = Math.random().toString(36).slice(2, 8);
+  return `audit_${datePart}_${randomPart}`;
+}
+
+function formatDate(d: Date): string {
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/packages/mcp-server/src/tools/builtin/mega-audit/start-mega-audit.ts
+++ b/packages/mcp-server/src/tools/builtin/mega-audit/start-mega-audit.ts
@@ -10,6 +10,7 @@
  * inline the returned instructions.
  */
 
+import { randomUUID } from 'node:crypto';
 import { StartMegaAuditArgs, StartMegaAuditResult } from '@slopweaver/contracts';
 import { ok } from '@slopweaver/errors';
 import { defineTool, type Tool } from '../../registry.ts';
@@ -53,8 +54,14 @@ export function createStartMegaAuditTool(args: CreateStartMegaAuditToolArgs = {}
 }
 
 function defaultGenerator(nowMs: number): string {
+  // The date prefix keeps audit_ids sortable on disk + greppable in
+  // logs. The UUID v4 suffix gives 122 bits of unguessable entropy —
+  // `Math.random()` is neither cryptographically random nor collision-
+  // resistant across rapid concurrent calls. Strip the dashes so the
+  // id is safe as a filename segment (the record_audit_progress
+  // handler validates `[A-Za-z0-9._-]` anyway).
   const datePart = formatDate(new Date(nowMs)).replaceAll('-', '');
-  const randomPart = Math.random().toString(36).slice(2, 8);
+  const randomPart = randomUUID().replaceAll('-', '');
   return `audit_${datePart}_${randomPart}`;
 }
 


### PR DESCRIPTION
**Problem**
Closes #60. SlopWeaver had no way to cold-start an AI work console from a user's connected MCP servers in a single 1M-context pass.

**Solution**
Two new MCP tools, `start_mega_audit` returns the instructional body Opus follows to inventory, poll, aggregate, and synthesise, and `record_audit_progress` appends JSONL events for the live UI tail. Tool-only design, no dependency on the prompt registry in #54.

**Proof this works**
_pending local verification_

**How to test**
1. `pnpm install && pnpm validate`
2. Build and start the binary, confirm `tools/list` shows `start_mega_audit` and `record_audit_progress`
3. Call `start_mega_audit` with no args, confirm the response carries an `audit_id`, a 90-day-back `since`, and the rendered instructions
4. Call `record_audit_progress` a handful of times with the same `audit_id`, confirm `<data-dir>/audit-progress/<audit_id>.jsonl` accumulates one row per call
5. Fire ten concurrent `record_audit_progress` calls against the same `audit_id`, confirm all ten rows land with no torn writes

<details>
<summary><b>For coding agents</b>: detailed context (not in voice)</summary>

### Scope

This PR ships the headline v1.1 feature from #60. It adds two builtin MCP tools and the instructional body that drives a cold-start mega-audit. No work-console plumbing is required, the JSONL log lives at `<data-dir>/audit-progress/<audit_id>.jsonl` (typically `~/.slopweaver/audit-progress/`) and the work-console writes are done by the model itself via separate tools that may or may not be wired up in any given server build (the prompt flags those as optional and documents a transcript-only fallback).

### Contracts

`StartMegaAuditArgs`: optional `since` (ISO date, defaults to today minus 90 days) and optional `per_source_token_budget` (int 1 to 200_000, defaults to 90_000). `StartMegaAuditResult` returns `audit_id`, `instructions`, the effective `since` + `per_source_token_budget`, and `generated_at`. The `audit_id` is generated server-side from a date prefix plus a UUID so callers cannot supply colliding ids; tests inject `generateAuditId` for determinism.

`RecordAuditProgressArgs`: `audit_id` + `phase` (`starting | inventory | polling | aggregating | synthesizing | writing | completed | failed`) + `message` are required, `source` and `pct` are optional. A Zod `.refine()` makes `source` required when `phase === 'polling'` so polling events never render as `(unknown source)` in the UI tail. `RecordAuditProgressResult` returns `log_path` and `bytes_appended`.

### Why no `line_number` in the result

Earlier revisions of this PR returned a `line_number` derived from a post-write read of the file. Two concurrent appenders to the same file could observe the same final length after their respective writes had both landed, so both would report the same `line_number` and the value would no longer identify the caller's own event. Fix commit `c659155` dropped `line_number` from the contract; the per-call promise still resolves once the caller's own `O_APPEND` write has landed, and the live UI tails the file directly rather than dereferencing line numbers returned to other callers. The same-audit parallel-append regression test (`appends every event under same-audit parallel calls`) fans ten concurrent appenders against one `audit_id` and asserts all ten distinct messages are present.

### Write path

The handler opens the per-audit log with `O_WRONLY | O_APPEND | O_CREAT` and issues a single `write()` of the encoded JSONL line plus trailing newline. Progress events are tens of bytes, well below `PIPE_BUF` (4KB Linux, 512B macOS), so the kernel guarantees the write lands contiguously at end-of-file even when other appenders are writing the same descriptor or a duplicate descriptor. No application-level locking, no read-modify-write, no shared mutex.

Concurrent audits never contend on the same file because the layout is one file per `audit_id`. The `isolates concurrent audits into distinct files` test interleaves writes across two `audit_id`s and asserts neither file contains rows from the other.

### `audit_id` sanitisation

`audit_id` flows straight into a filename. The handler runs an `isSafeAuditId` check before any filesystem call, rejecting empty strings, anything over 128 chars, anything containing `/` or `\`, the literal `.` and `..`, and any char outside `[A-Za-z0-9._-]`. The Zod schema's `NonEmptyStringSchema` is not load-bearing for safety here, the handler guard is. The `rejects audit_id values that could escape the audit-progress directory` test bypasses Zod and passes `../escape` through the handler directly to confirm the guard fires.

### Instructions content

The instructional body lives in `instructions.ts` as a single `MEGA_AUDIT_INSTRUCTIONS` string with `renderInstructions({ since })` doing a `replaceAll('SINCE_DATE', since)` substitution. Phases are: 0 branch+bootstrap (uses optional `ensure_work_console_branch` / `bootstrap_work_console`), 1 inventory (uses optional `list_available_mcp_servers` with a `tools/list` fallback that groups by `mcp__<server>__*` prefix), 2 polling (per-source budgets documented for Slack, GitHub, Linear, Gmail, Calendar, Notion, HubSpot etc.), 3 aggregate (one structured JSON input under the per-source budget), 4 synthesize (identity, ranked priorities, top stakeholders, voice patterns, open loops, programme detection), 5 write (drops `contexts/`, `rules/`, `work/`, `daily/` files using work-console write tools if present, otherwise emits the full package as a chat message).

`instructions.test.ts` enforces that every backticked snake_case identifier in the prompt is either in `REGISTERED_TOOLS` (the tools `apps/mcp-local/src/cli.ts` actually wires up), in `OPTIONAL_TOOLS` (tools the prompt references with an "if available" qualifier and a documented fallback), or in `SCHEMA_FIELDS_ALLOWLIST` (schema field names like `audit_id`, `payload_json`). Adding a new tool reference to the prompt without making one of those three choices fails the test.

### Files

- `packages/contracts/src/index.ts` + `index.test.ts`: Zod schemas + the polling-source refinement test
- `packages/mcp-server/src/tools/builtin/mega-audit/{index,instructions,start-mega-audit,record-audit-progress}.ts` + tests
- `packages/mcp-server/src/index.ts`: re-exports the two `create*` factories + `MEGA_AUDIT_INSTRUCTIONS` + `renderInstructions`
- `apps/mcp-local/src/cli.ts`: registers both tools in `runMcpServer`
- `apps/mcp-local/src/cli.smoke.test.ts`: asserts both names appear in the compiled binary's `tools/list`

### Follow-ups

- `/mega-audit` slash command wrapping `start_mega_audit` lands after #54 (prompt registry) merges
- Live UI tailer is PR #61, it reads from the same `<data-dir>/audit-progress/<audit_id>.jsonl` path

</details>
