### PR TITLE
feat(recall): semantic-search MCP tool over evidence_log

### DIFF
--- a/apps/mcp-local/src/cli.smoke.test.ts
+++ b/apps/mcp-local/src/cli.smoke.test.ts
@@ -70,6 +70,7 @@ describe('slopweaver bin (compiled CLI)', () => {
       expect(names).toContain('get_freshness');
       expect(names).toContain('catch_me_up');
       expect(names).toContain('search_work_context');
+      expect(names).toContain('recall');
 
       const ping = list.tools.find((t) => t.name === 'ping');
       expect(ping?.inputSchema.type).toBe('object');

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -46,6 +46,7 @@ import {
   createGetFreshnessTool,
   createMcpServer,
   createPingTool,
+  createRecallTool,
   createSearchWorkContextTool,
   createStartSessionTool,
   type StartSessionPoller,
@@ -171,6 +172,7 @@ async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void
       createGetFreshnessTool(),
       createCatchMeUpTool(),
       createSearchWorkContextTool(),
+      createRecallTool(),
     ],
   });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -167,7 +167,17 @@ export type RecallArgs = z.infer<typeof RecallArgs>;
 const RecallHitSchema = z
   .object({
     evidence: EvidenceLogEntry,
-    score: z.number().min(0).max(1),
+    /**
+     * Cosine similarity of query + evidence embeddings. The embedder
+     * is contracted to return L2-normalized vectors, so this is the
+     * true dot product in `[-1, 1]` — not a remapped/clamped variant.
+     * The `recall` tool itself filters non-positive scores out before
+     * returning, so in practice values are `(0, 1]`, but the wire
+     * contract preserves the underlying range so a future embedder
+     * that wants to expose anti-correlated hits doesn't need a
+     * breaking schema change.
+     */
+    score: z.number().min(-1).max(1),
   })
   .strict();
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -143,3 +143,40 @@ export const SearchWorkContextResult = z
   })
   .strict();
 export type SearchWorkContextResult = z.infer<typeof SearchWorkContextResult>;
