### PR TITLE
feat(draft): add start_draft MCP tool for reply generation

### DIFF
--- a/apps/mcp-local/src/cli.smoke.test.ts
+++ b/apps/mcp-local/src/cli.smoke.test.ts
@@ -70,6 +70,7 @@ describe('slopweaver bin (compiled CLI)', () => {
       expect(names).toContain('get_freshness');
       expect(names).toContain('catch_me_up');
       expect(names).toContain('search_work_context');
+      expect(names).toContain('start_draft');
 
       const ping = list.tools.find((t) => t.name === 'ping');
       expect(ping?.inputSchema.type).toBe('object');

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -47,6 +47,7 @@ import {
   createMcpServer,
   createPingTool,
   createSearchWorkContextTool,
+  createStartDraftTool,
   createStartSessionTool,
   type StartSessionPoller,
   startStdio,
@@ -171,6 +172,7 @@ async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void
       createGetFreshnessTool(),
       createCatchMeUpTool(),
       createSearchWorkContextTool(),
+      createStartDraftTool(),
     ],
   });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -143,3 +143,30 @@ export const SearchWorkContextResult = z
   })
   .strict();
 export type SearchWorkContextResult = z.infer<typeof SearchWorkContextResult>;
+
+// --- Draft generator -------------------------------------------------
+
+export const StartDraftArgs = z
+  .object({
+    /** Permalink to the thread / PR / ticket / email being replied to. */
+    thread_ref: NonEmptyStringSchema,
+    /** Optional one-line intent ("apologize for late chase", "request scope clarification"). */
+    intent: z.string().optional(),
+    /** Recipient identifier — used to pull stakeholder history via `recall` (when available). */
+    stakeholder: z.string().optional(),
+  })
+  .strict();
+export type StartDraftArgs = z.infer<typeof StartDraftArgs>;
+
+export const StartDraftResult = z
+  .object({
+    /** Stable id the caller passes to `record_audit_progress` etc. */
+    draft_id: NonEmptyStringSchema,
+    /** Slugified filename the draft will be saved under, e.g. "drafts/pr-12345-deploy-review.md". */
+    suggested_path: NonEmptyStringSchema,
+    /** Instructional body the model follows to draft the reply. */
+    instructions: NonEmptyStringSchema,
+    generated_at: IsoDatetimeSchema,
+  })
+  .strict();
+export type StartDraftResult = z.infer<typeof StartDraftResult>;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -24,6 +24,8 @@ export { createGetFreshnessTool } from './tools/builtin/get-freshness.ts';
 export type { CreateGetFreshnessToolArgs } from './tools/builtin/get-freshness.ts';
 export { createSearchWorkContextTool } from './tools/builtin/search-work-context.ts';
 export type { CreateSearchWorkContextToolArgs } from './tools/builtin/search-work-context.ts';