+
+// --- Semantic recall over the evidence_log ---------------------------
+
+export const RecallArgs = z
+  .object({
+    /** The natural-language query to match against evidence titles + bodies. */
+    query: NonEmptyStringSchema,
+    /** Max rows to return. 1–25; defaults to 10. */
+    limit: z.number().int().positive().max(25).optional(),
+    /** Optional filters; same shape as `search_work_context`. */
+    filters: z
+      .object({
+        integration: NonEmptyStringSchema.optional(),
+        kind: NonEmptyStringSchema.optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+export type RecallArgs = z.infer<typeof RecallArgs>;
+
+const RecallHitSchema = z
+  .object({
+    evidence: EvidenceLogEntry,
+    score: z.number().min(0).max(1),
+  })
+  .strict();
+
+export const RecallResult = z
+  .object({
+    hits: z.array(RecallHitSchema),
+    generated_at: IsoDatetimeSchema,
+    /** Marker for which embedder produced the scores — lets the live UI label the tab honestly. */
+    embedder: NonEmptyStringSchema,
+  })
+  .strict();
+export type RecallResult = z.infer<typeof RecallResult>;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -24,6 +24,8 @@ export { createGetFreshnessTool } from './tools/builtin/get-freshness.ts';
 export type { CreateGetFreshnessToolArgs } from './tools/builtin/get-freshness.ts';
 export { createSearchWorkContextTool } from './tools/builtin/search-work-context.ts';
 export type { CreateSearchWorkContextToolArgs } from './tools/builtin/search-work-context.ts';
+export { createRecallTool, createHashBagEmbedder, cosineSimilarity } from './tools/builtin/recall/index.ts';
+export type { CreateRecallToolArgs, Embedder } from './tools/builtin/recall/index.ts';
 export { createStartSessionTool } from './tools/composite/start-session.ts';
 export type {
   CreateStartSessionToolArgs,

--- a/packages/mcp-server/src/tools/builtin/recall/embedder.test.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/embedder.test.ts
@@ -1,5 +1,5 @@
 /**
- * Pure-function tests for the hash-bag embedder + cosine similarity.
+ * Pure-function tests for the signed-hash-bag embedder + cosine similarity.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -8,30 +8,30 @@ import { cosineSimilarity, createHashBagEmbedder } from './embedder.ts';
 describe('createHashBagEmbedder', () => {
   const embedder = createHashBagEmbedder();
 
-  it('produces a normalized vector of the configured dimensions', () => {
-    const v = embedder.embed('hello world');
+  it('produces a normalized vector of the configured dimensions', async () => {
+    const v = await embedder.embed('hello world');
     expect(v.length).toBe(256);
     let norm = 0;
     for (const x of v) norm += x * x;
     expect(Math.sqrt(norm)).toBeCloseTo(1, 5);
   });
 
-  it('is deterministic — same input → identical vector', () => {
-    const a = embedder.embed('foo bar baz');
-    const b = embedder.embed('foo bar baz');
+  it('is deterministic — same input → identical vector', async () => {
+    const a = await embedder.embed('foo bar baz');
+    const b = await embedder.embed('foo bar baz');
     expect(Array.from(a)).toEqual(Array.from(b));
   });
 
-  it('returns a zero vector for input with only stopwords + 1-char tokens', () => {
-    const v = embedder.embed('a the of an and');
+  it('returns a zero vector for input with only stopwords + 1-char tokens', async () => {
+    const v = await embedder.embed('a the of an and');
     let nonzero = 0;
     for (const x of v) if (x !== 0) nonzero += 1;
     expect(nonzero).toBe(0);
   });
 
-  it('is case-insensitive', () => {
-    const a = embedder.embed('Hello World');
-    const b = embedder.embed('hello world');
+  it('is case-insensitive', async () => {
+    const a = await embedder.embed('Hello World');
+    const b = await embedder.embed('hello world');
     expect(Array.from(a)).toEqual(Array.from(b));
   });
 
@@ -39,33 +39,77 @@ describe('createHashBagEmbedder', () => {
     expect(embedder.name).toBe('hash-bag-256');
     expect(embedder.dimensions).toBe(256);
   });
+
+  it('produces signed components (not just non-negative counts)', async () => {
+    // Signed hashing assigns each token a +/-1 sign. Across a moderately
+    // diverse vocabulary we expect both polarities to appear; a purely
+    // non-negative vector would mean the sign bit isn't being applied.
+    const v = await embedder.embed(
+      'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega',
+    );
+    let hasPositive = false;
+    let hasNegative = false;
+    for (const x of v) {
+      if (x > 0) hasPositive = true;
+      if (x < 0) hasNegative = true;
+    }
+    expect(hasPositive).toBe(true);
+    expect(hasNegative).toBe(true);
+  });
 });
 
 describe('cosineSimilarity', () => {
   const embedder = createHashBagEmbedder();
 
-  it('returns 1.0 for identical inputs', () => {
-    const v = embedder.embed('alpha beta gamma');
+  it('returns 1.0 for identical inputs', async () => {
+    const v = await embedder.embed('alpha beta gamma');
     expect(cosineSimilarity(v, v)).toBeCloseTo(1, 5);
   });
 
-  it('returns ~0 for inputs with no shared tokens', () => {
-    const a = embedder.embed('alpha beta gamma');
-    const b = embedder.embed('completely different lexicon entirely');
-    expect(cosineSimilarity(a, b)).toBeLessThan(0.2);
+  it('returns ~0 for inputs with no shared tokens', async () => {
+    const a = await embedder.embed('alpha beta gamma');
+    const b = await embedder.embed('completely different lexicon entirely');
+    // Signed hashing collision-cancels in expectation; unrelated single-token
+    // pairs occasionally still spike via collisions, but multi-token disjoint
+    // corpora should sit well under 0.05.
+    expect(Math.abs(cosineSimilarity(a, b))).toBeLessThan(0.05);
   });
 
-  it('returns a value in [0, 1] for partial overlap', () => {
-    const a = embedder.embed('alpha beta gamma');
-    const b = embedder.embed('alpha delta epsilon');
+  it('returns a value in [-1, 1] for partial overlap (positive on shared tokens)', async () => {
+    const a = await embedder.embed('alpha beta gamma');
+    const b = await embedder.embed('alpha delta epsilon');
     const score = cosineSimilarity(a, b);
     expect(score).toBeGreaterThan(0);
     expect(score).toBeLessThan(1);
   });
 
-  it('returns 0 for mismatched dimensions', () => {
-    const a = createHashBagEmbedder({ dimensions: 128 }).embed('test');
-    const b = createHashBagEmbedder({ dimensions: 256 }).embed('test');
+  it('keeps known unsigned-hashing collision pairs near zero', async () => {
+    // The unsigned bag-of-buckets variant scored these greek-letter pairs
+    // at 1.0 because their sha1-mod-256 buckets happened to collide. The
+    // signed variant has the same bucket collision but an opposing sign
+    // bit, so the dot product drops back to the disjoint-vocab baseline.
+    const pairs: ReadonlyArray<readonly [string, string]> = [
+      ['theta', 'tau'],
+      ['epsilon', 'omega'],
+    ];
+    for (const [left, right] of pairs) {
+      const a = await embedder.embed(left);
+      const b = await embedder.embed(right);
+      // Single-token collisions can still spike +/-1 on the few buckets
+      // they occupy. The point is that they're no longer pinned to +1.
+      expect(cosineSimilarity(a, b)).toBeLessThan(0.999);
+    }
+  });
+
+  it('keeps a multi-token disjoint corpus tightly near zero', async () => {
+    const a = await embedder.embed('payments billing invoice subscription customer renewal');
+    const b = await embedder.embed('compiler lexer parser token grammar production');
+    expect(Math.abs(cosineSimilarity(a, b))).toBeLessThan(0.05);
+  });
+
+  it('returns 0 for mismatched dimensions', async () => {
+    const a = await createHashBagEmbedder({ dimensions: 128 }).embed('test');
+    const b = await createHashBagEmbedder({ dimensions: 256 }).embed('test');
     expect(cosineSimilarity(a, b)).toBe(0);
   });
 });

--- a/packages/mcp-server/src/tools/builtin/recall/embedder.test.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/embedder.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure-function tests for the hash-bag embedder + cosine similarity.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { cosineSimilarity, createHashBagEmbedder } from './embedder.ts';
+
+describe('createHashBagEmbedder', () => {
+  const embedder = createHashBagEmbedder();
+
+  it('produces a normalized vector of the configured dimensions', () => {
+    const v = embedder.embed('hello world');
+    expect(v.length).toBe(256);
+    let norm = 0;
+    for (const x of v) norm += x * x;
+    expect(Math.sqrt(norm)).toBeCloseTo(1, 5);
+  });
+
+  it('is deterministic — same input → identical vector', () => {
+    const a = embedder.embed('foo bar baz');
+    const b = embedder.embed('foo bar baz');
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it('returns a zero vector for input with only stopwords + 1-char tokens', () => {
+    const v = embedder.embed('a the of an and');
+    let nonzero = 0;
+    for (const x of v) if (x !== 0) nonzero += 1;
+    expect(nonzero).toBe(0);
+  });
+
+  it('is case-insensitive', () => {
+    const a = embedder.embed('Hello World');
+    const b = embedder.embed('hello world');
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it('exposes a stable name + dimensions', () => {
+    expect(embedder.name).toBe('hash-bag-256');
+    expect(embedder.dimensions).toBe(256);
+  });
+});
+
+describe('cosineSimilarity', () => {
+  const embedder = createHashBagEmbedder();
+
+  it('returns 1.0 for identical inputs', () => {
+    const v = embedder.embed('alpha beta gamma');
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1, 5);
+  });
+
+  it('returns ~0 for inputs with no shared tokens', () => {
+    const a = embedder.embed('alpha beta gamma');
+    const b = embedder.embed('completely different lexicon entirely');
+    expect(cosineSimilarity(a, b)).toBeLessThan(0.2);
+  });
+
+  it('returns a value in [0, 1] for partial overlap', () => {
+    const a = embedder.embed('alpha beta gamma');
+    const b = embedder.embed('alpha delta epsilon');
+    const score = cosineSimilarity(a, b);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(1);
+  });
+
+  it('returns 0 for mismatched dimensions', () => {
+    const a = createHashBagEmbedder({ dimensions: 128 }).embed('test');
+    const b = createHashBagEmbedder({ dimensions: 256 }).embed('test');
+    expect(cosineSimilarity(a, b)).toBe(0);
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/recall/embedder.test.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/embedder.test.ts
@@ -10,7 +10,7 @@ describe('createHashBagEmbedder', () => {
 
   it('produces a normalized vector of the configured dimensions', async () => {
     const v = await embedder.embed('hello world');
-    expect(v.length).toBe(256);
+    expect(v.length).toBe(4096);
     let norm = 0;
     for (const x of v) norm += x * x;
     expect(Math.sqrt(norm)).toBeCloseTo(1, 5);
@@ -36,8 +36,8 @@ describe('createHashBagEmbedder', () => {
   });
 
   it('exposes a stable name + dimensions', () => {
-    expect(embedder.name).toBe('hash-bag-256');
-    expect(embedder.dimensions).toBe(256);
+    expect(embedder.name).toBe('hash-bag-4096');
+    expect(embedder.dimensions).toBe(4096);
   });
 
   it('produces signed components (not just non-negative counts)', async () => {
@@ -86,8 +86,14 @@ describe('cosineSimilarity', () => {
   it('keeps known unsigned-hashing collision pairs near zero', async () => {
     // The unsigned bag-of-buckets variant scored these greek-letter pairs
     // at 1.0 because their sha1-mod-256 buckets happened to collide. The
-    // signed variant has the same bucket collision but an opposing sign
-    // bit, so the dot product drops back to the disjoint-vocab baseline.
+    // single-hash signed variant fixed bucket-only collisions but still
+    // pinned to +1.0 when the sign bit also matched (e.g. `epsilon`/`chi`).
+    // Multi-hash sketching (k=3, 4096 buckets) drops the all-buckets-
+    // collide probability to ~1e-12; single-bucket collisions can still
+    // contribute 1/k = ~0.333 to cosine when the sign matches, so the
+    // threshold is set to 0.5 for the worst-case single-token regime.
+    // Multi-token corpora cancel collisions in expectation — see the
+    // multi-token disjoint-corpus test below for the tighter bound.
     const pairs: ReadonlyArray<readonly [string, string]> = [
       ['theta', 'tau'],
       ['epsilon', 'omega'],
@@ -95,9 +101,53 @@ describe('cosineSimilarity', () => {
     for (const [left, right] of pairs) {
       const a = await embedder.embed(left);
       const b = await embedder.embed(right);
-      // Single-token collisions can still spike +/-1 on the few buckets
-      // they occupy. The point is that they're no longer pinned to +1.
-      expect(cosineSimilarity(a, b)).toBeLessThan(0.999);
+      expect(Math.abs(cosineSimilarity(a, b))).toBeLessThan(0.5);
+    }
+  });
+
+  it('keeps disjoint single-token pairs from collapsing to +1.0 (multi-hash regression)', async () => {
+    // Iter-2 of PR #70 found that signed feature hashing with a single
+    // (bucket, sign) pair per token still produced false +1.0 scores
+    // when two unrelated tokens collided on BOTH bucket AND sign — e.g.
+    // `epsilon`/`chi` and `xi`/`phi` under the 256-bucket variant. The
+    // fix is multi-hash sketching (k=3 independent bucket+sign pairs
+    // per token), which drops all-pairs-collide probability to ~1e-12
+    // at 4096 buckets. This test sweeps a broad set of disjoint Greek
+    // and Latin token pairs and asserts NONE score above 0.3 (loose
+    // upper bound — actual scores cluster near zero, often exactly 0
+    // when no bucket overlap occurs at all).
+    const pairs: ReadonlyArray<readonly [string, string]> = [
+      // Pairs observed to false-positive in iter-2:
+      ['epsilon', 'chi'],
+      ['xi', 'phi'],
+      // Other Greek letters paired arbitrarily:
+      ['alpha', 'beta'],
+      ['gamma', 'delta'],
+      ['zeta', 'eta'],
+      ['theta', 'iota'],
+      ['kappa', 'lambda'],
+      ['mu', 'nu'],
+      ['omicron', 'rho'],
+      ['sigma', 'upsilon'],
+      ['psi', 'omega'],
+      // Latin/English pairs across unrelated domains:
+      ['payment', 'compiler'],
+      ['invoice', 'lexer'],
+      ['customer', 'parser'],
+      ['subscription', 'grammar'],
+      ['renewal', 'token'],
+      ['billing', 'production'],
+      ['refund', 'syntax'],
+      ['dashboard', 'inference'],
+      ['analytics', 'gradient'],
+      ['warehouse', 'neuron'],
+      ['router', 'embedding'],
+    ];
+    for (const [left, right] of pairs) {
+      const a = await embedder.embed(left);
+      const b = await embedder.embed(right);
+      const score = cosineSimilarity(a, b);
+      expect(Math.abs(score)).toBeLessThan(0.3);
     }
   });
 

--- a/packages/mcp-server/src/tools/builtin/recall/embedder.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/embedder.ts
@@ -1,7 +1,8 @@
 /**
- * Deterministic hash-bag-of-words embedder. Tokenizes input, hashes
- * each token into a fixed-dimensional vector slot, accumulates counts,
- * L2-normalizes the result. Pure function, zero deps.
+ * Deterministic signed-feature-hashing embedder. Tokenizes input,
+ * hashes each token into a fixed-dimensional vector slot AND a sign
+ * bit, accumulates signed counts, L2-normalizes the result. Pure
+ * function, zero deps.
  *
  * Not as semantically rich as a real local model (bge-small etc.) but:
  *
@@ -10,21 +11,38 @@
  * 2. Fast — no model download, no warm-up, no GC pressure on a
  *    bge-small-class WASM runtime.
  * 3. Zero deps — node:crypto is in the standard library.
- * 4. Drop-in swappable — the embedder interface stays the same, so a
+ * 4. Drop-in swappable — the embedder interface is async, so a
  *    follow-up PR can substitute a real model without touching the
  *    `recall` tool.
  *
+ * **Why signed hashing.** A naive unsigned bag-of-buckets collides
+ * unrelated tokens additively: if `theta` and `tau` happen to map to
+ * the same bucket they both increment it, scoring 1.0 on cosine
+ * despite sharing no vocabulary. The signed variant assigns each
+ * token an independent +/-1 sign from a separate hash bit; collisions
+ * still happen but contribute zero in expectation, so unrelated
+ * corpora score near zero rather than near one. Reference: Weinberger
+ * et al., "Feature Hashing for Large Scale Multitask Learning" (2009).
+ *
  * The 256-dimensional fingerprint gives reasonable substring-overlap
  * similarity at low cost. Cosine similarity of two embeddings is what
- * `recall` ranks on.
+ * `recall` ranks on. Vectors are L2-normalized inside `embed`, so the
+ * similarity helper is a plain dot product in [-1, 1].
  */
 
 import { createHash } from 'node:crypto';
 
+/**
+ * Embedder interface — async by design so a real local model
+ * (bge-small via @xenova/transformers, candle, etc.) is drop-in
+ * swappable. Implementations MUST return an L2-normalized
+ * `Float32Array` of length `dimensions`; `cosineSimilarity` assumes
+ * unit vectors and skips re-normalizing.
+ */
 export type Embedder = {
   readonly name: string;
   readonly dimensions: number;
-  readonly embed: (text: string) => Float32Array;
+  readonly embed: (text: string) => Promise<Float32Array>;
 };
 
 const DEFAULT_DIMENSIONS = 256;
@@ -67,11 +85,23 @@ function tokenize(text: string): string[] {
     .filter((t) => t.length >= 2 && !STOPWORDS.has(t));
 }
 
-function hashToBucket(token: string, dimensions: number): number {
-  // sha1 → first 4 bytes → 32-bit unsigned int → modulo dimensions.
+/**
+ * Hash a token to (bucket, sign). Both come from the same sha1
+ * digest but use independent byte ranges so they're statistically
+ * uncorrelated:
+ *  - bucket: first 4 bytes → uint32 → modulo dimensions
+ *  - sign:   byte 4, low bit → -1 or +1
+ */
+function hashTokenSigned({ token, dimensions }: { token: string; dimensions: number }): {
+  bucket: number;
+  sign: 1 | -1;
+} {
   const digest = createHash('sha1').update(token).digest();
   const first = digest.readUInt32BE(0);
-  return first % dimensions;
+  const bucket = first % dimensions;
+  const signByte = digest[4] ?? 0;
+  const sign: 1 | -1 = (signByte & 1) === 0 ? 1 : -1;
+  return { bucket, sign };
 }
 
 export function createHashBagEmbedder(args: { dimensions?: number } = {}): Embedder {
@@ -83,8 +113,8 @@ export function createHashBagEmbedder(args: { dimensions?: number } = {}): Embed
       const vec = new Float32Array(dimensions);
       const tokens = tokenize(text);
       for (const token of tokens) {
-        const bucket = hashToBucket(token, dimensions);
-        vec[bucket] = (vec[bucket] ?? 0) + 1;
+        const { bucket, sign } = hashTokenSigned({ token, dimensions });
+        vec[bucket] = (vec[bucket] ?? 0) + sign;
       }
       // L2-normalize so cosine similarity = dot product.
       let norm = 0;
@@ -98,15 +128,18 @@ export function createHashBagEmbedder(args: { dimensions?: number } = {}): Embed
           vec[i] = (vec[i] ?? 0) / norm;
         }
       }
-      return vec;
+      return Promise.resolve(vec);
     },
   };
 }
 
 /**
- * Cosine similarity of two L2-normalized embedding vectors. Since both
- * inputs are unit vectors, this is just the dot product. Returns a
- * value in [0, 1] — the clamp catches floating-point overshoot.
+ * Cosine similarity of two L2-normalized embedding vectors. Since
+ * both inputs are unit vectors, this is just the dot product, which
+ * lives in `[-1, 1]`. The clamp catches floating-point overshoot at
+ * the bounds; we do NOT remap to `[0, 1]` — callers that want a
+ * non-negative score should filter or shift downstream. Returns `0`
+ * for mismatched dimensions (defensive; ranks the row out).
  */
 export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
   if (a.length !== b.length) return 0;
@@ -114,7 +147,7 @@ export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
   for (let i = 0; i < a.length; i += 1) {
     dot += (a[i] ?? 0) * (b[i] ?? 0);
   }
-  if (dot < 0) return 0;
+  if (dot < -1) return -1;
   if (dot > 1) return 1;
   return dot;
 }

--- a/packages/mcp-server/src/tools/builtin/recall/embedder.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/embedder.ts
@@ -24,7 +24,19 @@
  * corpora score near zero rather than near one. Reference: Weinberger
  * et al., "Feature Hashing for Large Scale Multitask Learning" (2009).
  *
- * The 256-dimensional fingerprint gives reasonable substring-overlap
+ * **Why multi-hash sketching.** Single-hash signed feature hashing
+ * still pins unrelated single-token inputs to +1.0 cosine when their
+ * one (bucket, sign) pair happens to collide — for the previous
+ * 256-bucket variant `epsilon`/`chi` and `xi`/`phi` both did this.
+ * We map each token into k=3 (bucket, sign) pairs derived from
+ * independent slices of the same sha1 digest; vectors accumulate
+ * `(1/sqrt(k)) * sign` into each of the k buckets. The probability
+ * that two unrelated tokens collide on ALL k bucket-sign pairs is
+ * `(1 / (2 * bucket_count))^k`, which for 4096 buckets and k=3 is
+ * ~1.8e-12 — vanishingly small. The `1/sqrt(k)` scaling keeps each
+ * token's contribution unit-norm regardless of k.
+ *
+ * The 4096-dimensional fingerprint gives reasonable substring-overlap
  * similarity at low cost. Cosine similarity of two embeddings is what
  * `recall` ranks on. Vectors are L2-normalized inside `embed`, so the
  * similarity helper is a plain dot product in [-1, 1].
@@ -45,7 +57,18 @@ export type Embedder = {
   readonly embed: (text: string) => Promise<Float32Array>;
 };
 
-const DEFAULT_DIMENSIONS = 256;
+const DEFAULT_DIMENSIONS = 4096;
+
+/**
+ * Number of independent (bucket, sign) pairs each token contributes
+ * to. With k=3 and 4096 buckets the all-pairs-collide probability
+ * between two distinct tokens is ~1.8e-12, which moves false-positive
+ * +1.0 cosine scores from "observed in practice" to "won't happen in
+ * any realistic test or corpus." sha1 produces 20 bytes; each
+ * (bucket, sign) pair consumes 5 (4 for bucket + 1 for sign), so k=3
+ * fits in one digest with bytes 0..14.
+ */
+const HASH_COPIES = 3;
 
 /** Tokenize: lowercase, split on non-word, strip 1-char tokens + stopwords. */
 const STOPWORDS = new Set([
@@ -86,26 +109,36 @@ function tokenize(text: string): string[] {
 }
 
 /**
- * Hash a token to (bucket, sign). Both come from the same sha1
- * digest but use independent byte ranges so they're statistically
- * uncorrelated:
- *  - bucket: first 4 bytes → uint32 → modulo dimensions
- *  - sign:   byte 4, low bit → -1 or +1
+ * Hash a token to k independent (bucket, sign) pairs. All k pairs
+ * come from the same sha1 digest but use disjoint byte ranges so
+ * they're statistically uncorrelated. For each copy i in 0..k-1:
+ *  - bucket: bytes (5*i)..(5*i+3) as uint32 BE → modulo dimensions
+ *  - sign:   byte (5*i+4), low bit → -1 or +1
+ *
+ * sha1 produces 20 bytes; HASH_COPIES=3 uses bytes 0..14.
  */
-function hashTokenSigned({ token, dimensions }: { token: string; dimensions: number }): {
+function hashTokenSigned({ token, dimensions }: { token: string; dimensions: number }): ReadonlyArray<{
   bucket: number;
   sign: 1 | -1;
-} {
+}> {
   const digest = createHash('sha1').update(token).digest();
-  const first = digest.readUInt32BE(0);
-  const bucket = first % dimensions;
-  const signByte = digest[4] ?? 0;
-  const sign: 1 | -1 = (signByte & 1) === 0 ? 1 : -1;
-  return { bucket, sign };
+  const pairs: Array<{ bucket: number; sign: 1 | -1 }> = [];
+  for (let i = 0; i < HASH_COPIES; i += 1) {
+    const offset = i * 5;
+    const bucket = digest.readUInt32BE(offset) % dimensions;
+    const signByte = digest[offset + 4] ?? 0;
+    const sign: 1 | -1 = (signByte & 1) === 0 ? 1 : -1;
+    pairs.push({ bucket, sign });
+  }
+  return pairs;
 }
 
 export function createHashBagEmbedder(args: { dimensions?: number } = {}): Embedder {
   const dimensions = args.dimensions ?? DEFAULT_DIMENSIONS;
+  // Per-copy scaling so each token's combined contribution across the
+  // k buckets has L2 norm 1, matching the single-hash variant's
+  // behavior. Independent of token vocabulary or token count.
+  const perCopyWeight = 1 / Math.sqrt(HASH_COPIES);
   return {
     name: `hash-bag-${dimensions}`,
     dimensions,
@@ -113,8 +146,10 @@ export function createHashBagEmbedder(args: { dimensions?: number } = {}): Embed
       const vec = new Float32Array(dimensions);
       const tokens = tokenize(text);
       for (const token of tokens) {
-        const { bucket, sign } = hashTokenSigned({ token, dimensions });
-        vec[bucket] = (vec[bucket] ?? 0) + sign;
+        const pairs = hashTokenSigned({ token, dimensions });
+        for (const { bucket, sign } of pairs) {
+          vec[bucket] = (vec[bucket] ?? 0) + sign * perCopyWeight;
+        }
       }
       // L2-normalize so cosine similarity = dot product.
       let norm = 0;

--- a/packages/mcp-server/src/tools/builtin/recall/embedder.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/embedder.ts
@@ -1,0 +1,120 @@
+/**
+ * Deterministic hash-bag-of-words embedder. Tokenizes input, hashes
+ * each token into a fixed-dimensional vector slot, accumulates counts,
+ * L2-normalizes the result. Pure function, zero deps.
+ *
+ * Not as semantically rich as a real local model (bge-small etc.) but:
+ *
+ * 1. Deterministic — tests are stable; same input always gives the
+ *    same vector.
+ * 2. Fast — no model download, no warm-up, no GC pressure on a
+ *    bge-small-class WASM runtime.
+ * 3. Zero deps — node:crypto is in the standard library.
+ * 4. Drop-in swappable — the embedder interface stays the same, so a
+ *    follow-up PR can substitute a real model without touching the
+ *    `recall` tool.
+ *
+ * The 256-dimensional fingerprint gives reasonable substring-overlap
+ * similarity at low cost. Cosine similarity of two embeddings is what
+ * `recall` ranks on.
+ */
+
+import { createHash } from 'node:crypto';
+
+export type Embedder = {
+  readonly name: string;
+  readonly dimensions: number;
+  readonly embed: (text: string) => Float32Array;
+};
+
+const DEFAULT_DIMENSIONS = 256;
+
+/** Tokenize: lowercase, split on non-word, strip 1-char tokens + stopwords. */
+const STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'as',
+  'at',
+  'be',
+  'but',
+  'by',
+  'for',
+  'from',
+  'has',
+  'have',
+  'in',
+  'is',
+  'it',
+  'its',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'this',
+  'to',
+  'was',
+  'were',
+  'will',
+  'with',
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .filter((t) => t.length >= 2 && !STOPWORDS.has(t));
+}
+
+function hashToBucket(token: string, dimensions: number): number {
+  // sha1 → first 4 bytes → 32-bit unsigned int → modulo dimensions.
+  const digest = createHash('sha1').update(token).digest();
+  const first = digest.readUInt32BE(0);
+  return first % dimensions;
+}
+
+export function createHashBagEmbedder(args: { dimensions?: number } = {}): Embedder {
+  const dimensions = args.dimensions ?? DEFAULT_DIMENSIONS;
+  return {
+    name: `hash-bag-${dimensions}`,
+    dimensions,
+    embed: (text) => {
+      const vec = new Float32Array(dimensions);
+      const tokens = tokenize(text);
+      for (const token of tokens) {
+        const bucket = hashToBucket(token, dimensions);
+        vec[bucket] = (vec[bucket] ?? 0) + 1;
+      }
+      // L2-normalize so cosine similarity = dot product.
+      let norm = 0;
+      for (let i = 0; i < dimensions; i += 1) {
+        const v = vec[i] ?? 0;
+        norm += v * v;
+      }
+      norm = Math.sqrt(norm);
+      if (norm > 0) {
+        for (let i = 0; i < dimensions; i += 1) {
+          vec[i] = (vec[i] ?? 0) / norm;
+        }
+      }
+      return vec;
+    },
+  };
+}
+
+/**
+ * Cosine similarity of two L2-normalized embedding vectors. Since both
+ * inputs are unit vectors, this is just the dot product. Returns a
+ * value in [0, 1] — the clamp catches floating-point overshoot.
+ */
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  if (a.length !== b.length) return 0;
+  let dot = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    dot += (a[i] ?? 0) * (b[i] ?? 0);
+  }
+  if (dot < 0) return 0;
+  if (dot > 1) return 1;
+  return dot;
+}

--- a/packages/mcp-server/src/tools/builtin/recall/index.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Recall barrel. The tool itself plus the embedder interface and the
+ * default hash-bag implementation, so future PRs swapping in a real
+ * local model can import the interface without touching the tool body.
+ */
+
+export { createRecallTool } from './recall.ts';
+export type { CreateRecallToolArgs } from './recall.ts';
+export { createHashBagEmbedder, cosineSimilarity } from './embedder.ts';
+export type { Embedder } from './embedder.ts';

--- a/packages/mcp-server/src/tools/builtin/recall/recall.test.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/recall.test.ts
@@ -1,0 +1,111 @@
+/**
+ * End-to-end tests for the recall MCP tool. Seeds the evidence_log,
+ * queries, asserts ranked results + the wire-contract via Zod.
+ */
+
+import { RecallArgs, RecallResult } from '@slopweaver/contracts';
+import { createDb, evidenceLog } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRecallTool } from './recall.ts';
+
+const FIXED_NOW = 1_762_000_000_000;
+const ONE_MIN = 60 * 1000;
+
+describe('createRecallTool', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  function seedRow(overrides: Partial<typeof evidenceLog.$inferInsert>): number {
+    const base = {
+      integration: 'github',
+      externalId: `ext-${Math.random().toString(36).slice(2)}`,
+      kind: 'pull_request',
+      citationUrl: null,
+      title: 'Add widget',
+      body: null,
+      payloadJson: '{}',
+      occurredAtMs: FIXED_NOW - ONE_MIN,
+      firstSeenAtMs: FIXED_NOW - ONE_MIN,
+      lastSeenAtMs: FIXED_NOW - ONE_MIN,
+      createdAtMs: FIXED_NOW - ONE_MIN,
+      updatedAtMs: FIXED_NOW - ONE_MIN,
+    } satisfies typeof evidenceLog.$inferInsert;
+    return dbHandle.db
+      .insert(evidenceLog)
+      .values({ ...base, ...overrides })
+      .returning({ id: evidenceLog.id })
+      .get().id;
+  }
+
+  it('returns hits ranked by cosine similarity', async () => {
+    seedRow({ title: 'Authentication migration', body: 'Switching from PAT to OAuth tokens' });
+    seedRow({ title: 'Unrelated docs update', body: 'Fixing typos in CONTRIBUTING.md' });
+    seedRow({ title: 'OAuth scope changes', body: 'Adjusting OAuth scopes for the new flow' });
+
+    const tool = createRecallTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecallArgs.parse({ query: 'oauth authentication', limit: 5 }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = RecallResult.parse(result.value);
+      expect(parsed.hits.length).toBe(2); // the auth rows; not the typos row
+      expect(parsed.embedder).toBe('hash-bag-256');
+      expect(parsed.hits[0]?.score).toBeGreaterThan(parsed.hits[1]?.score ?? 1.1);
+    }
+  });
+
+  it('respects the limit argument', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      seedRow({ title: `auth widget ${i}`, body: 'oauth setup' });
+    }
+    const tool = createRecallTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecallArgs.parse({ query: 'auth', limit: 2 }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = RecallResult.parse(result.value);
+      expect(parsed.hits.length).toBe(2);
+    }
+  });
+
+  it('filters by integration when supplied', async () => {
+    seedRow({ integration: 'github', title: 'github auth' });
+    seedRow({ integration: 'slack', title: 'slack auth' });
+    const tool = createRecallTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecallArgs.parse({ query: 'auth', filters: { integration: 'slack' } }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = RecallResult.parse(result.value);
+      expect(parsed.hits.length).toBe(1);
+      expect(parsed.hits[0]?.evidence.integration).toBe('slack');
+    }
+  });
+
+  it('returns an empty hits list when nothing matches', async () => {
+    seedRow({ title: 'completely unrelated', body: 'lorem ipsum' });
+    const tool = createRecallTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecallArgs.parse({ query: 'oauth migration' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = RecallResult.parse(result.value);
+      expect(parsed.hits).toEqual([]);
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/recall/recall.test.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/recall.test.ts
@@ -95,6 +95,43 @@ describe('createRecallTool', () => {
     }
   });
 
+  it('filters by kind when supplied (pushed into SQL)', async () => {
+    seedRow({ integration: 'github', kind: 'pull_request', title: 'oauth pr' });
+    seedRow({ integration: 'github', kind: 'issue', title: 'oauth issue' });
+    const tool = createRecallTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecallArgs.parse({ query: 'oauth', filters: { kind: 'issue' } }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = RecallResult.parse(result.value);
+      expect(parsed.hits.length).toBe(1);
+      expect(parsed.hits[0]?.evidence.kind).toBe('issue');
+    }
+  });
+
+  it('combines integration + kind filters in SQL', async () => {
+    seedRow({ integration: 'github', kind: 'pull_request', title: 'oauth gh pr' });
+    seedRow({ integration: 'github', kind: 'issue', title: 'oauth gh issue' });
+    seedRow({ integration: 'slack', kind: 'message', title: 'oauth slack msg' });
+    const tool = createRecallTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecallArgs.parse({
+        query: 'oauth',
+        filters: { integration: 'github', kind: 'issue' },
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = RecallResult.parse(result.value);
+      expect(parsed.hits.length).toBe(1);
+      expect(parsed.hits[0]?.evidence.integration).toBe('github');
+      expect(parsed.hits[0]?.evidence.kind).toBe('issue');
+    }
+  });
+
   it('returns an empty hits list when nothing matches', async () => {
     seedRow({ title: 'completely unrelated', body: 'lorem ipsum' });
     const tool = createRecallTool({ now: () => FIXED_NOW });

--- a/packages/mcp-server/src/tools/builtin/recall/recall.test.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/recall.test.ts
@@ -58,7 +58,7 @@ describe('createRecallTool', () => {
     if (result.isOk()) {
       const parsed = RecallResult.parse(result.value);
       expect(parsed.hits.length).toBe(2); // the auth rows; not the typos row
-      expect(parsed.embedder).toBe('hash-bag-256');
+      expect(parsed.embedder).toBe('hash-bag-4096');
       expect(parsed.hits[0]?.score).toBeGreaterThan(parsed.hits[1]?.score ?? 1.1);
     }
   });

--- a/packages/mcp-server/src/tools/builtin/recall/recall.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/recall.ts
@@ -3,10 +3,17 @@
  * row we embed `title + ' ' + body` (best-effort: empty fields skipped)
  * and rank by cosine similarity with the query embedding.
  *
- * v1.1 first cut uses the deterministic hash-bag embedder (zero deps,
- * pure functions, fast). A follow-up will swap in a local transformer
- * model (bge-small via @xenova/transformers) behind the same
- * `Embedder` interface — the tool body doesn't change.
+ * v1.1 first cut uses the deterministic signed-hash-bag embedder
+ * (zero deps, pure function, fast). The embedder interface is async
+ * so a follow-up can swap in a local transformer model (bge-small via
+ * @xenova/transformers) behind the same `Embedder` interface — the
+ * tool body doesn't change.
+ *
+ * The embedder is contracted to return L2-normalized vectors;
+ * `cosineSimilarity` is a plain dot product in `[-1, 1]`. We filter
+ * non-positive scores out — negatives indicate the document is
+ * actively anti-correlated under signed hashing, which is noise we
+ * don't want to surface.
  *
  * No migration here: embeddings are computed per query against the
  * live evidence_log. That's fine up to ~10K rows; beyond that we'll
@@ -16,7 +23,7 @@
 import { RecallArgs, RecallResult, type EvidenceLogEntry } from '@slopweaver/contracts';
 import { evidenceLog } from '@slopweaver/db';
 import { ok } from '@slopweaver/errors';
-import { eq } from 'drizzle-orm';
+import { and, eq, type SQL } from 'drizzle-orm';
 import { defineTool, type Tool } from '../../registry.ts';
 import { shapeEvidenceRow } from '../../shape-evidence.ts';
 import { cosineSimilarity, createHashBagEmbedder, type Embedder } from './embedder.ts';
@@ -37,31 +44,34 @@ export function createRecallTool(args: CreateRecallToolArgs = {}): Tool {
   return defineTool({
     name: 'recall',
     description:
-      'Semantic search over evidence_log rows. Embeds the query and every (title + body) pair, ranks by cosine similarity, returns the top-N matches with their scores. v1.1 first cut uses a deterministic hash-bag embedder; a real local model will land in a follow-up behind the same interface.',
+      'Semantic search over evidence_log rows. Embeds the query and every (title + body) pair, ranks by cosine similarity, returns the top-N matches with their scores. v1.1 first cut uses a deterministic signed-hash-bag embedder; a real local model will land in a follow-up behind the same async interface.',
     inputSchema: RecallArgs,
     outputSchema: RecallResult,
     handler: async ({ input, ctx: { db } }) => {
       const limit = input.limit ?? DEFAULT_LIMIT;
-      const queryVec = embedder.embed(input.query);
+      const queryVec = await embedder.embed(input.query);
 
-      let query = db.select().from(evidenceLog).$dynamic();
+      // Compose `integration` + `kind` filters in SQL via `and(...)` so
+      // the dataset gets filtered before it hits JS — important once the
+      // evidence_log grows past in-memory-sort scale.
+      const conditions: SQL[] = [];
       if (input.filters?.integration !== undefined) {
-        query = query.where(eq(evidenceLog.integration, input.filters.integration));
+        conditions.push(eq(evidenceLog.integration, input.filters.integration));
       }
-      // Drizzle's $dynamic builder only supports one .where() chain, so we
-      // can't easily AND both filters. Materialize and filter `kind` in JS
-      // for v1.1 first cut — the dataset stays small (<10K rows) so the
-      // overhead is negligible. A follow-up can move both filters into SQL
-      // when the row count grows.
-      const rows = query.all();
-      const filteredKind = input.filters?.kind;
-      const candidateRows = filteredKind === undefined ? rows : rows.filter((r) => r.kind === filteredKind);
+      if (input.filters?.kind !== undefined) {
+        conditions.push(eq(evidenceLog.kind, input.filters.kind));
+      }
+      const whereExpr = conditions.length === 0 ? undefined : and(...conditions);
+      const rows =
+        whereExpr === undefined
+          ? db.select().from(evidenceLog).all()
+          : db.select().from(evidenceLog).where(whereExpr).all();
 
       const scored: { entry: EvidenceLogEntry; score: number }[] = [];
-      for (const row of candidateRows) {
+      for (const row of rows) {
         const text = [row.title ?? '', row.body ?? ''].filter((s) => s.length > 0).join(' ');
         if (text.length === 0) continue;
-        const docVec = embedder.embed(text);
+        const docVec = await embedder.embed(text);
         const score = cosineSimilarity(queryVec, docVec);
         if (score <= 0) continue;
         const shaped = shapeEvidenceRow(row);

--- a/packages/mcp-server/src/tools/builtin/recall/recall.ts
+++ b/packages/mcp-server/src/tools/builtin/recall/recall.ts
@@ -1,0 +1,81 @@
+/**
+ * `recall` MCP tool — semantic search across `evidence_log`. For each
+ * row we embed `title + ' ' + body` (best-effort: empty fields skipped)
+ * and rank by cosine similarity with the query embedding.
+ *
+ * v1.1 first cut uses the deterministic hash-bag embedder (zero deps,
+ * pure functions, fast). A follow-up will swap in a local transformer
+ * model (bge-small via @xenova/transformers) behind the same
+ * `Embedder` interface — the tool body doesn't change.
+ *
+ * No migration here: embeddings are computed per query against the
+ * live evidence_log. That's fine up to ~10K rows; beyond that we'll
+ * add a cached `embedding` column behind a feature flag.
+ */
+
+import { RecallArgs, RecallResult, type EvidenceLogEntry } from '@slopweaver/contracts';
+import { evidenceLog } from '@slopweaver/db';
+import { ok } from '@slopweaver/errors';
+import { eq } from 'drizzle-orm';
+import { defineTool, type Tool } from '../../registry.ts';
+import { shapeEvidenceRow } from '../../shape-evidence.ts';
+import { cosineSimilarity, createHashBagEmbedder, type Embedder } from './embedder.ts';
+
+const DEFAULT_LIMIT = 10;
+
+export type CreateRecallToolArgs = {
+  /** Override the embedder (tests + a future swap to a real model). */
+  embedder?: Embedder;
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  now?: () => number;
+};
+
+export function createRecallTool(args: CreateRecallToolArgs = {}): Tool {
+  const embedder = args.embedder ?? createHashBagEmbedder();
+  const now = args.now ?? Date.now;
+
+  return defineTool({
+    name: 'recall',
+    description:
+      'Semantic search over evidence_log rows. Embeds the query and every (title + body) pair, ranks by cosine similarity, returns the top-N matches with their scores. v1.1 first cut uses a deterministic hash-bag embedder; a real local model will land in a follow-up behind the same interface.',
+    inputSchema: RecallArgs,
+    outputSchema: RecallResult,
+    handler: async ({ input, ctx: { db } }) => {
+      const limit = input.limit ?? DEFAULT_LIMIT;
+      const queryVec = embedder.embed(input.query);
+
+      let query = db.select().from(evidenceLog).$dynamic();
+      if (input.filters?.integration !== undefined) {
+        query = query.where(eq(evidenceLog.integration, input.filters.integration));
+      }
+      // Drizzle's $dynamic builder only supports one .where() chain, so we
+      // can't easily AND both filters. Materialize and filter `kind` in JS
+      // for v1.1 first cut — the dataset stays small (<10K rows) so the
+      // overhead is negligible. A follow-up can move both filters into SQL
+      // when the row count grows.
+      const rows = query.all();
+      const filteredKind = input.filters?.kind;
+      const candidateRows = filteredKind === undefined ? rows : rows.filter((r) => r.kind === filteredKind);
+
+      const scored: { entry: EvidenceLogEntry; score: number }[] = [];
+      for (const row of candidateRows) {
+        const text = [row.title ?? '', row.body ?? ''].filter((s) => s.length > 0).join(' ');
+        if (text.length === 0) continue;
+        const docVec = embedder.embed(text);
+        const score = cosineSimilarity(queryVec, docVec);
+        if (score <= 0) continue;
+        const shaped = shapeEvidenceRow(row);
+        if (shaped === null) continue;
+        scored.push({ entry: shaped, score });
+      }
+      scored.sort((a, b) => b.score - a.score);
+      const hits = scored.slice(0, limit).map(({ entry, score }) => ({ evidence: entry, score }));
+
+      return ok({
+        hits,
+        generated_at: new Date(now()).toISOString(),
+        embedder: embedder.name,
+      });
+    },
+  });
+}


### PR DESCRIPTION
**Problem**
Claude Code couldn't ask "show me anything in the evidence log about OAuth migration" and get ranked results. Substring matching in `search_work_context` misses paraphrases, and there was no semantic-search seam to plug a real local model into later.

**Solution**
New `recall` MCP tool that embeds the query and every row's `title + body`, then ranks by cosine similarity. The embedder sits behind an async `Embedder` interface so a real local model (bge-small etc.) drops in later without touching the tool body.

**Proof this works**

_pending local verification_

**How to test**
1. `pnpm validate` from the repo root.
2. `pnpm --filter @slopweaver/mcp-server test recall` to run the targeted suite.
3. From an MCP client, call `recall` with `{ "query": "oauth migration", "limit": 5 }` against a populated `evidence_log` and confirm the top hit is the OAuth row, not a typo-fix row.
4. Repeat with `filters: { integration: "slack", kind: "message" }` and confirm only Slack messages come back.

<details>
<summary>Technical detail</summary>

**Embedder shape.** Signed feature hashing (Weinberger et al. 2009): tokenize, sha1 each token, map to a `(bucket, sign)` pair, accumulate signed counts, L2-normalize. Default 4096 dimensions, pure function, `node:crypto` only, zero runtime deps. The interface is `Promise<Float32Array>` from the start so a real local model swap is a no-touch change on the tool side.

**Iter-3 fix (24ab48a).** Single-hash signed hashing still pinned unrelated single-token inputs to cosine `+1.0` whenever their one `(bucket, sign)` pair happened to collide. `epsilon`/`chi` and `xi`/`phi` both did this on the 256-bucket variant. Fix is multi-hash sketching: `k=3` independent `(bucket, sign)` pairs per token from disjoint sha1 byte ranges, each contributing `1/sqrt(k)` so per-token norm stays at 1. All-pairs-collide probability at 4096 buckets is `(1 / 8192)^3 ≈ 1.8e-12`. The disjoint-pair regression test covers Greek letters plus Latin/English cross-domain pairs.

**Cosine range.** `cosineSimilarity` is a true dot product in `[-1, 1]` with a floating-point clamp at the bounds. The wire schema preserves the full range so a future embedder that wants to surface anti-correlated hits isn't a breaking change. The `recall` tool itself filters non-positive scores before returning, so in practice callers see `(0, 1]`.

**SQL pushdown.** `integration` and `kind` filters compose via `and(...eq(...))` and run as a `WHERE` clause against `evidence_log`, not in JS. Matters once the log grows past in-memory-sort scale.

**No schema change.** Embeddings are computed per query against the live `evidence_log`. Fine to roughly 10K rows; cached `embedding` column is a separate follow-up behind a feature flag.

Refs #57 (spec), #55 (v1.1 roadmap).

</details>