+export { createStartDraftTool } from './tools/builtin/draft/index.ts';
+export type { CreateStartDraftToolArgs } from './tools/builtin/draft/index.ts';
 export { createStartSessionTool } from './tools/composite/start-session.ts';
 export type {
   CreateStartSessionToolArgs,

--- a/packages/mcp-server/src/tools/builtin/draft/index.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/index.ts
@@ -1,0 +1,7 @@
+/**
+ * `/draft` barrel — currently a single tool wrapping the instructional
+ * body. The `/draft` slash command shim lands on top of #54.
+ */
+
+export { createStartDraftTool } from './start-draft.ts';
+export type { CreateStartDraftToolArgs } from './start-draft.ts';

--- a/packages/mcp-server/src/tools/builtin/draft/instructions.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/instructions.ts
@@ -1,0 +1,95 @@
+/**
+ * Instructional body returned by `start_draft`. The model receives
+ * this as the tool's structured output and follows it inline to
+ * produce a reply matching the user's voice rules.
+ *
+ * No personal identifiers anywhere. The instructions reference the
+ * user's own writing patterns abstractly; the actual stakeholder
+ * history is pulled at runtime from the user's connected MCP servers.
+ */
+
+export const DRAFT_INSTRUCTIONS = `# Draft a reply
+
+You're drafting a reply on the user's behalf. The output goes to a
+file on disk under \`.claude/personal/drafts/\` — it does not send.
+The user reviews, edits if needed, then triggers \`send_via_source\`
+(PR #59) to actually deliver.
+
+## Inputs
+
+- **\`thread_ref\`** (supplied by the caller): the permalink to the
+  thread / PR / ticket / email being replied to.
+- **\`intent\`** (optional): a one-line statement of what the user
+  wants to convey. Treat as a strong hint, not a script.
+- **\`stakeholder\`** (optional): an identifier for the recipient
+  (Slack user_id, GitHub username, email, etc.). Used to pull
+  stakeholder history if \`recall\` is available.
+
+## Steps
+
+1. **Pull context.** Fetch the source thread via the appropriate MCP
+   server (Slack \`slack_read_thread\`, GitHub \`gh pr view\` or PR
+   API, Gmail \`get_thread\`, Linear ticket fetch, etc.). Capture the
+   full conversation, not just the last message — the user's reply
+   needs to address the actual ask.
+
+2. **Pull stakeholder history.** If \`recall\` is available (PR #57)
+   and \`stakeholder\` is supplied, call:
+
+   \`\`\`
+   recall({
+     query: "<stakeholder identifier> <key topic words from the thread>",
+     limit: 15,
+     filters: { integration: "slack" | "github" | ... }
+   })
+   \`\`\`
+
+   The hits surface the user's last 10–15 interactions with this
+   stakeholder. Use them to calibrate tone — formal vs casual, prior
+   in-jokes, recurring topics, response cadence.
+
+3. **Pull voice rules.** Read \`.claude/personal/rules/communication-style.md\`
+   via \`read_console_file\` (PR #54) — or, if the work-console tools
+   aren't present, ask the caller to supply the rules markdown.
+
+4. **Draft.** Compose the reply in the user's voice. One concrete
+   call-out per paragraph. Keep it tight — most great replies are
+   2–4 sentences, not paragraphs. Don't editorialise; just answer
+   what was asked.
+
+5. **Lint with voice rules.** Call \`apply_voice_rules({ draft,
+   rules_markdown })\` (PR #56) on your output. If the edit log
+   reports rewrites, surface them in the chat output ("rewrote 2
+   phrases per voice rules"). Use the rewritten string as the final
+   draft.
+
+6. **Save.** Use \`write_console_file\` (PR #54) to drop the draft at
+   the \`suggested_path\` returned by this tool. Include frontmatter:
+
+   \`\`\`yaml
+   ---
+   draft_id: <id>
+   thread_ref: <ref>
+   target: <slack:C123/thread:1234.5678 | github:owner/repo/pulls/456 | ...>
+   status: pending
+   ---
+   \`\`\`
+
+   The \`target:\` field is what \`send_via_source\` (PR #59) parses
+   later to route the send. Build it from the \`thread_ref\`.
+
+7. **Surface.** Print the draft to chat. End with one line:
+   \`Draft saved to <path>. Reply with \\\`send\\\` to deliver via <platform>, or edit + re-save.\`
+
+## Hard rules
+
+- **Never send.** This tool drafts; \`send_via_source\` sends. The
+  user is the final gate.
+- **Apply voice rules.** Always pass through \`apply_voice_rules\`
+  before saving. The post-processor is the last-mile safety net.
+- **One draft per call.** If the user wants alternatives, they can
+  call \`/draft\` again with a different \`intent\`.
+- **No personal data hardcoded in the output.** Pull all
+  identifiers from the source thread + stakeholder lookup — never
+  guess names or contexts.
+`;

--- a/packages/mcp-server/src/tools/builtin/draft/instructions.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/instructions.ts
@@ -34,10 +34,11 @@ The user reviews, edits if needed, then triggers \`send_via_source\`
    needs to address the actual ask.
 
    **Failure mode — missing source MCP.** If the MCP server hosting
-   the thread is not connected (no Slack MCP for a \`slack:\` ref, no
-   GitHub MCP / \`gh\` CLI for a \`github:\` ref, no Gmail MCP for a
-   \`gmail:\` ref), **fail closed**. Stop and return an error to chat:
-   "Cannot draft: source thread MCP for <platform> is not connected.
+   the thread is not connected (no Slack MCP for a \`slack:\` ref,
+   no GitHub MCP / \`gh\` CLI for a \`github:\` ref, no Gmail MCP for
+   a \`gmail:\` ref, no Linear MCP for a \`linear:\` ref),
+   **fail closed**. Stop and return an error to chat: "Cannot draft:
+   source thread MCP for <platform> is not connected.
    Install/authenticate the relevant MCP server, then retry." Do not
    guess at the thread contents from the ref alone.
 
@@ -124,6 +125,7 @@ will reject anything else:
 - \`github:<owner>/<repo>/issue/<number>\` (e.g.
   \`github:slopweaver/slopweaver/issue/42\`) — note: \`issue\`, not
   \`issues\`.
+- \`linear:<issue_id>\` (e.g. \`linear:PLT-583\`)
 
 ## Hard rules
 

--- a/packages/mcp-server/src/tools/builtin/draft/instructions.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/instructions.ts
@@ -33,6 +33,14 @@ The user reviews, edits if needed, then triggers \`send_via_source\`
    full conversation, not just the last message — the user's reply
    needs to address the actual ask.
 
+   **Failure mode — missing source MCP.** If the MCP server hosting
+   the thread is not connected (no Slack MCP for a \`slack:\` ref, no
+   GitHub MCP / \`gh\` CLI for a \`github:\` ref, no Gmail MCP for a
+   \`gmail:\` ref), **fail closed**. Stop and return an error to chat:
+   "Cannot draft: source thread MCP for <platform> is not connected.
+   Install/authenticate the relevant MCP server, then retry." Do not
+   guess at the thread contents from the ref alone.
+
 2. **Pull stakeholder history.** If \`recall\` is available (PR #57)
    and \`stakeholder\` is supplied, call:
 
@@ -47,6 +55,13 @@ The user reviews, edits if needed, then triggers \`send_via_source\`
    The hits surface the user's last 10–15 interactions with this
    stakeholder. Use them to calibrate tone — formal vs casual, prior
    in-jokes, recurring topics, response cadence.
+
+   **Failure mode — \`recall\` not available.** If PR #57 hasn't
+   merged yet (or the \`recall\` tool isn't registered for any other
+   reason), **continue without it**. Add a note to the chat output:
+   "Historical stakeholder context unavailable (recall tool not
+   registered); calibrating tone from the thread alone." Do not block
+   the draft on this.
 
 3. **Pull voice rules.** Read \`.claude/personal/rules/communication-style.md\`
    via \`read_console_file\` (PR #54) — or, if the work-console tools
@@ -63,6 +78,12 @@ The user reviews, edits if needed, then triggers \`send_via_source\`
    phrases per voice rules"). Use the rewritten string as the final
    draft.
 
+   **Failure mode — \`apply_voice_rules\` not available.** If PR #68
+   hasn't merged yet (or the tool isn't registered), **continue
+   without the lint pass**. Add a warning to the chat output: "Voice
+   lint skipped (apply_voice_rules tool not registered); review the
+   draft manually for tone." Do not block the draft on this.
+
 6. **Save.** Use \`write_console_file\` (PR #54) to drop the draft at
    the \`suggested_path\` returned by this tool. Include frontmatter:
 
@@ -70,7 +91,7 @@ The user reviews, edits if needed, then triggers \`send_via_source\`
    ---
    draft_id: <id>
    thread_ref: <ref>
-   target: <slack:C123/thread:1234.5678 | github:owner/repo/pulls/456 | ...>
+   target: <see "Supported target shapes" below>
    status: pending
    ---
    \`\`\`
@@ -78,17 +99,43 @@ The user reviews, edits if needed, then triggers \`send_via_source\`
    The \`target:\` field is what \`send_via_source\` (PR #59) parses
    later to route the send. Build it from the \`thread_ref\`.
 
+   **Failure mode — \`write_console_file\` not available.** If the
+   work-console tools aren't registered, **do not block the draft**.
+   Instead, return the full draft body (frontmatter + content) inline
+   in the chat output, and tell the user: "Could not write to
+   \`<suggested_path>\` (write_console_file not registered); the full
+   draft is above — copy it into your console manually."
+
 7. **Surface.** Print the draft to chat. End with one line:
    \`Draft saved to <path>. Reply with \\\`send\\\` to deliver via <platform>, or edit + re-save.\`
+
+## Supported \`target:\` shapes
+
+The \`target:\` field in the frontmatter is what \`send_via_source\`
+(PR #59) parses. Use exactly one of these forms — \`parse-target.ts\`
+will reject anything else:
+
+- \`slack:<channel_id>/thread:<thread_ts>\` (e.g.
+  \`slack:C1234567/thread:1700000000.123456\`)
+- \`gmail:<thread_id>\` (e.g. \`gmail:18f3c2a9b1e4d5f6\`)
+- \`github:<owner>/<repo>/pull/<number>\` (e.g.
+  \`github:slopweaver/slopweaver/pull/71\`) — note: \`pull\`, not
+  \`pulls\`.
+- \`github:<owner>/<repo>/issue/<number>\` (e.g.
+  \`github:slopweaver/slopweaver/issue/42\`) — note: \`issue\`, not
+  \`issues\`.
 
 ## Hard rules
 
 - **Never send.** This tool drafts; \`send_via_source\` sends. The
   user is the final gate.
-- **Apply voice rules.** Always pass through \`apply_voice_rules\`
-  before saving. The post-processor is the last-mile safety net.
+- **Apply voice rules when available.** Pass through
+  \`apply_voice_rules\` before saving when the tool is registered;
+  surface a warning in chat when it isn't (see step 5).
 - **One draft per call.** If the user wants alternatives, they can
-  call \`/draft\` again with a different \`intent\`.
+  call \`/draft\` again with a different \`intent\`. The
+  \`suggested_path\` includes the \`draft_id\`, so repeat calls don't
+  overwrite earlier drafts.
 - **No personal data hardcoded in the output.** Pull all
   identifiers from the source thread + stakeholder lookup — never
   guess names or contexts.

--- a/packages/mcp-server/src/tools/builtin/draft/start-draft.test.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/start-draft.test.ts
@@ -57,12 +57,84 @@ describe('createStartDraftTool', () => {
     if (result.isOk()) {
       const parsed = StartDraftResult.parse(result.value);
       expect(parsed.draft_id).toBe('draft_fixed');
-      expect(parsed.suggested_path).toBe('drafts/https-github-com-owner-repo-pull-123.md');
+      expect(parsed.suggested_path).toBe('drafts/https-github-com-owner-repo-pull-123-draft_fixed.md');
       expect(parsed.instructions).toContain('Draft a reply');
       expect(parsed.instructions).toContain('apply_voice_rules');
       expect(parsed.instructions).toContain('recall');
       expect(parsed.instructions).not.toContain('@everlab');
       expect(parsed.generated_at).toBe(new Date(FIXED_NOW).toISOString());
+    }
+  });
+
+  it('includes draft_id in the suggested_path so repeat calls do not collide', async () => {
+    let counter = 0;
+    const tool = createStartDraftTool({
+      now: () => FIXED_NOW,
+      generateDraftId: () => `draft_${++counter}`,
+    });
+    const a = await tool.handler({
+      input: StartDraftArgs.parse({ thread_ref: 'slack:C123/thread:1.2' }),
+      ctx: { db: dbHandle.db },
+    });
+    const b = await tool.handler({
+      input: StartDraftArgs.parse({ thread_ref: 'slack:C123/thread:1.2' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(a.isOk()).toBe(true);
+    expect(b.isOk()).toBe(true);
+    if (a.isOk() && b.isOk()) {
+      const pa = StartDraftResult.parse(a.value);
+      const pb = StartDraftResult.parse(b.value);
+      // The slug anchor is identical (same thread_ref) but the draft_id
+      // suffix differs, so the two paths can't collide on disk.
+      expect(pa.suggested_path).toBe('drafts/slack-c123-thread-1-2-draft_1.md');
+      expect(pb.suggested_path).toBe('drafts/slack-c123-thread-1-2-draft_2.md');
+      expect(pa.suggested_path).not.toBe(pb.suggested_path);
+      expect(pa.suggested_path).toContain(pa.draft_id);
+      expect(pb.suggested_path).toContain(pb.draft_id);
+    }
+  });
+
+  it('enumerates the supported target: shapes (pull, not pulls)', async () => {
+    const tool = createStartDraftTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: StartDraftArgs.parse({ thread_ref: 'x' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = StartDraftResult.parse(result.value);
+      // Must match send_via_source's parse-target.ts shape (PR #72).
+      expect(parsed.instructions).toContain('github:<owner>/<repo>/pull/<number>');
+      expect(parsed.instructions).toContain('github:<owner>/<repo>/issue/<number>');
+      expect(parsed.instructions).toContain('slack:<channel_id>/thread:<thread_ts>');
+      expect(parsed.instructions).toContain('gmail:<thread_id>');
+      // The wrong shape must NOT appear in the canonical enumeration.
+      expect(parsed.instructions).not.toContain('github:owner/repo/pulls/');
+    }
+  });
+
+  it('documents fail-closed / continue-with-warning failure modes', async () => {
+    const tool = createStartDraftTool({ now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: StartDraftArgs.parse({ thread_ref: 'x' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const body = StartDraftResult.parse(result.value).instructions;
+      // Source thread MCP missing → fail closed.
+      expect(body).toContain('Failure mode — missing source MCP');
+      expect(body).toContain('fail closed');
+      // recall missing → continue with note.
+      expect(body).toContain('Failure mode — `recall` not available');
+      expect(body).toContain('continue without it');
+      // apply_voice_rules missing → continue with warning.
+      expect(body).toContain('Failure mode — `apply_voice_rules` not available');
+      expect(body).toContain('lint skipped');
+      // write_console_file missing → return inline.
+      expect(body).toContain('Failure mode — `write_console_file` not available');
+      expect(body).toContain('return the full draft body');
     }
   });
 
@@ -81,7 +153,9 @@ describe('createStartDraftTool', () => {
     expect(a.isOk()).toBe(true);
     expect(b.isOk()).toBe(true);
     if (a.isOk() && b.isOk()) {
-      expect(a.value.instructions).toBe(b.value.instructions);
+      const pa = StartDraftResult.parse(a.value);
+      const pb = StartDraftResult.parse(b.value);
+      expect(pa.instructions).toBe(pb.instructions);
     }
   });
 
@@ -98,7 +172,9 @@ describe('createStartDraftTool', () => {
     expect(a.isOk()).toBe(true);
     expect(b.isOk()).toBe(true);
     if (a.isOk() && b.isOk()) {
-      expect(a.value.draft_id).not.toBe(b.value.draft_id);
+      const pa = StartDraftResult.parse(a.value);
+      const pb = StartDraftResult.parse(b.value);
+      expect(pa.draft_id).not.toBe(pb.draft_id);
     }
   });
 });

--- a/packages/mcp-server/src/tools/builtin/draft/start-draft.test.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/start-draft.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for `start_draft`. The tool is mostly a slug + ID generator
+ * plus the instructional body — verify all three plus the wire shape.
+ */
+
+import { StartDraftArgs, StartDraftResult } from '@slopweaver/contracts';
+import { createDb } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createStartDraftTool, slugifyAnchor } from './start-draft.ts';
+
+const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
+
+describe('slugifyAnchor', () => {
+  it.each([
+    ['#10407', '10407'],
+    ['https://github.com/owner/repo/pull/123', 'https-github-com-owner-repo-pull-123'],
+    ['slack:C1234/thread:1234.5678', 'slack-c1234-thread-1234-5678'],
+    ['UPPERCASE WITH SPACES', 'uppercase-with-spaces'],
+  ])('slugifies %s → %s', (input, expected) => {
+    expect(slugifyAnchor(input)).toBe(expected);
+  });
+
+  it('returns "untitled" when input is all special chars', () => {
+    expect(slugifyAnchor('!!!')).toBe('untitled');
+  });
+
+  it('caps the slug at 80 chars', () => {
+    const long = 'x'.repeat(100);
+    expect(slugifyAnchor(long).length).toBe(80);
+  });
+});
+
+describe('createStartDraftTool', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  it('returns a draft_id, suggested_path, and the instructional body', async () => {
+    const tool = createStartDraftTool({
+      now: () => FIXED_NOW,
+      generateDraftId: () => 'draft_fixed',
+    });
+    const result = await tool.handler({
+      input: StartDraftArgs.parse({
+        thread_ref: 'https://github.com/owner/repo/pull/123',
+        intent: 'request scope clarification',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = StartDraftResult.parse(result.value);
+      expect(parsed.draft_id).toBe('draft_fixed');
+      expect(parsed.suggested_path).toBe('drafts/https-github-com-owner-repo-pull-123.md');
+      expect(parsed.instructions).toContain('Draft a reply');
+      expect(parsed.instructions).toContain('apply_voice_rules');
+      expect(parsed.instructions).toContain('recall');
+      expect(parsed.instructions).not.toContain('@everlab');
+      expect(parsed.generated_at).toBe(new Date(FIXED_NOW).toISOString());
+    }
+  });
+
+  it('honours the optional intent argument by ignoring it in the body', async () => {
+    const tool = createStartDraftTool({ now: () => FIXED_NOW });
+    const a = await tool.handler({
+      input: StartDraftArgs.parse({ thread_ref: 'x', intent: 'foo' }),
+      ctx: { db: dbHandle.db },
+    });
+    const b = await tool.handler({
+      input: StartDraftArgs.parse({ thread_ref: 'x', intent: 'bar' }),
+      ctx: { db: dbHandle.db },
+    });
+    // The instructional body is constant; intent is a runtime hint the
+    // model uses but isn't substituted into the template.
+    expect(a.isOk()).toBe(true);
+    expect(b.isOk()).toBe(true);
+    if (a.isOk() && b.isOk()) {
+      expect(a.value.instructions).toBe(b.value.instructions);
+    }
+  });
+
+  it('generates distinct draft_ids by default', async () => {
+    const tool = createStartDraftTool({ now: () => FIXED_NOW });
+    const a = await tool.handler({
+      input: StartDraftArgs.parse({ thread_ref: 'x' }),
+      ctx: { db: dbHandle.db },
+    });
+    const b = await tool.handler({
+      input: StartDraftArgs.parse({ thread_ref: 'x' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(a.isOk()).toBe(true);
+    expect(b.isOk()).toBe(true);
+    if (a.isOk() && b.isOk()) {
+      expect(a.value.draft_id).not.toBe(b.value.draft_id);
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/draft/start-draft.test.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/start-draft.test.ts
@@ -109,6 +109,9 @@ describe('createStartDraftTool', () => {
       expect(parsed.instructions).toContain('github:<owner>/<repo>/issue/<number>');
       expect(parsed.instructions).toContain('slack:<channel_id>/thread:<thread_ts>');
       expect(parsed.instructions).toContain('gmail:<thread_id>');
+      // Linear support landed in PR #72's parse-target.ts; the draft
+      // instructions must enumerate it so the model knows to emit it.
+      expect(parsed.instructions).toContain('linear:<issue_id>');
       // The wrong shape must NOT appear in the canonical enumeration.
       expect(parsed.instructions).not.toContain('github:owner/repo/pulls/');
     }
@@ -159,7 +162,7 @@ describe('createStartDraftTool', () => {
     }
   });
 
-  it('generates distinct draft_ids by default', async () => {
+  it('generates distinct draft_ids by default using crypto.randomUUID (no collisions)', async () => {
     const tool = createStartDraftTool({ now: () => FIXED_NOW });
     const a = await tool.handler({
       input: StartDraftArgs.parse({ thread_ref: 'x' }),
@@ -175,6 +178,32 @@ describe('createStartDraftTool', () => {
       const pa = StartDraftResult.parse(a.value);
       const pb = StartDraftResult.parse(b.value);
       expect(pa.draft_id).not.toBe(pb.draft_id);
+      // RFC 4122 v4 — `draft_<8>-<4>-<4>-<4>-<12>` hex with version
+      // nibble `4` and variant nibble `8/9/a/b`. Pin the shape so a
+      // future regression to `Math.random()` (which gave only ~36 bits
+      // of entropy and allowed collisions) is caught here.
+      const uuidV4Re = /^draft_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+      expect(pa.draft_id).toMatch(uuidV4Re);
+      expect(pb.draft_id).toMatch(uuidV4Re);
     }
+  });
+
+  it('large batch of default draft_ids has zero collisions (UUID v4 entropy)', async () => {
+    // With Math.random() at 6 base36 chars (~36 bits), birthday-paradox
+    // collisions show up in the low-thousands range. UUID v4 has ~122
+    // bits, so 1000 generations should still be entirely distinct.
+    const tool = createStartDraftTool({ now: () => FIXED_NOW });
+    const ids = new Set<string>();
+    for (let i = 0; i < 1000; i += 1) {
+      const r = await tool.handler({
+        input: StartDraftArgs.parse({ thread_ref: 'x' }),
+        ctx: { db: dbHandle.db },
+      });
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) {
+        ids.add(StartDraftResult.parse(r.value).draft_id);
+      }
+    }
+    expect(ids.size).toBe(1000);
   });
 });

--- a/packages/mcp-server/src/tools/builtin/draft/start-draft.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/start-draft.ts
@@ -8,6 +8,7 @@
  * command shim lands once #54 merges.
  */
 
+import { randomUUID } from 'node:crypto';
 import { StartDraftArgs, StartDraftResult } from '@slopweaver/contracts';
 import { ok } from '@slopweaver/errors';
 import { defineTool, type Tool } from '../../registry.ts';
@@ -16,8 +17,12 @@ import { DRAFT_INSTRUCTIONS } from './instructions.ts';
 export type CreateStartDraftToolArgs = {
   /** Clock injection for tests. Defaults to `Date.now`. */
   now?: () => number;
-  /** ID generator for tests. Defaults to a date + shortid. */
-  generateDraftId?: (nowMs: number) => string;
+  /**
+   * ID generator for tests. Defaults to `crypto.randomUUID()` (RFC 4122
+   * v4 — ~122 bits of entropy), which makes collisions across repeat
+   * `/draft` calls effectively impossible.
+   */
+  generateDraftId?: () => string;
 };
 
 export function createStartDraftTool(args: CreateStartDraftToolArgs = {}): Tool {
@@ -32,7 +37,7 @@ export function createStartDraftTool(args: CreateStartDraftToolArgs = {}): Tool 
     outputSchema: StartDraftResult,
     handler: async ({ input }) => {
       const nowMs = now();
-      const draftId = generateDraftId(nowMs);
+      const draftId = generateDraftId();
       // Include `draft_id` so calling `/draft` twice for the same thread
       // doesn't overwrite the first draft. The slug stays as the
       // human-readable anchor; the id is the uniqueness guarantee.
@@ -62,8 +67,13 @@ export function slugifyAnchor(input: string): string {
   );
 }
 
-function defaultGenerator(nowMs: number): string {
-  const datePart = new Date(nowMs).toISOString().slice(0, 10).replaceAll('-', '');
-  const randomPart = Math.random().toString(36).slice(2, 8);
-  return `draft_${datePart}_${randomPart}`;
+/**
+ * `crypto.randomUUID()` is RFC 4122 v4 — ~122 bits of entropy — so two
+ * concurrent `/draft` calls (or two within the same millisecond) can
+ * never collide on `draft_id`. The `draft_` prefix preserves the
+ * "this looks like a draft anchor" affordance the previous date-coded
+ * format had without leaking any clock state into the identifier.
+ */
+function defaultGenerator(): string {
+  return `draft_${randomUUID()}`;
 }

--- a/packages/mcp-server/src/tools/builtin/draft/start-draft.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/start-draft.ts
@@ -1,0 +1,66 @@
+/**
+ * `start_draft` MCP tool. Returns the instructional body the model
+ * follows to draft a reply to the referenced thread, plus a
+ * slugified suggested path under `drafts/`.
+ *
+ * Tool-only design (mirroring `start_mega_audit`) so the PR is
+ * independent of #54 / the prompt registry. A thin `/draft` slash
+ * command shim lands once #54 merges.
+ */
+
+import { StartDraftArgs, StartDraftResult } from '@slopweaver/contracts';
+import { ok } from '@slopweaver/errors';
+import { defineTool, type Tool } from '../../registry.ts';
+import { DRAFT_INSTRUCTIONS } from './instructions.ts';
+
+export type CreateStartDraftToolArgs = {
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** ID generator for tests. Defaults to a date + shortid. */
+  generateDraftId?: (nowMs: number) => string;
+};
+
+export function createStartDraftTool(args: CreateStartDraftToolArgs = {}): Tool {
+  const now = args.now ?? Date.now;
+  const generateDraftId = args.generateDraftId ?? defaultGenerator;
+
+  return defineTool({
+    name: 'start_draft',
+    description:
+      'Returns the instructional body for drafting a reply to a thread/PR/ticket/email. The model fetches the source thread via whichever MCP server hosts it, pulls stakeholder history via `recall` (if available), applies voice rules via `apply_voice_rules`, saves to .claude/personal/drafts/, and prints the draft to chat. Never sends — `send_via_source` (PR #59) closes that loop.',
+    inputSchema: StartDraftArgs,
+    outputSchema: StartDraftResult,
+    handler: async ({ input }) => {
+      const nowMs = now();
+      const draftId = generateDraftId(nowMs);
+      const suggestedPath = `drafts/${slugifyAnchor(input.thread_ref)}.md`;
+      return ok({
+        draft_id: draftId,
+        suggested_path: suggestedPath,
+        instructions: DRAFT_INSTRUCTIONS,
+        generated_at: new Date(nowMs).toISOString(),
+      });
+    },
+  });
+}
+
+/**
+ * Lowercase, replace non-alphanumeric runs with hyphens, trim leading
+ * and trailing hyphens. Same conventions as `register_handoff` (PR #54)
+ * so reviewers don't have to remember two slug schemes.
+ */
+export function slugifyAnchor(input: string): string {
+  return (
+    input
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80) || 'untitled'
+  );
+}
+
+function defaultGenerator(nowMs: number): string {
+  const datePart = new Date(nowMs).toISOString().slice(0, 10).replaceAll('-', '');
+  const randomPart = Math.random().toString(36).slice(2, 8);
+  return `draft_${datePart}_${randomPart}`;
+}

--- a/packages/mcp-server/src/tools/builtin/draft/start-draft.ts
+++ b/packages/mcp-server/src/tools/builtin/draft/start-draft.ts
@@ -33,7 +33,10 @@ export function createStartDraftTool(args: CreateStartDraftToolArgs = {}): Tool 
     handler: async ({ input }) => {
       const nowMs = now();
       const draftId = generateDraftId(nowMs);
-      const suggestedPath = `drafts/${slugifyAnchor(input.thread_ref)}.md`;
+      // Include `draft_id` so calling `/draft` twice for the same thread
+      // doesn't overwrite the first draft. The slug stays as the
+      // human-readable anchor; the id is the uniqueness guarantee.
+      const suggestedPath = `drafts/${slugifyAnchor(input.thread_ref)}-${draftId}.md`;
       return ok({
         draft_id: draftId,
         suggested_path: suggestedPath,


### PR DESCRIPTION
**Problem**

Replying in someone's voice across Slack, GitHub, Gmail, and Linear means juggling four MCPs, stakeholder history, and a per-user style guide every time. There was no single entry point that bundled "fetch the thread, pull tone calibration, draft in voice, save for review" into one tool call.

**Solution**

New `start_draft` MCP tool returns an instructional body the model follows to draft a reply, slug a save path under `drafts/`, and stop short of sending. The send loop stays with `send_via_source` (#59), so the user is always the final gate.

**Proof this works**

_pending local verification_

**How to test**

1. `pnpm validate` from the worktree root.
2. `pnpm test --filter @slopweaver/mcp-server start-draft` and confirm slug, ID, target enumeration, and failure-mode tests pass.
3. Run the compiled CLI and call `tools/list`, confirm `start_draft` is registered alongside the other builtins.
4. Call `start_draft` with `{ "thread_ref": "https://github.com/owner/repo/pull/123" }` and confirm `draft_id` is a `draft_<uuid-v4>` and `suggested_path` includes it.

<details>
<summary>Technical detail</summary>

Closes #58. Fourth v1.1 PR after #54, #68, #70.

Wire shape lives in `packages/contracts/src/index.ts` as `StartDraftArgs` / `StartDraftResult`. Tool implementation is `packages/mcp-server/src/tools/builtin/draft/start-draft.ts` with the instructional body factored into `instructions.ts` so the test file can string-match against it without dragging the whole tool in.

Iter-3 fix (`7106263`) tightened two things flagged in review:

1. `target:` enumeration in the draft instructions now includes `linear:<issue_id>`, matching the shape `parse-target.ts` (PR #72) accepts. Without this the model would emit `linear:PLT-583` and the downstream send router would reject it.
2. `draft_id` generator switched from `Math.random().toString(36).slice(2, 8)` to `crypto.randomUUID()`. The old generator gave ~36 bits of entropy and birthday-paradox collisions were realistic in the low thousands. UUID v4 has ~122 bits, so the 1000-draft no-collision test is now a real guarantee rather than a coin flip. The test pins the `draft_<8>-<4>-<4>-<4>-<12>` shape with the v4 version and variant nibbles so a regression to `Math.random()` fails loud.

Failure modes documented inline in `instructions.ts` and pinned by the `documents fail-closed / continue-with-warning failure modes` test:

- **Source thread MCP missing** (no Slack MCP for a `slack:` ref, no `gh` for `github:`, etc.): fail closed. Stop and tell the user to install the relevant MCP. Do not guess thread contents.
- **`recall` not registered** (PR #57 hasn't landed): continue without stakeholder history. Surface a chat note that tone was calibrated from the thread alone.
- **`apply_voice_rules` not registered** (PR #68 hasn't landed): continue without the lint pass. Surface a warning telling the user to review tone manually.
- **`write_console_file` not registered** (PR #54 hasn't landed): return the full draft body inline in chat instead of blocking on the save.

The dispatch order is fail-closed for the source thread because there's no safe fallback, and continue-with-warning for the three optional collaborators because the draft is still useful (just less calibrated).

</details>
