### PR TITLE
feat(send): add prepare_send + record_send_outcome MCP tools

### DIFF
--- a/apps/mcp-local/src/cli.smoke.test.ts
+++ b/apps/mcp-local/src/cli.smoke.test.ts
@@ -70,6 +70,8 @@ describe('slopweaver bin (compiled CLI)', () => {
       expect(names).toContain('get_freshness');
       expect(names).toContain('catch_me_up');
       expect(names).toContain('search_work_context');
+      expect(names).toContain('prepare_send');
+      expect(names).toContain('record_send_outcome');
 
       const ping = list.tools.find((t) => t.name === 'ping');
       expect(ping?.inputSchema.type).toBe('object');

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -46,6 +46,8 @@ import {
   createGetFreshnessTool,
   createMcpServer,
   createPingTool,
+  createPrepareSendTool,
+  createRecordSendOutcomeTool,
   createSearchWorkContextTool,
   createStartSessionTool,
   type StartSessionPoller,
@@ -171,6 +173,8 @@ async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void
       createGetFreshnessTool(),
       createCatchMeUpTool(),
       createSearchWorkContextTool(),
+      createPrepareSendTool(),
+      createRecordSendOutcomeTool(),
     ],
   });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -143,3 +143,76 @@ export const SearchWorkContextResult = z
   })
   .strict();
 export type SearchWorkContextResult = z.infer<typeof SearchWorkContextResult>;
+
+// --- Send-via-source (one-tap reply) ----------------------------------
+
+export const PrepareSendArgs = z
+  .object({
+    /** Absolute path to the draft file (frontmatter + body markdown). */
+    draft_path: NonEmptyStringSchema,
+  })
+  .strict();
+export type PrepareSendArgs = z.infer<typeof PrepareSendArgs>;
+
+const SendTargetSchema = z.discriminatedUnion('platform', [
+  z
+    .object({
+      platform: z.literal('slack'),
+      channel: NonEmptyStringSchema,
+      thread_ts: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      platform: z.literal('github'),
+      owner: NonEmptyStringSchema,
+      repo: NonEmptyStringSchema,
+      kind: z.enum(['pull', 'issue']),
+      number: z.number().int().positive(),
+    })
+    .strict(),
+  z
+    .object({
+      platform: z.literal('gmail'),
+      thread_id: NonEmptyStringSchema,
+    })
+    .strict(),
+  z
+    .object({
+      platform: z.literal('linear'),
+      issue_id: NonEmptyStringSchema,
+    })
+    .strict(),
+]);
+
+export const PrepareSendResult = z
+  .object({
+    draft_id: z.string().optional(),
+    target: SendTargetSchema,
+    body: NonEmptyStringSchema,
+    instructions: NonEmptyStringSchema,
+    generated_at: IsoDatetimeSchema,
+  })
+  .strict();
+export type PrepareSendResult = z.infer<typeof PrepareSendResult>;
+
+export const RecordSendOutcomeArgs = z
+  .object({
+    /** Same draft_path that was passed to `prepare_send`. */
+    draft_path: NonEmptyStringSchema,
+    status: z.enum(['sent', 'failed', 'cancelled']),
+    /** Required when status='sent'. Source platform's permalink to the posted message. */
+    sent_url: z.url().optional(),
+    /** Required when status='failed'. */
+    error: z.string().optional(),
+  })
+  .strict();
+export type RecordSendOutcomeArgs = z.infer<typeof RecordSendOutcomeArgs>;
+
+export const RecordSendOutcomeResult = z
+  .object({
+    log_path: NonEmptyStringSchema,
+    line_number: z.number().int().positive(),
+  })
+  .strict();
+export type RecordSendOutcomeResult = z.infer<typeof RecordSendOutcomeResult>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -231,19 +231,23 @@ export const PrepareSendResult = z
      * Opaque token that the model must echo back as
      * `confirmation_token` on the second call. Present on both passes
      * (so the second-pass response can self-attest which token it
-     * resolved). Tied to the draft's `frontmatter_hash` — re-issuing
-     * `prepare_send` after the draft mutates produces a new token and
-     * invalidates any previously-issued one.
+     * resolved). Tied to the draft's `content_hash` — re-issuing
+     * `prepare_send` after the draft mutates (frontmatter OR body)
+     * produces a new token and invalidates any previously-issued one.
      */
     confirmation_token: NonEmptyStringSchema,
     /**
-     * Stable hash of the draft's frontmatter (sorted-key
-     * `key: value\n` body). `record_send_outcome` requires the model to
-     * echo this back; mismatch means the draft was edited between
-     * `prepare_send` and `record_send_outcome` and the outcome is
-     * rejected as drift.
+     * Stable hash of the draft's full content (sorted-key frontmatter
+     * `key: value\n` body, with `status` excluded, plus the trimmed
+     * body). `record_send_outcome` requires the model to echo this
+     * back; mismatch means the draft was edited between `prepare_send`
+     * and `record_send_outcome` and the outcome is rejected as drift.
+     * Body coverage is essential — without it, a model could edit the
+     * draft text after the first `prepare_send`, send the edited body
+     * on the confirmed call, and the calibration log would still
+     * validate against the old hash.
      */
-    frontmatter_hash: NonEmptyStringSchema,
+    content_hash: NonEmptyStringSchema,
     instructions: NonEmptyStringSchema,
     generated_at: IsoDatetimeSchema,
   })
@@ -258,12 +262,14 @@ export type PrepareSendResult = z.infer<typeof PrepareSendResult>;
  *  - `failed` → `error` is required, `sent_url` must be absent.
  *  - `cancelled` → neither `sent_url` nor `error`.
  *
- * Every variant requires `draft_id` and `frontmatter_hash`. The tool
- * reads the draft from disk, validates the frontmatter still matches
- * (same `draft_id`, same hash), refuses to overwrite a terminal status
- * with a different terminal status, and atomically rewrites the
- * draft's `status:` field via temp-file + rename before appending to
- * the JSONL log.
+ * Every variant requires `draft_id` and `content_hash`. The tool
+ * reads the draft from disk, validates the content still matches
+ * (same `draft_id`, same hash over frontmatter + body), refuses to
+ * overwrite a terminal status with a different terminal status, and
+ * atomically rewrites the draft's `status:` field via temp-file +
+ * rename before appending to the JSONL log. Repeat calls with the
+ * same `(draft_id, status, content_hash)` are idempotent — the
+ * existing log line is returned, no duplicate row is written.
  *
  * Implemented as a single `ZodObject` + `.superRefine` rather than a
  * `z.discriminatedUnion` because the MCP tool registry (see
@@ -277,8 +283,8 @@ export const RecordSendOutcomeArgs = z
     draft_path: NonEmptyStringSchema,
     /** Echoed from the draft's frontmatter. Must match what's on disk. */
     draft_id: NonEmptyStringSchema,
-    /** Echoed from the `PrepareSendResult.frontmatter_hash` field. */
-    frontmatter_hash: NonEmptyStringSchema,
+    /** Echoed from the `PrepareSendResult.content_hash` field. */
+    content_hash: NonEmptyStringSchema,
     status: z.enum(['sent', 'failed', 'cancelled']),
     /** Required when status='sent'. Source platform's permalink to the posted message. */
     sent_url: z.url().optional(),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -146,10 +146,24 @@ export type SearchWorkContextResult = z.infer<typeof SearchWorkContextResult>;
 
 // --- Send-via-source (one-tap reply) ----------------------------------
 
+/**
+ * `prepare_send` is a two-step tool. The model calls it first without
+ * `confirmed` (or with `confirmed: false`) to get the parsed routing
+ * payload plus a `confirmation_token`. After the user OKs the 5-second
+ * undo gate, the model re-invokes `prepare_send` with `confirmed: true`
+ * and the matching token; only then does the response include the
+ * executable `tool_args` for the downstream MCP send tool. This makes
+ * "never auto-send without confirmation" a structural property of the
+ * contract, not just prose in the instructions string.
+ */
 export const PrepareSendArgs = z
   .object({
     /** Absolute path to the draft file (frontmatter + body markdown). */
     draft_path: NonEmptyStringSchema,
+    /** Set to `true` on the second call to release executable `tool_args`. */
+    confirmed: z.boolean().optional(),
+    /** Echo back the token returned on the first (unconfirmed) call. */
+    confirmation_token: z.string().optional(),
   })
   .strict();
 export type PrepareSendArgs = z.infer<typeof PrepareSendArgs>;
@@ -190,29 +204,145 @@ export const PrepareSendResult = z
     draft_id: z.string().optional(),
     target: SendTargetSchema,
     body: NonEmptyStringSchema,
+    /**
+     * Identifier of the downstream MCP server that hosts the send tool
+     * (e.g. `"slack"`, `"github"`, `"gmail"`, `"linear"`). The model uses
+     * this together with `tool_name` to pick the right `mcp__<server>__*`
+     * tool to invoke.
+     */
+    server: NonEmptyStringSchema,
+    /** Fully-qualified MCP tool name (e.g. `"slack_send_message"`). */
+    tool_name: NonEmptyStringSchema,
+    /**
+     * Machine-readable args for `tool_name`. **Only populated on a
+     * confirmed call** (`confirmed: true` + matching token). On the first
+     * (unconfirmed) call this is omitted and `requires_confirmation` is
+     * `true` — the model must surface the undo gate, await user OK, then
+     * re-call `prepare_send` with the token to obtain executable args.
+     */
+    tool_args: z.record(z.string(), JsonValueSchema).optional(),
+    /**
+     * `true` when the response is the first-pass routing summary (no
+     * executable args). `false` once the model has supplied a valid
+     * `confirmation_token` and `tool_args` is populated.
+     */
+    requires_confirmation: z.boolean(),
+    /**
+     * Opaque token that the model must echo back as
+     * `confirmation_token` on the second call. Present on both passes
+     * (so the second-pass response can self-attest which token it
+     * resolved). Tied to the draft's `frontmatter_hash` — re-issuing
+     * `prepare_send` after the draft mutates produces a new token and
+     * invalidates any previously-issued one.
+     */
+    confirmation_token: NonEmptyStringSchema,
+    /**
+     * Stable hash of the draft's frontmatter (sorted-key
+     * `key: value\n` body). `record_send_outcome` requires the model to
+     * echo this back; mismatch means the draft was edited between
+     * `prepare_send` and `record_send_outcome` and the outcome is
+     * rejected as drift.
+     */
+    frontmatter_hash: NonEmptyStringSchema,
     instructions: NonEmptyStringSchema,
     generated_at: IsoDatetimeSchema,
   })
   .strict();
 export type PrepareSendResult = z.infer<typeof PrepareSendResult>;
 
+/**
+ * `record_send_outcome` enforces shape correlation per `status` via
+ * `.superRefine`:
+ *  - `sent` → `sent_url` is required (the source platform's
+ *    permalink), `error` must be absent.
+ *  - `failed` → `error` is required, `sent_url` must be absent.
+ *  - `cancelled` → neither `sent_url` nor `error`.
+ *
+ * Every variant requires `draft_id` and `frontmatter_hash`. The tool
+ * reads the draft from disk, validates the frontmatter still matches
+ * (same `draft_id`, same hash), refuses to overwrite a terminal status
+ * with a different terminal status, and atomically rewrites the
+ * draft's `status:` field via temp-file + rename before appending to
+ * the JSONL log.
+ *
+ * Implemented as a single `ZodObject` + `.superRefine` rather than a
+ * `z.discriminatedUnion` because the MCP tool registry (see
+ * `packages/mcp-server/src/tools/registry.ts`) constrains
+ * `inputSchema` to `z.ZodObject` so the JSON-Schema export round-trips
+ * cleanly through `tools/list`.
+ */
 export const RecordSendOutcomeArgs = z
   .object({
     /** Same draft_path that was passed to `prepare_send`. */
     draft_path: NonEmptyStringSchema,
+    /** Echoed from the draft's frontmatter. Must match what's on disk. */
+    draft_id: NonEmptyStringSchema,
+    /** Echoed from the `PrepareSendResult.frontmatter_hash` field. */
+    frontmatter_hash: NonEmptyStringSchema,
     status: z.enum(['sent', 'failed', 'cancelled']),
     /** Required when status='sent'. Source platform's permalink to the posted message. */
     sent_url: z.url().optional(),
     /** Required when status='failed'. */
-    error: z.string().optional(),
+    error: NonEmptyStringSchema.optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.status === 'sent') {
+      if (value.sent_url == null) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['sent_url'],
+          message: '`sent_url` is required when status="sent"',
+        });
+      }
+      if (value.error != null) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['error'],
+          message: '`error` must be absent when status="sent"',
+        });
+      }
+    } else if (value.status === 'failed') {
+      if (value.error == null) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['error'],
+          message: '`error` is required when status="failed"',
+        });
+      }
+      if (value.sent_url != null) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['sent_url'],
+          message: '`sent_url` must be absent when status="failed"',
+        });
+      }
+    } else {
+      // status === 'cancelled'
+      if (value.sent_url != null) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['sent_url'],
+          message: '`sent_url` must be absent when status="cancelled"',
+        });
+      }
+      if (value.error != null) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['error'],
+          message: '`error` must be absent when status="cancelled"',
+        });
+      }
+    }
+  });
 export type RecordSendOutcomeArgs = z.infer<typeof RecordSendOutcomeArgs>;
 
 export const RecordSendOutcomeResult = z
   .object({
     log_path: NonEmptyStringSchema,
     line_number: z.number().int().positive(),
+    /** Final value written to the draft frontmatter's `status:` field. */
+    draft_status: z.enum(['sent', 'failed', 'cancelled']),
   })
   .strict();
 export type RecordSendOutcomeResult = z.infer<typeof RecordSendOutcomeResult>;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -24,6 +24,18 @@ export { createGetFreshnessTool } from './tools/builtin/get-freshness.ts';
 export type { CreateGetFreshnessToolArgs } from './tools/builtin/get-freshness.ts';
 export { createSearchWorkContextTool } from './tools/builtin/search-work-context.ts';
 export type { CreateSearchWorkContextToolArgs } from './tools/builtin/search-work-context.ts';
+export {
+  createPrepareSendTool,
+  createRecordSendOutcomeTool,
+  parseTarget,
+  parseFrontmatter,
+} from './tools/builtin/send/index.ts';
+export type {
+  CreatePrepareSendToolArgs,
+  CreateRecordSendOutcomeToolArgs,
+  ParsedTarget,
+  ParsedDraft,
+} from './tools/builtin/send/index.ts';
 export { createStartSessionTool } from './tools/composite/start-session.ts';
 export type {
   CreateStartSessionToolArgs,

--- a/packages/mcp-server/src/tools/builtin/send/index.ts
+++ b/packages/mcp-server/src/tools/builtin/send/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Send-via-source barrel. Two tools: `prepare_send` (parse + validate
+ * + return platform-specific send instructions) and `record_send_outcome`
+ * (append-only JSONL log of every send attempt).
+ *
+ * Slopweaver's MCP server can't call other MCP servers across the SDK
+ * boundary, so the actual platform send happens in the model's
+ * follow-up tool call after `prepare_send` returns.
+ */
+
+export { createPrepareSendTool } from './prepare-send.ts';
+export type { CreatePrepareSendToolArgs } from './prepare-send.ts';
+export { createRecordSendOutcomeTool } from './record-send-outcome.ts';
+export type { CreateRecordSendOutcomeToolArgs } from './record-send-outcome.ts';
+export { parseTarget } from './parse-target.ts';
+export type { ParsedTarget } from './parse-target.ts';
+export { parseFrontmatter } from './parse-frontmatter.ts';
+export type { ParsedDraft } from './parse-frontmatter.ts';

--- a/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { parseFrontmatter } from './parse-frontmatter.ts';
+import { hashFrontmatter, parseFrontmatter, serializeDraft } from './parse-frontmatter.ts';
 
 describe('parseFrontmatter', () => {
   it('parses a well-formed frontmatter block + body', () => {
     const input = '---\ndraft_id: abc\ntarget: slack:C123\n---\n\nReply body here.\n';
-    const r = parseFrontmatter(input);
+    const r = parseFrontmatter({ input });
     expect(r).not.toBeNull();
     if (r != null) {
       expect(r.frontmatter['draft_id']).toBe('abc');
@@ -14,19 +14,70 @@ describe('parseFrontmatter', () => {
   });
 
   it('returns null for missing opening fence', () => {
-    expect(parseFrontmatter('no frontmatter here')).toBeNull();
+    expect(parseFrontmatter({ input: 'no frontmatter here' })).toBeNull();
   });
 
   it('returns null for missing closing fence', () => {
-    expect(parseFrontmatter('---\ndraft_id: abc\nbody without close')).toBeNull();
+    expect(parseFrontmatter({ input: '---\ndraft_id: abc\nbody without close' })).toBeNull();
   });
 
   it('ignores blank lines and lines without colons', () => {
     const input = '---\n\ndraft_id: abc\nthis is a comment\ntarget: slack:C1\n---\nbody';
-    const r = parseFrontmatter(input);
+    const r = parseFrontmatter({ input });
     expect(r).not.toBeNull();
     if (r != null) {
       expect(r.frontmatter).toEqual({ draft_id: 'abc', target: 'slack:C1' });
     }
+  });
+});
+
+describe('hashFrontmatter', () => {
+  it('produces a stable hex hash for the same input', () => {
+    const h1 = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
+    const h2 = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('is order-independent (sort-stable)', () => {
+    const h1 = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
+    const h2 = hashFrontmatter({ frontmatter: { target: 'slack:C1', draft_id: 'a' } });
+    expect(h1).toBe(h2);
+  });
+
+  it('ignores the `status` field so record_send_outcome can rewrite it without invalidating the hash', () => {
+    const before = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
+    const afterSent = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1', status: 'sent' } });
+    const afterFailed = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1', status: 'failed' } });
+    expect(before).toBe(afterSent);
+    expect(before).toBe(afterFailed);
+  });
+
+  it('changes when target or draft_id change', () => {
+    const base = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
+    const changedId = hashFrontmatter({ frontmatter: { draft_id: 'b', target: 'slack:C1' } });
+    const changedTarget = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C2' } });
+    expect(changedId).not.toBe(base);
+    expect(changedTarget).not.toBe(base);
+  });
+});
+
+describe('serializeDraft', () => {
+  it('round-trips parseFrontmatter → serializeDraft for a basic draft', () => {
+    const input = '---\ndraft_id: abc\ntarget: slack:C1\n---\nbody here\n';
+    const parsed = parseFrontmatter({ input });
+    expect(parsed).not.toBeNull();
+    if (parsed != null) {
+      const out = serializeDraft({ frontmatter: parsed.frontmatter, body: parsed.body });
+      const reparsed = parseFrontmatter({ input: out });
+      expect(reparsed?.frontmatter).toEqual(parsed.frontmatter);
+      expect(reparsed?.body).toBe(parsed.body);
+    }
+  });
+
+  it('emits keys in sorted order', () => {
+    const out = serializeDraft({ frontmatter: { target: 'slack:C1', draft_id: 'a' }, body: 'b' });
+    // draft_id < target alphabetically
+    expect(out).toBe('---\ndraft_id: a\ntarget: slack:C1\n---\nb');
   });
 });

--- a/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hashFrontmatter, parseFrontmatter, serializeDraft } from './parse-frontmatter.ts';
+import { hashContent, parseFrontmatter, serializeDraft } from './parse-frontmatter.ts';
 
 describe('parseFrontmatter', () => {
   it('parses a well-formed frontmatter block + body', () => {
@@ -31,34 +31,52 @@ describe('parseFrontmatter', () => {
   });
 });
 
-describe('hashFrontmatter', () => {
+describe('hashContent', () => {
   it('produces a stable hex hash for the same input', () => {
-    const h1 = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
-    const h2 = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
+    const h1 = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C1' }, body: 'hello' });
+    const h2 = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C1' }, body: 'hello' });
     expect(h1).toBe(h2);
     expect(h1).toMatch(/^[0-9a-f]{16}$/);
   });
 
-  it('is order-independent (sort-stable)', () => {
-    const h1 = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
-    const h2 = hashFrontmatter({ frontmatter: { target: 'slack:C1', draft_id: 'a' } });
+  it('is order-independent for frontmatter keys (sort-stable)', () => {
+    const h1 = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C1' }, body: 'hello' });
+    const h2 = hashContent({ frontmatter: { target: 'slack:C1', draft_id: 'a' }, body: 'hello' });
     expect(h1).toBe(h2);
   });
 
   it('ignores the `status` field so record_send_outcome can rewrite it without invalidating the hash', () => {
-    const before = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
-    const afterSent = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1', status: 'sent' } });
-    const afterFailed = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1', status: 'failed' } });
+    const before = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C1' }, body: 'hi' });
+    const afterSent = hashContent({
+      frontmatter: { draft_id: 'a', target: 'slack:C1', status: 'sent' },
+      body: 'hi',
+    });
+    const afterFailed = hashContent({
+      frontmatter: { draft_id: 'a', target: 'slack:C1', status: 'failed' },
+      body: 'hi',
+    });
     expect(before).toBe(afterSent);
     expect(before).toBe(afterFailed);
   });
 
   it('changes when target or draft_id change', () => {
-    const base = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C1' } });
-    const changedId = hashFrontmatter({ frontmatter: { draft_id: 'b', target: 'slack:C1' } });
-    const changedTarget = hashFrontmatter({ frontmatter: { draft_id: 'a', target: 'slack:C2' } });
+    const base = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C1' }, body: 'hi' });
+    const changedId = hashContent({ frontmatter: { draft_id: 'b', target: 'slack:C1' }, body: 'hi' });
+    const changedTarget = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C2' }, body: 'hi' });
     expect(changedId).not.toBe(base);
     expect(changedTarget).not.toBe(base);
+  });
+
+  it('changes when the body changes (body coverage is the iter-3 fix)', () => {
+    const base = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C1' }, body: 'original' });
+    const edited = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C1' }, body: 'EDITED' });
+    expect(edited).not.toBe(base);
+  });
+
+  it('treats body whitespace at the edges as insignificant (trim)', () => {
+    const base = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C1' }, body: 'hi there' });
+    const padded = hashContent({ frontmatter: { draft_id: 'a', target: 'slack:C1' }, body: '  hi there\n' });
+    expect(padded).toBe(base);
   });
 });
 

--- a/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { parseFrontmatter } from './parse-frontmatter.ts';
+
+describe('parseFrontmatter', () => {
+  it('parses a well-formed frontmatter block + body', () => {
+    const input = '---\ndraft_id: abc\ntarget: slack:C123\n---\n\nReply body here.\n';
+    const r = parseFrontmatter(input);
+    expect(r).not.toBeNull();
+    if (r != null) {
+      expect(r.frontmatter['draft_id']).toBe('abc');
+      expect(r.frontmatter['target']).toBe('slack:C123');
+      expect(r.body.trim()).toBe('Reply body here.');
+    }
+  });
+
+  it('returns null for missing opening fence', () => {
+    expect(parseFrontmatter('no frontmatter here')).toBeNull();
+  });
+
+  it('returns null for missing closing fence', () => {
+    expect(parseFrontmatter('---\ndraft_id: abc\nbody without close')).toBeNull();
+  });
+
+  it('ignores blank lines and lines without colons', () => {
+    const input = '---\n\ndraft_id: abc\nthis is a comment\ntarget: slack:C1\n---\nbody';
+    const r = parseFrontmatter(input);
+    expect(r).not.toBeNull();
+    if (r != null) {
+      expect(r.frontmatter).toEqual({ draft_id: 'abc', target: 'slack:C1' });
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.ts
@@ -41,21 +41,38 @@ export function parseFrontmatter({ input }: { input: string }): ParsedDraft | nu
 }
 
 /**
- * Stable, order-independent hash of a frontmatter record. Keys are
- * sorted before hashing so adding/removing the `status:` field (which
- * `record_send_outcome` rewrites) doesn't perturb it — the hash
- * intentionally excludes `status` so the model can be told "this hash
- * pins the draft target+body+id between prepare_send and
- * record_send_outcome" without having to re-issue the hash on every
- * status transition.
+ * Stable, order-independent hash of the entire draft content
+ * (frontmatter + body). Frontmatter keys are sorted before hashing so
+ * adding/removing the `status:` field (which `record_send_outcome`
+ * rewrites) doesn't perturb the hash — `status` is excluded so the
+ * model can be told "this hash pins the draft id+target+body between
+ * prepare_send and record_send_outcome" without having to re-issue
+ * the hash on every status transition.
+ *
+ * Body is included because a model could otherwise edit the draft
+ * body between the first (unconfirmed) and second (confirmed)
+ * `prepare_send` call, send the edited text, and the calibration log
+ * would still validate against the original hash. With body
+ * coverage, any change to the body invalidates the confirmation
+ * token and triggers a fresh user confirmation.
+ *
+ * Body is trimmed before hashing to match how `prepare_send` and
+ * `record_send_outcome` already normalise it on read.
  */
-export function hashFrontmatter({ frontmatter }: { frontmatter: Readonly<Record<string, string>> }): string {
-  const entries = Object.entries(frontmatter)
+export function hashContent({
+  frontmatter,
+  body,
+}: {
+  frontmatter: Readonly<Record<string, string>>;
+  body: string;
+}): string {
+  const fmEntries = Object.entries(frontmatter)
     .filter(([k]) => k !== 'status')
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([k, v]) => `${k}: ${v}`)
     .join('\n');
-  return createHash('sha256').update(entries, 'utf-8').digest('hex').slice(0, 16);
+  const payload = `${fmEntries}\n---\n${body.trim()}`;
+  return createHash('sha256').update(payload, 'utf-8').digest('hex').slice(0, 16);
 }
 
 /**

--- a/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.ts
@@ -5,16 +5,18 @@
  * deterministic, and we want zero deps for the send pipeline.
  *
  * Supports: top-level string values only. No nested objects, no
- * arrays, no quoting. The `target:` and `draft_id:` fields are the
- * only ones currently consumed.
+ * arrays, no quoting. The `target:`, `draft_id:`, and `status:` fields
+ * are the only ones consumed today.
  */
+
+import { createHash } from 'node:crypto';
 
 export type ParsedDraft = {
   readonly frontmatter: Readonly<Record<string, string>>;
   readonly body: string;
 };
 
-export function parseFrontmatter(input: string): ParsedDraft | null {
+export function parseFrontmatter({ input }: { input: string }): ParsedDraft | null {
   if (!input.startsWith('---\n') && !input.startsWith('---\r\n')) {
     return null;
   }
@@ -36,4 +38,41 @@ export function parseFrontmatter(input: string): ParsedDraft | null {
     frontmatter[key] = value;
   }
   return { frontmatter, body };
+}
+
+/**
+ * Stable, order-independent hash of a frontmatter record. Keys are
+ * sorted before hashing so adding/removing the `status:` field (which
+ * `record_send_outcome` rewrites) doesn't perturb it — the hash
+ * intentionally excludes `status` so the model can be told "this hash
+ * pins the draft target+body+id between prepare_send and
+ * record_send_outcome" without having to re-issue the hash on every
+ * status transition.
+ */
+export function hashFrontmatter({ frontmatter }: { frontmatter: Readonly<Record<string, string>> }): string {
+  const entries = Object.entries(frontmatter)
+    .filter(([k]) => k !== 'status')
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  return createHash('sha256').update(entries, 'utf-8').digest('hex').slice(0, 16);
+}
+
+/**
+ * Serialise a frontmatter record back into the `---\n<lines>\n---\n<body>`
+ * shape this parser consumes. Used by `record_send_outcome` to rewrite
+ * the `status:` field while preserving every other key and the body.
+ * Keys are emitted in sorted order to keep the output deterministic
+ * (mirrors `hashFrontmatter`'s sort).
+ */
+export function serializeDraft({
+  frontmatter,
+  body,
+}: {
+  frontmatter: Readonly<Record<string, string>>;
+  body: string;
+}): string {
+  const sortedEntries = Object.entries(frontmatter).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const fmLines = sortedEntries.map(([k, v]) => `${k}: ${v}`).join('\n');
+  return `---\n${fmLines}\n---\n${body}`;
 }

--- a/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-frontmatter.ts
@@ -1,0 +1,39 @@
+/**
+ * Tiny YAML-frontmatter parser. Drafts under `.claude/personal/drafts/`
+ * follow a fixed shape: `--- key: value\nkey: value ---\n<body>`. We
+ * intentionally don't pull in `yaml` for this — the surface is small,
+ * deterministic, and we want zero deps for the send pipeline.
+ *
+ * Supports: top-level string values only. No nested objects, no
+ * arrays, no quoting. The `target:` and `draft_id:` fields are the
+ * only ones currently consumed.
+ */
+
+export type ParsedDraft = {
+  readonly frontmatter: Readonly<Record<string, string>>;
+  readonly body: string;
+};
+
+export function parseFrontmatter(input: string): ParsedDraft | null {
+  if (!input.startsWith('---\n') && !input.startsWith('---\r\n')) {
+    return null;
+  }
+  const afterOpen = input.indexOf('\n') + 1;
+  const closeIdx = input.indexOf('\n---', afterOpen);
+  if (closeIdx === -1) return null;
+  const fmBlock = input.slice(afterOpen, closeIdx);
+  const bodyStart = input.indexOf('\n', closeIdx + 4);
+  const body = bodyStart === -1 ? '' : input.slice(bodyStart + 1);
+  const frontmatter: Record<string, string> = {};
+  for (const line of fmBlock.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = trimmed.slice(0, colonIdx).trim();
+    const value = trimmed.slice(colonIdx + 1).trim();
+    if (key.length === 0) continue;
+    frontmatter[key] = value;
+  }
+  return { frontmatter, body };
+}

--- a/packages/mcp-server/src/tools/builtin/send/parse-target.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-target.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { parseTarget } from './parse-target.ts';
+
+describe('parseTarget', () => {
+  it('parses a Slack channel-only target', () => {
+    expect(parseTarget('slack:C12345')).toEqual({ platform: 'slack', channel: 'C12345' });
+  });
+
+  it('parses a Slack channel + thread_ts target', () => {
+    expect(parseTarget('slack:C12345/thread:1234.5678')).toEqual({
+      platform: 'slack',
+      channel: 'C12345',
+      thread_ts: '1234.5678',
+    });
+  });
+
+  it('parses a GitHub PR target', () => {
+    expect(parseTarget('github:slopweaver/slopweaver/pull/123')).toEqual({
+      platform: 'github',
+      owner: 'slopweaver',
+      repo: 'slopweaver',
+      kind: 'pull',
+      number: 123,
+    });
+  });
+
+  it('parses a GitHub issue target', () => {
+    expect(parseTarget('github:owner/repo/issue/7')).toEqual({
+      platform: 'github',
+      owner: 'owner',
+      repo: 'repo',
+      kind: 'issue',
+      number: 7,
+    });
+  });
+
+  it('parses a Gmail target', () => {
+    expect(parseTarget('gmail:abc123')).toEqual({ platform: 'gmail', thread_id: 'abc123' });
+  });
+
+  it('parses a Linear target', () => {
+    expect(parseTarget('linear:PLT-583')).toEqual({ platform: 'linear', issue_id: 'PLT-583' });
+  });
+
+  it('returns null for unknown platform prefix', () => {
+    expect(parseTarget('jira:ABC-123')).toBeNull();
+  });
+
+  it('returns null for malformed GitHub target', () => {
+    expect(parseTarget('github:owner/repo/notakind/1')).toBeNull();
+    expect(parseTarget('github:owner/repo/pull/zero')).toBeNull();
+  });
+
+  it('returns null for slack with empty channel', () => {
+    expect(parseTarget('slack:')).toBeNull();
+    expect(parseTarget('slack:/thread:123')).toBeNull();
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/send/parse-target.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-target.test.ts
@@ -3,29 +3,53 @@ import { parseTarget } from './parse-target.ts';
 
 describe('parseTarget', () => {
   it('parses a Slack channel-only target', () => {
-    expect(parseTarget('slack:C12345')).toEqual({ platform: 'slack', channel: 'C12345' });
+    expect(parseTarget({ target: 'slack:C12345' })).toEqual({ platform: 'slack', channel: 'C12345' });
   });
 
   it('parses a Slack channel + thread_ts target', () => {
-    expect(parseTarget('slack:C12345/thread:1234.5678')).toEqual({
+    expect(parseTarget({ target: 'slack:C12345/thread:1234.5678' })).toEqual({
       platform: 'slack',
       channel: 'C12345',
       thread_ts: '1234.5678',
     });
   });
 
-  it('parses a GitHub PR target', () => {
-    expect(parseTarget('github:slopweaver/slopweaver/pull/123')).toEqual({
+  // Uses a fake owner/repo to keep the public repo free of self-references;
+  // `parseTarget` is purely string-based and never resolves the owner/repo.
+  it('parses a GitHub PR target (singular kind)', () => {
+    expect(parseTarget({ target: 'github:acme/widgets/pull/123' })).toEqual({
       platform: 'github',
-      owner: 'slopweaver',
-      repo: 'slopweaver',
+      owner: 'acme',
+      repo: 'widgets',
       kind: 'pull',
       number: 123,
     });
   });
 
-  it('parses a GitHub issue target', () => {
-    expect(parseTarget('github:owner/repo/issue/7')).toEqual({
+  // PR #71 emits `pulls/` (plural) in its template; accept both shapes and
+  // normalise to the singular `pull` so downstream consumers see one form.
+  it('parses a GitHub PR target with plural `pulls` kind and normalises to `pull`', () => {
+    expect(parseTarget({ target: 'github:acme/widgets/pulls/456' })).toEqual({
+      platform: 'github',
+      owner: 'acme',
+      repo: 'widgets',
+      kind: 'pull',
+      number: 456,
+    });
+  });
+
+  it('parses a GitHub issue target (singular kind)', () => {
+    expect(parseTarget({ target: 'github:owner/repo/issue/7' })).toEqual({
+      platform: 'github',
+      owner: 'owner',
+      repo: 'repo',
+      kind: 'issue',
+      number: 7,
+    });
+  });
+
+  it('parses a GitHub issue target with plural `issues` kind', () => {
+    expect(parseTarget({ target: 'github:owner/repo/issues/7' })).toEqual({
       platform: 'github',
       owner: 'owner',
       repo: 'repo',
@@ -35,24 +59,40 @@ describe('parseTarget', () => {
   });
 
   it('parses a Gmail target', () => {
-    expect(parseTarget('gmail:abc123')).toEqual({ platform: 'gmail', thread_id: 'abc123' });
+    expect(parseTarget({ target: 'gmail:abc123' })).toEqual({ platform: 'gmail', thread_id: 'abc123' });
   });
 
   it('parses a Linear target', () => {
-    expect(parseTarget('linear:PLT-583')).toEqual({ platform: 'linear', issue_id: 'PLT-583' });
+    expect(parseTarget({ target: 'linear:PLT-583' })).toEqual({ platform: 'linear', issue_id: 'PLT-583' });
   });
 
   it('returns null for unknown platform prefix', () => {
-    expect(parseTarget('jira:ABC-123')).toBeNull();
+    expect(parseTarget({ target: 'jira:ABC-123' })).toBeNull();
   });
 
   it('returns null for malformed GitHub target', () => {
-    expect(parseTarget('github:owner/repo/notakind/1')).toBeNull();
-    expect(parseTarget('github:owner/repo/pull/zero')).toBeNull();
+    expect(parseTarget({ target: 'github:owner/repo/notakind/1' })).toBeNull();
+    expect(parseTarget({ target: 'github:owner/repo/pull/zero' })).toBeNull();
+  });
+
+  // Codex P2: the previous `Number.parseInt` happily returned 123 for
+  // `123junk` — the tightened regex must reject any trailing garbage on the
+  // numeric segment. Also reject leading zeros and negatives.
+  it('returns null when the numeric segment has trailing garbage', () => {
+    expect(parseTarget({ target: 'github:owner/repo/pull/123junk' })).toBeNull();
+    expect(parseTarget({ target: 'github:owner/repo/pull/123 ' })).toBeNull();
+  });
+
+  it('returns null for a leading-zero numeric segment', () => {
+    expect(parseTarget({ target: 'github:owner/repo/pull/0123' })).toBeNull();
+  });
+
+  it('returns null for a zero PR number', () => {
+    expect(parseTarget({ target: 'github:owner/repo/pull/0' })).toBeNull();
   });
 
   it('returns null for slack with empty channel', () => {
-    expect(parseTarget('slack:')).toBeNull();
-    expect(parseTarget('slack:/thread:123')).toBeNull();
+    expect(parseTarget({ target: 'slack:' })).toBeNull();
+    expect(parseTarget({ target: 'slack:/thread:123' })).toBeNull();
   });
 });

--- a/packages/mcp-server/src/tools/builtin/send/parse-target.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-target.ts
@@ -7,14 +7,21 @@
  *
  *   slack:<channel_id>/thread:<ts>     → Slack reply in a thread
  *   slack:<channel_id>                  → Slack top-level message in a channel
- *   github:<owner>/<repo>/pull/<n>     → GitHub PR comment
- *   github:<owner>/<repo>/issue/<n>    → GitHub issue comment
+ *   github:<owner>/<repo>/pull[s]/<n>  → GitHub PR comment
+ *   github:<owner>/<repo>/issue[s]/<n> → GitHub issue comment
  *   gmail:<thread_id>                   → Gmail reply
  *   linear:<issue_id>                   → Linear comment
+ *
+ * `pull` and `pulls` (and `issue`/`issues`) are both accepted because
+ * PR #71 (`start_draft`) emits the plural form in its template while
+ * earlier shapes used the singular. Normalised to the singular form on
+ * the way out so downstream consumers see one canonical shape.
  *
  * Pure function. Returns `null` if the target string doesn't match any
  * supported shape — the caller surfaces a typed error.
  */
+
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
 
 export type ParsedTarget =
   | { readonly platform: 'slack'; readonly channel: string; readonly thread_ts?: string }
@@ -28,9 +35,9 @@ export type ParsedTarget =
   | { readonly platform: 'gmail'; readonly thread_id: string }
   | { readonly platform: 'linear'; readonly issue_id: string };
 
-export function parseTarget(target: string): ParsedTarget | null {
-  if (target.startsWith('slack:')) return parseSlackTarget(target);
-  if (target.startsWith('github:')) return parseGithubTarget(target);
+export function parseTarget({ target }: { target: string }): ParsedTarget | null {
+  if (target.startsWith('slack:')) return parseSlackTarget({ target });
+  if (target.startsWith('github:')) return parseGithubTarget({ target });
   if (target.startsWith('gmail:')) {
     const id = target.slice('gmail:'.length).trim();
     if (id.length === 0) return null;
@@ -44,7 +51,7 @@ export function parseTarget(target: string): ParsedTarget | null {
   return null;
 }
 
-function parseSlackTarget(target: string): ParsedTarget | null {
+function parseSlackTarget({ target }: { target: string }): ParsedTarget | null {
   // slack:<channel>[/thread:<ts>]
   const body = target.slice('slack:'.length);
   const threadMarker = '/thread:';
@@ -60,16 +67,27 @@ function parseSlackTarget(target: string): ParsedTarget | null {
   return { platform: 'slack', channel, thread_ts: threadTs };
 }
 
-function parseGithubTarget(target: string): ParsedTarget | null {
-  // github:<owner>/<repo>/(pull|issue)/<number>
+function parseGithubTarget({ target }: { target: string }): ParsedTarget | null {
+  // github:<owner>/<repo>/(pull|pulls|issue|issues)/<number>
   const body = target.slice('github:'.length);
   const parts = body.split('/');
   if (parts.length !== 4) return null;
   const [owner, repo, kindRaw, numberRaw] = parts;
   if (owner == null || repo == null || kindRaw == null || numberRaw == null) return null;
   if (owner.length === 0 || repo.length === 0) return null;
-  if (kindRaw !== 'pull' && kindRaw !== 'issue') return null;
+  const kind = normalizeGithubKind({ kindRaw });
+  if (kind === null) return null;
+  // Strict positive-integer gate: `Number.parseInt('123junk', 10)` silently
+  // returns 123, swallowing trailing garbage. Reject anything that isn't a
+  // bare base-10 positive integer (no leading zero, no sign, no suffix).
+  if (!POSITIVE_INTEGER_PATTERN.test(numberRaw)) return null;
   const number = Number.parseInt(numberRaw, 10);
   if (!Number.isFinite(number) || number <= 0) return null;
-  return { platform: 'github', owner, repo, kind: kindRaw, number };
+  return { platform: 'github', owner, repo, kind, number };
+}
+
+function normalizeGithubKind({ kindRaw }: { kindRaw: string }): 'pull' | 'issue' | null {
+  if (kindRaw === 'pull' || kindRaw === 'pulls') return 'pull';
+  if (kindRaw === 'issue' || kindRaw === 'issues') return 'issue';
+  return null;
 }

--- a/packages/mcp-server/src/tools/builtin/send/parse-target.ts
+++ b/packages/mcp-server/src/tools/builtin/send/parse-target.ts
@@ -1,0 +1,75 @@
+/**
+ * Parser for the `target:` frontmatter field of a draft file. Accepts
+ * a compact URI-style string and returns a discriminated union the
+ * `prepare_send` tool consumes.
+ *
+ * Supported shapes:
+ *
+ *   slack:<channel_id>/thread:<ts>     → Slack reply in a thread
+ *   slack:<channel_id>                  → Slack top-level message in a channel
+ *   github:<owner>/<repo>/pull/<n>     → GitHub PR comment
+ *   github:<owner>/<repo>/issue/<n>    → GitHub issue comment
+ *   gmail:<thread_id>                   → Gmail reply
+ *   linear:<issue_id>                   → Linear comment
+ *
+ * Pure function. Returns `null` if the target string doesn't match any
+ * supported shape — the caller surfaces a typed error.
+ */
+
+export type ParsedTarget =
+  | { readonly platform: 'slack'; readonly channel: string; readonly thread_ts?: string }
+  | {
+      readonly platform: 'github';
+      readonly owner: string;
+      readonly repo: string;
+      readonly kind: 'pull' | 'issue';
+      readonly number: number;
+    }
+  | { readonly platform: 'gmail'; readonly thread_id: string }
+  | { readonly platform: 'linear'; readonly issue_id: string };
+
+export function parseTarget(target: string): ParsedTarget | null {
+  if (target.startsWith('slack:')) return parseSlackTarget(target);
+  if (target.startsWith('github:')) return parseGithubTarget(target);
+  if (target.startsWith('gmail:')) {
+    const id = target.slice('gmail:'.length).trim();
+    if (id.length === 0) return null;
+    return { platform: 'gmail', thread_id: id };
+  }
+  if (target.startsWith('linear:')) {
+    const id = target.slice('linear:'.length).trim();
+    if (id.length === 0) return null;
+    return { platform: 'linear', issue_id: id };
+  }
+  return null;
+}
+
+function parseSlackTarget(target: string): ParsedTarget | null {
+  // slack:<channel>[/thread:<ts>]
+  const body = target.slice('slack:'.length);
+  const threadMarker = '/thread:';
+  const threadIdx = body.indexOf(threadMarker);
+  if (threadIdx === -1) {
+    const channel = body.trim();
+    if (channel.length === 0) return null;
+    return { platform: 'slack', channel };
+  }
+  const channel = body.slice(0, threadIdx).trim();
+  const threadTs = body.slice(threadIdx + threadMarker.length).trim();
+  if (channel.length === 0 || threadTs.length === 0) return null;
+  return { platform: 'slack', channel, thread_ts: threadTs };
+}
+
+function parseGithubTarget(target: string): ParsedTarget | null {
+  // github:<owner>/<repo>/(pull|issue)/<number>
+  const body = target.slice('github:'.length);
+  const parts = body.split('/');
+  if (parts.length !== 4) return null;
+  const [owner, repo, kindRaw, numberRaw] = parts;
+  if (owner == null || repo == null || kindRaw == null || numberRaw == null) return null;
+  if (owner.length === 0 || repo.length === 0) return null;
+  if (kindRaw !== 'pull' && kindRaw !== 'issue') return null;
+  const number = Number.parseInt(numberRaw, 10);
+  if (!Number.isFinite(number) || number <= 0) return null;
+  return { platform: 'github', owner, repo, kind: kindRaw, number };
+}

--- a/packages/mcp-server/src/tools/builtin/send/prepare-send.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/prepare-send.test.ts
@@ -25,7 +25,7 @@ describe('createPrepareSendTool', () => {
     return async () => content;
   }
 
-  it('returns the parsed Slack target + body + instructions', async () => {
+  it('returns routing metadata + token but NO tool_args on the unconfirmed first call', async () => {
     const draft = '---\ndraft_id: d1\ntarget: slack:C123/thread:1234.5678\n---\nHey, picking this back up.\n';
     const tool = createPrepareSendTool({ now: () => FIXED_NOW, readFileImpl: makeReader(draft) });
     const result = await tool.handler({
@@ -42,10 +42,95 @@ describe('createPrepareSendTool', () => {
         thread_ts: '1234.5678',
       });
       expect(parsed.body).toBe('Hey, picking this back up.');
+      expect(parsed.server).toBe('slack');
+      expect(parsed.tool_name).toBe('slack_send_message');
+      expect(parsed.requires_confirmation).toBe(true);
+      expect(parsed.tool_args).toBeUndefined();
+      expect(parsed.confirmation_token.length).toBeGreaterThan(0);
+      expect(parsed.frontmatter_hash.length).toBeGreaterThan(0);
       expect(parsed.instructions).toContain('5 seconds');
       expect(parsed.instructions).toContain('undo');
-      expect(parsed.instructions).toContain('record_send_outcome');
+      expect(parsed.instructions).toContain('confirmed: true');
     }
+  });
+
+  it('returns tool_args on the confirmed second call when the token matches', async () => {
+    const draft = '---\ndraft_id: d1\ntarget: slack:C123/thread:1234.5678\n---\nHey, picking this back up.\n';
+    const tool = createPrepareSendTool({ now: () => FIXED_NOW, readFileImpl: makeReader(draft) });
+    const first = await tool.handler({
+      input: PrepareSendArgs.parse({ draft_path: '/tmp/drafts/d1.md' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(first.isOk()).toBe(true);
+    if (!first.isOk()) return;
+    const firstParsed = PrepareSendResult.parse(first.value);
+
+    const second = await tool.handler({
+      input: PrepareSendArgs.parse({
+        draft_path: '/tmp/drafts/d1.md',
+        confirmed: true,
+        confirmation_token: firstParsed.confirmation_token,
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(second.isOk()).toBe(true);
+    if (second.isOk()) {
+      const parsed = PrepareSendResult.parse(second.value);
+      expect(parsed.requires_confirmation).toBe(false);
+      expect(parsed.tool_args).toEqual({
+        channel_id: 'C123',
+        thread_ts: '1234.5678',
+        text: 'Hey, picking this back up.',
+      });
+      expect(parsed.instructions).toContain('mcp__slack__slack_send_message');
+      expect(parsed.instructions).toContain('record_send_outcome');
+      expect(parsed.instructions).toContain(parsed.frontmatter_hash);
+    }
+  });
+
+  it('rejects a confirmed call with a mismatching token', async () => {
+    const draft = '---\ndraft_id: d1\ntarget: slack:C123\n---\nbody\n';
+    const tool = createPrepareSendTool({ now: () => FIXED_NOW, readFileImpl: makeReader(draft) });
+    const result = await tool.handler({
+      input: PrepareSendArgs.parse({
+        draft_path: '/tmp/d.md',
+        confirmed: true,
+        confirmation_token: 'not-the-real-token',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toContain('confirmation_token mismatch');
+  });
+
+  it('uses MCP routing (not gh api) for a GitHub PR target', async () => {
+    const draft = '---\ndraft_id: d2\ntarget: github:acme/widgets/pulls/9\n---\nLGTM modulo lint.\n';
+    const tool = createPrepareSendTool({ now: () => FIXED_NOW, readFileImpl: makeReader(draft) });
+    const first = await tool.handler({
+      input: PrepareSendArgs.parse({ draft_path: '/tmp/d.md' }),
+      ctx: { db: dbHandle.db },
+    });
+    if (!first.isOk()) throw new Error('unexpected error');
+    const firstParsed = PrepareSendResult.parse(first.value);
+    expect(firstParsed.server).toBe('github');
+    expect(firstParsed.tool_name).toBe('add_issue_comment');
+
+    const second = await tool.handler({
+      input: PrepareSendArgs.parse({
+        draft_path: '/tmp/d.md',
+        confirmed: true,
+        confirmation_token: firstParsed.confirmation_token,
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    if (!second.isOk()) throw new Error('unexpected error');
+    const secondParsed = PrepareSendResult.parse(second.value);
+    expect(secondParsed.tool_args).toEqual({
+      owner: 'acme',
+      repo: 'widgets',
+      issue_number: 9,
+      body: 'LGTM modulo lint.',
+    });
   });
 
   it('errors when target frontmatter is missing', async () => {

--- a/packages/mcp-server/src/tools/builtin/send/prepare-send.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/prepare-send.test.ts
@@ -47,7 +47,7 @@ describe('createPrepareSendTool', () => {
       expect(parsed.requires_confirmation).toBe(true);
       expect(parsed.tool_args).toBeUndefined();
       expect(parsed.confirmation_token.length).toBeGreaterThan(0);
-      expect(parsed.frontmatter_hash.length).toBeGreaterThan(0);
+      expect(parsed.content_hash.length).toBeGreaterThan(0);
       expect(parsed.instructions).toContain('5 seconds');
       expect(parsed.instructions).toContain('undo');
       expect(parsed.instructions).toContain('confirmed: true');
@@ -84,7 +84,7 @@ describe('createPrepareSendTool', () => {
       });
       expect(parsed.instructions).toContain('mcp__slack__slack_send_message');
       expect(parsed.instructions).toContain('record_send_outcome');
-      expect(parsed.instructions).toContain(parsed.frontmatter_hash);
+      expect(parsed.instructions).toContain(parsed.content_hash);
     }
   });
 
@@ -101,6 +101,46 @@ describe('createPrepareSendTool', () => {
     });
     expect(result.isErr()).toBe(true);
     if (result.isErr()) expect(result.error.message).toContain('confirmation_token mismatch');
+  });
+
+  /**
+   * Iter-3 P1: confirmation token must cover body drift. If the body
+   * changes between the unconfirmed and confirmed calls, the old
+   * token must NOT validate — otherwise an edited body could be sent
+   * without fresh user approval. Frontmatter-only hashing missed
+   * this; content-hash (frontmatter + body) closes it.
+   */
+  it('invalidates the confirmation token when the draft body changes between calls', async () => {
+    const originalDraft = '---\ndraft_id: d1\ntarget: slack:C123\n---\nOriginal body\n';
+    const editedDraft = '---\ndraft_id: d1\ntarget: slack:C123\n---\nMALICIOUSLY EDITED BODY\n';
+
+    let draftContent = originalDraft;
+    const tool = createPrepareSendTool({
+      now: () => FIXED_NOW,
+      readFileImpl: async () => draftContent,
+    });
+
+    const first = await tool.handler({
+      input: PrepareSendArgs.parse({ draft_path: '/tmp/d.md' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(first.isOk()).toBe(true);
+    if (!first.isOk()) return;
+    const firstParsed = PrepareSendResult.parse(first.value);
+
+    // Body mutates between the two prepare_send calls.
+    draftContent = editedDraft;
+
+    const second = await tool.handler({
+      input: PrepareSendArgs.parse({
+        draft_path: '/tmp/d.md',
+        confirmed: true,
+        confirmation_token: firstParsed.confirmation_token,
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(second.isErr()).toBe(true);
+    if (second.isErr()) expect(second.error.message).toContain('confirmation_token mismatch');
   });
 
   it('uses MCP routing (not gh api) for a GitHub PR target', async () => {

--- a/packages/mcp-server/src/tools/builtin/send/prepare-send.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/prepare-send.test.ts
@@ -1,0 +1,98 @@
+/**
+ * End-to-end tests for the prepare_send tool. Uses an injected
+ * fake-fs reader so we don't need a real file on disk.
+ */
+
+import { PrepareSendArgs, PrepareSendResult } from '@slopweaver/contracts';
+import { createDb } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createPrepareSendTool } from './prepare-send.ts';
+
+const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
+
+describe('createPrepareSendTool', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  function makeReader(content: string): (p: string) => Promise<string> {
+    return async () => content;
+  }
+
+  it('returns the parsed Slack target + body + instructions', async () => {
+    const draft = '---\ndraft_id: d1\ntarget: slack:C123/thread:1234.5678\n---\nHey, picking this back up.\n';
+    const tool = createPrepareSendTool({ now: () => FIXED_NOW, readFileImpl: makeReader(draft) });
+    const result = await tool.handler({
+      input: PrepareSendArgs.parse({ draft_path: '/tmp/drafts/d1.md' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = PrepareSendResult.parse(result.value);
+      expect(parsed.draft_id).toBe('d1');
+      expect(parsed.target).toEqual({
+        platform: 'slack',
+        channel: 'C123',
+        thread_ts: '1234.5678',
+      });
+      expect(parsed.body).toBe('Hey, picking this back up.');
+      expect(parsed.instructions).toContain('5 seconds');
+      expect(parsed.instructions).toContain('undo');
+      expect(parsed.instructions).toContain('record_send_outcome');
+    }
+  });
+
+  it('errors when target frontmatter is missing', async () => {
+    const draft = '---\ndraft_id: d1\n---\nbody\n';
+    const tool = createPrepareSendTool({ now: () => FIXED_NOW, readFileImpl: makeReader(draft) });
+    const result = await tool.handler({
+      input: PrepareSendArgs.parse({ draft_path: '/tmp/d.md' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toContain('missing the required');
+  });
+
+  it('errors when target syntax is unsupported', async () => {
+    const draft = '---\ntarget: facebook:lol\n---\nbody\n';
+    const tool = createPrepareSendTool({ now: () => FIXED_NOW, readFileImpl: makeReader(draft) });
+    const result = await tool.handler({
+      input: PrepareSendArgs.parse({ draft_path: '/tmp/d.md' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toContain('does not match any supported shape');
+  });
+
+  it('errors when body is empty', async () => {
+    const draft = '---\ntarget: slack:C1\n---\n\n';
+    const tool = createPrepareSendTool({ now: () => FIXED_NOW, readFileImpl: makeReader(draft) });
+    const result = await tool.handler({
+      input: PrepareSendArgs.parse({ draft_path: '/tmp/d.md' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toContain('empty body');
+  });
+
+  it("errors when the draft file can't be read", async () => {
+    const tool = createPrepareSendTool({
+      now: () => FIXED_NOW,
+      readFileImpl: async () => {
+        throw new Error('ENOENT: no such file');
+      },
+    });
+    const result = await tool.handler({
+      input: PrepareSendArgs.parse({ draft_path: '/missing.md' }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toContain('failed to read');
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/send/prepare-send.ts
+++ b/packages/mcp-server/src/tools/builtin/send/prepare-send.ts
@@ -1,26 +1,37 @@
 /**
  * `prepare_send` — read a draft file, parse the YAML frontmatter,
  * resolve the `target:` to a typed platform target, return the body
- * + an instruction block for the model to actually invoke the right
- * MCP send tool.
+ * + structured MCP routing data + an instruction block for the model
+ * to actually invoke the right MCP send tool.
  *
  * SlopWeaver's MCP server can't call other MCP servers across the SDK
  * boundary — that's the client's job (Claude Code in practice). So we
  * prepare the payload + tell the model which `mcp__*__*` tool to call
  * with which arguments, and the model executes.
  *
- * Includes a 5-second "undo gate" instruction in the body so the model
- * pauses before invoking the actual send tool — gives the user a
- * chance to type `undo` and abort.
+ * Two-step confirmation flow. The first call (without `confirmed`)
+ * returns `requires_confirmation: true`, a `confirmation_token`, the
+ * routing metadata (`server`, `tool_name`), and the body — but **not**
+ * `tool_args`. The model surfaces the 5-second undo gate to the user.
+ * Only after the user OKs does the model call `prepare_send` again
+ * with `confirmed: true` + the same token; that response includes
+ * `tool_args` (the executable payload). "Never auto-send without
+ * confirmation" is therefore enforced by the contract, not just prose.
+ *
+ * The `confirmation_token` is deterministic per (draft_path,
+ * frontmatter_hash) so a re-call from the same draft state yields the
+ * same token. Editing the draft between calls changes the hash, which
+ * changes the token, which invalidates any pending confirmation.
  */
 
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { PrepareSendArgs, PrepareSendResult } from '@slopweaver/contracts';
 import { err, ok } from '@slopweaver/errors';
 import { McpErrors } from '../../../errors.ts';
 import { defineTool, type Tool } from '../../registry.ts';
-import { parseFrontmatter } from './parse-frontmatter.ts';
-import { parseTarget } from './parse-target.ts';
+import { hashFrontmatter, parseFrontmatter } from './parse-frontmatter.ts';
+import { parseTarget, type ParsedTarget } from './parse-target.ts';
 
 export type CreatePrepareSendToolArgs = {
   /** Clock injection for tests. Defaults to `Date.now`. */
@@ -36,7 +47,7 @@ export function createPrepareSendTool(args: CreatePrepareSendToolArgs = {}): Too
   return defineTool({
     name: 'prepare_send',
     description:
-      'Read a draft file, parse its YAML frontmatter, validate the `target:` field, and return the parsed target + body + an instruction block telling the model exactly which platform MCP tool to invoke with which arguments. Does NOT send — the model runs the next tool. Includes the 5-second undo gate as part of the instructions.',
+      'Read a draft file, parse its YAML frontmatter, validate the `target:` field, and return the parsed target + body + structured MCP routing (`server`, `tool_name`) + an instruction block. Two-step confirmation: the first call returns `requires_confirmation: true` and a `confirmation_token` but omits the executable `tool_args`; the second call (`confirmed: true` + same token) returns `tool_args` for the model to execute. Includes the 5-second undo gate in the instructions on the first pass.',
     inputSchema: PrepareSendArgs,
     outputSchema: PrepareSendResult,
     handler: async ({ input }) => {
@@ -52,7 +63,7 @@ export function createPrepareSendTool(args: CreatePrepareSendToolArgs = {}): Too
           ),
         );
       }
-      const parsed = parseFrontmatter(content);
+      const parsed = parseFrontmatter({ input: content });
       if (parsed === null) {
         return err(
           McpErrors.unexpected(
@@ -72,13 +83,13 @@ export function createPrepareSendTool(args: CreatePrepareSendToolArgs = {}): Too
           ),
         );
       }
-      const target = parseTarget(targetRaw);
+      const target = parseTarget({ target: targetRaw });
       if (target === null) {
         return err(
           McpErrors.unexpected(
             'prepare_send',
             undefined,
-            `target "${targetRaw}" does not match any supported shape (slack:<channel>[/thread:<ts>], github:<owner>/<repo>/(pull|issue)/<n>, gmail:<thread_id>, linear:<issue_id>)`,
+            `target "${targetRaw}" does not match any supported shape (slack:<channel>[/thread:<ts>], github:<owner>/<repo>/(pull|pulls|issue|issues)/<n>, gmail:<thread_id>, linear:<issue_id>)`,
           ),
         );
       }
@@ -87,29 +98,141 @@ export function createPrepareSendTool(args: CreatePrepareSendToolArgs = {}): Too
         return err(McpErrors.unexpected('prepare_send', undefined, `draft at ${input.draft_path} has an empty body`));
       }
       const draftId = parsed.frontmatter['draft_id'];
+      const frontmatterHash = hashFrontmatter({ frontmatter: parsed.frontmatter });
+      const confirmationToken = deriveConfirmationToken({
+        draftPath: input.draft_path,
+        frontmatterHash,
+      });
+
+      const isConfirmed = input.confirmed === true;
+      if (isConfirmed && input.confirmation_token !== confirmationToken) {
+        return err(
+          McpErrors.unexpected(
+            'prepare_send',
+            undefined,
+            `confirmation_token mismatch — re-call prepare_send without \`confirmed\` to fetch a fresh token (the draft frontmatter may have changed since the first call)`,
+          ),
+        );
+      }
+
+      const routing = buildRouting({ target, body });
       return ok({
         ...(draftId != null && draftId.length > 0 && { draft_id: draftId }),
         target,
         body,
-        instructions: buildInstructions({ target, body, draftPath: input.draft_path }),
+        server: routing.server,
+        tool_name: routing.tool_name,
+        ...(isConfirmed && { tool_args: routing.tool_args }),
+        requires_confirmation: !isConfirmed,
+        confirmation_token: confirmationToken,
+        frontmatter_hash: frontmatterHash,
+        instructions: buildInstructions({
+          target,
+          draftPath: input.draft_path,
+          routing,
+          isConfirmed,
+          confirmationToken,
+          frontmatterHash,
+          draftId: draftId != null && draftId.length > 0 ? draftId : null,
+        }),
         generated_at: new Date(now()).toISOString(),
       });
     },
   });
 }
 
-function buildInstructions(args: {
-  target: ReturnType<typeof parseTarget> & object;
-  body: string;
-  draftPath: string;
-}): string {
-  const lead = `# Send the draft\n\nA draft is ready at \`${args.draftPath}\`. Before invoking the send tool, surface this one-liner to the user:\n\n> Sending to ${describeTarget(args.target)} in 5 seconds. Reply with \`undo\` to cancel.\n\nWait for either an \`undo\` (in which case call \`record_send_outcome\` with status \`cancelled\` and stop) or 5 seconds of silence.\n\n`;
-  const exec = renderExec(args.target);
-  const post = `\nAfter the send tool returns, call \`record_send_outcome({ draft_path: "${args.draftPath}", status: "sent", sent_url: <permalink-from-send-response> })\`. If the send tool errors, call it with status \`failed\` and the error message.\n`;
-  return `${lead}${exec}${post}`;
+/**
+ * `tool_args` must serialise cleanly through the MCP wire (JSON) and
+ * round-trip through the `PrepareSendResult` Zod schema, which expects
+ * `Record<string, JsonValue>`. Mirror the JsonValue shape locally so
+ * the buildRouting helper's return type lines up with the contract
+ * without importing the type from `@slopweaver/contracts` (it's not in
+ * the public exports). The shape (mutable Array, mutable object) is
+ * intentionally the same as the contracts' internal `JsonValue` so
+ * structural assignment works under TS's strict structural compat
+ * check.
+ */
+type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+type ToolArgs = Record<string, JsonValue>;
+
+type Routing = {
+  readonly server: string;
+  readonly tool_name: string;
+  readonly tool_args: ToolArgs;
+};
+
+/**
+ * Map a parsed target to the downstream MCP server + tool + args. GitHub
+ * stays on the MCP routing path (no `gh api` fallback) — `mcp__github__add_issue_comment`
+ * handles both issue and PR comments (PR comments use the issues
+ * endpoint upstream).
+ */
+function buildRouting({ target, body }: { target: ParsedTarget; body: string }): Routing {
+  if (target.platform === 'slack') {
+    const args: ToolArgs = { channel_id: target.channel, text: body };
+    if (target.thread_ts != null) args['thread_ts'] = target.thread_ts;
+    return { server: 'slack', tool_name: 'slack_send_message', tool_args: args };
+  }
+  if (target.platform === 'github') {
+    return {
+      server: 'github',
+      tool_name: 'add_issue_comment',
+      tool_args: {
+        owner: target.owner,
+        repo: target.repo,
+        issue_number: target.number,
+        body,
+      },
+    };
+  }
+  if (target.platform === 'gmail') {
+    return {
+      server: 'gmail',
+      tool_name: 'send_message',
+      tool_args: { thread_id: target.thread_id, body },
+    };
+  }
+  return {
+    server: 'linear',
+    tool_name: 'create_comment',
+    tool_args: { issueId: target.issue_id, body },
+  };
 }
 
-function describeTarget(target: ReturnType<typeof parseTarget> & object): string {
+/**
+ * Deterministic per-draft-state token. Tying the token to the
+ * frontmatter hash (not just a random nonce) means: editing the draft
+ * between the first and second call changes the hash → changes the
+ * token → the second call fails the equality check. That's the
+ * "drift detection" half of the confirmation gate.
+ */
+function deriveConfirmationToken({
+  draftPath,
+  frontmatterHash,
+}: {
+  draftPath: string;
+  frontmatterHash: string;
+}): string {
+  return createHash('sha256').update(`${draftPath}\n${frontmatterHash}`, 'utf-8').digest('hex').slice(0, 24);
+}
+
+function buildInstructions(args: {
+  target: ParsedTarget;
+  draftPath: string;
+  routing: Routing;
+  isConfirmed: boolean;
+  confirmationToken: string;
+  frontmatterHash: string;
+  draftId: string | null;
+}): string {
+  if (!args.isConfirmed) {
+    return `# Confirm the send\n\nA draft is ready at \`${args.draftPath}\`. Routing:\n\n- server: \`${args.routing.server}\`\n- tool: \`${args.routing.tool_name}\`\n- target: ${describeTarget(args.target)}\n\nSurface this one-liner to the user:\n\n> Sending to ${describeTarget(args.target)} in 5 seconds. Reply with \`undo\` to cancel.\n\nWait for either an \`undo\` (in which case call \`record_send_outcome\` with status \`cancelled\` and stop) or 5 seconds of silence.\n\nThen re-call \`prepare_send\` with \`confirmed: true\` and \`confirmation_token: "${args.confirmationToken}"\` to receive the executable \`tool_args\`. Do not invoke any send tool without that second response — the contract intentionally omits \`tool_args\` on the unconfirmed pass.\n`;
+  }
+  const draftIdLine = args.draftId != null ? `, draft_id: "${args.draftId}"` : '';
+  return `# Execute the send\n\nInvoke \`mcp__${args.routing.server}__${args.routing.tool_name}\` with the \`tool_args\` from this response. After it returns:\n\n- On success: \`record_send_outcome({ draft_path: "${args.draftPath}"${draftIdLine}, frontmatter_hash: "${args.frontmatterHash}", status: "sent", sent_url: <permalink-from-send-response> })\`\n- On failure: \`record_send_outcome({ draft_path: "${args.draftPath}"${draftIdLine}, frontmatter_hash: "${args.frontmatterHash}", status: "failed", error: <message> })\`\n`;
+}
+
+function describeTarget(target: ParsedTarget): string {
   if (target.platform === 'slack') {
     return target.thread_ts != null
       ? `Slack thread ${target.thread_ts} in channel ${target.channel}`
@@ -122,18 +245,4 @@ function describeTarget(target: ReturnType<typeof parseTarget> & object): string
     return `Gmail thread ${target.thread_id}`;
   }
   return `Linear issue ${target.issue_id}`;
-}
-
-function renderExec(target: ReturnType<typeof parseTarget> & object): string {
-  if (target.platform === 'slack') {
-    const threadLine = target.thread_ts != null ? `, thread_ts: "${target.thread_ts}"` : '';
-    return `\`\`\`\nslack_send_message({ channel_id: "${target.channel}"${threadLine}, text: <body> })\n\`\`\`\n`;
-  }
-  if (target.platform === 'github') {
-    return `\`\`\`\ngh api -X POST /repos/${target.owner}/${target.repo}/issues/${target.number}/comments -F body=<body>\n\`\`\`\n(Or use the equivalent github MCP tool if one is connected.)\n`;
-  }
-  if (target.platform === 'gmail') {
-    return `\`\`\`\nmcp__gmail__send_message({ thread_id: "${target.thread_id}", body: <body> })\n\`\`\`\n(Send via reply to existing thread.)\n`;
-  }
-  return `\`\`\`\nmcp__linear__create_comment({ issueId: "${target.issue_id}", body: <body> })\n\`\`\`\n`;
 }

--- a/packages/mcp-server/src/tools/builtin/send/prepare-send.ts
+++ b/packages/mcp-server/src/tools/builtin/send/prepare-send.ts
@@ -19,9 +19,12 @@
  * confirmation" is therefore enforced by the contract, not just prose.
  *
  * The `confirmation_token` is deterministic per (draft_path,
- * frontmatter_hash) so a re-call from the same draft state yields the
- * same token. Editing the draft between calls changes the hash, which
- * changes the token, which invalidates any pending confirmation.
+ * content_hash) so a re-call from the same draft state yields the
+ * same token. Editing the draft between calls — frontmatter OR body —
+ * changes the hash, which changes the token, which invalidates any
+ * pending confirmation. Body coverage is critical: without it, a
+ * model could edit the body between the unconfirmed and confirmed
+ * passes and send text the user never approved.
  */
 
 import { createHash } from 'node:crypto';
@@ -30,7 +33,7 @@ import { PrepareSendArgs, PrepareSendResult } from '@slopweaver/contracts';
 import { err, ok } from '@slopweaver/errors';
 import { McpErrors } from '../../../errors.ts';
 import { defineTool, type Tool } from '../../registry.ts';
-import { hashFrontmatter, parseFrontmatter } from './parse-frontmatter.ts';
+import { hashContent, parseFrontmatter } from './parse-frontmatter.ts';
 import { parseTarget, type ParsedTarget } from './parse-target.ts';
 
 export type CreatePrepareSendToolArgs = {
@@ -98,10 +101,10 @@ export function createPrepareSendTool(args: CreatePrepareSendToolArgs = {}): Too
         return err(McpErrors.unexpected('prepare_send', undefined, `draft at ${input.draft_path} has an empty body`));
       }
       const draftId = parsed.frontmatter['draft_id'];
-      const frontmatterHash = hashFrontmatter({ frontmatter: parsed.frontmatter });
+      const contentHash = hashContent({ frontmatter: parsed.frontmatter, body });
       const confirmationToken = deriveConfirmationToken({
         draftPath: input.draft_path,
-        frontmatterHash,
+        contentHash,
       });
 
       const isConfirmed = input.confirmed === true;
@@ -110,7 +113,7 @@ export function createPrepareSendTool(args: CreatePrepareSendToolArgs = {}): Too
           McpErrors.unexpected(
             'prepare_send',
             undefined,
-            `confirmation_token mismatch — re-call prepare_send without \`confirmed\` to fetch a fresh token (the draft frontmatter may have changed since the first call)`,
+            `confirmation_token mismatch — re-call prepare_send without \`confirmed\` to fetch a fresh token (the draft content may have changed since the first call)`,
           ),
         );
       }
@@ -125,14 +128,14 @@ export function createPrepareSendTool(args: CreatePrepareSendToolArgs = {}): Too
         ...(isConfirmed && { tool_args: routing.tool_args }),
         requires_confirmation: !isConfirmed,
         confirmation_token: confirmationToken,
-        frontmatter_hash: frontmatterHash,
+        content_hash: contentHash,
         instructions: buildInstructions({
           target,
           draftPath: input.draft_path,
           routing,
           isConfirmed,
           confirmationToken,
-          frontmatterHash,
+          contentHash,
           draftId: draftId != null && draftId.length > 0 ? draftId : null,
         }),
         generated_at: new Date(now()).toISOString(),
@@ -201,19 +204,15 @@ function buildRouting({ target, body }: { target: ParsedTarget; body: string }):
 
 /**
  * Deterministic per-draft-state token. Tying the token to the
- * frontmatter hash (not just a random nonce) means: editing the draft
- * between the first and second call changes the hash → changes the
- * token → the second call fails the equality check. That's the
- * "drift detection" half of the confirmation gate.
+ * content hash (frontmatter + body) means: editing the draft between
+ * the first and second call — frontmatter OR body — changes the
+ * hash → changes the token → the second call fails the equality
+ * check. That's the "drift detection" half of the confirmation
+ * gate, and the body coverage closes the body-edit attack on the
+ * earlier frontmatter-only token.
  */
-function deriveConfirmationToken({
-  draftPath,
-  frontmatterHash,
-}: {
-  draftPath: string;
-  frontmatterHash: string;
-}): string {
-  return createHash('sha256').update(`${draftPath}\n${frontmatterHash}`, 'utf-8').digest('hex').slice(0, 24);
+function deriveConfirmationToken({ draftPath, contentHash }: { draftPath: string; contentHash: string }): string {
+  return createHash('sha256').update(`${draftPath}\n${contentHash}`, 'utf-8').digest('hex').slice(0, 24);
 }
 
 function buildInstructions(args: {
@@ -222,14 +221,14 @@ function buildInstructions(args: {
   routing: Routing;
   isConfirmed: boolean;
   confirmationToken: string;
-  frontmatterHash: string;
+  contentHash: string;
   draftId: string | null;
 }): string {
   if (!args.isConfirmed) {
     return `# Confirm the send\n\nA draft is ready at \`${args.draftPath}\`. Routing:\n\n- server: \`${args.routing.server}\`\n- tool: \`${args.routing.tool_name}\`\n- target: ${describeTarget(args.target)}\n\nSurface this one-liner to the user:\n\n> Sending to ${describeTarget(args.target)} in 5 seconds. Reply with \`undo\` to cancel.\n\nWait for either an \`undo\` (in which case call \`record_send_outcome\` with status \`cancelled\` and stop) or 5 seconds of silence.\n\nThen re-call \`prepare_send\` with \`confirmed: true\` and \`confirmation_token: "${args.confirmationToken}"\` to receive the executable \`tool_args\`. Do not invoke any send tool without that second response — the contract intentionally omits \`tool_args\` on the unconfirmed pass.\n`;
   }
   const draftIdLine = args.draftId != null ? `, draft_id: "${args.draftId}"` : '';
-  return `# Execute the send\n\nInvoke \`mcp__${args.routing.server}__${args.routing.tool_name}\` with the \`tool_args\` from this response. After it returns:\n\n- On success: \`record_send_outcome({ draft_path: "${args.draftPath}"${draftIdLine}, frontmatter_hash: "${args.frontmatterHash}", status: "sent", sent_url: <permalink-from-send-response> })\`\n- On failure: \`record_send_outcome({ draft_path: "${args.draftPath}"${draftIdLine}, frontmatter_hash: "${args.frontmatterHash}", status: "failed", error: <message> })\`\n`;
+  return `# Execute the send\n\nInvoke \`mcp__${args.routing.server}__${args.routing.tool_name}\` with the \`tool_args\` from this response. After it returns:\n\n- On success: \`record_send_outcome({ draft_path: "${args.draftPath}"${draftIdLine}, content_hash: "${args.contentHash}", status: "sent", sent_url: <permalink-from-send-response> })\`\n- On failure: \`record_send_outcome({ draft_path: "${args.draftPath}"${draftIdLine}, content_hash: "${args.contentHash}", status: "failed", error: <message> })\`\n`;
 }
 
 function describeTarget(target: ParsedTarget): string {

--- a/packages/mcp-server/src/tools/builtin/send/prepare-send.ts
+++ b/packages/mcp-server/src/tools/builtin/send/prepare-send.ts
@@ -1,0 +1,139 @@
+/**
+ * `prepare_send` — read a draft file, parse the YAML frontmatter,
+ * resolve the `target:` to a typed platform target, return the body
+ * + an instruction block for the model to actually invoke the right
+ * MCP send tool.
+ *
+ * SlopWeaver's MCP server can't call other MCP servers across the SDK
+ * boundary — that's the client's job (Claude Code in practice). So we
+ * prepare the payload + tell the model which `mcp__*__*` tool to call
+ * with which arguments, and the model executes.
+ *
+ * Includes a 5-second "undo gate" instruction in the body so the model
+ * pauses before invoking the actual send tool — gives the user a
+ * chance to type `undo` and abort.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { PrepareSendArgs, PrepareSendResult } from '@slopweaver/contracts';
+import { err, ok } from '@slopweaver/errors';
+import { McpErrors } from '../../../errors.ts';
+import { defineTool, type Tool } from '../../registry.ts';
+import { parseFrontmatter } from './parse-frontmatter.ts';
+import { parseTarget } from './parse-target.ts';
+
+export type CreatePrepareSendToolArgs = {
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Override the fs reader (tests). */
+  readFileImpl?: (path: string) => Promise<string>;
+};
+
+export function createPrepareSendTool(args: CreatePrepareSendToolArgs = {}): Tool {
+  const now = args.now ?? Date.now;
+  const readImpl = args.readFileImpl ?? ((p) => readFile(p, 'utf-8'));
+
+  return defineTool({
+    name: 'prepare_send',
+    description:
+      'Read a draft file, parse its YAML frontmatter, validate the `target:` field, and return the parsed target + body + an instruction block telling the model exactly which platform MCP tool to invoke with which arguments. Does NOT send — the model runs the next tool. Includes the 5-second undo gate as part of the instructions.',
+    inputSchema: PrepareSendArgs,
+    outputSchema: PrepareSendResult,
+    handler: async ({ input }) => {
+      let content: string;
+      try {
+        content = await readImpl(input.draft_path);
+      } catch (e) {
+        return err(
+          McpErrors.unexpected(
+            'prepare_send',
+            undefined,
+            `failed to read draft at ${input.draft_path}: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+      }
+      const parsed = parseFrontmatter(content);
+      if (parsed === null) {
+        return err(
+          McpErrors.unexpected(
+            'prepare_send',
+            undefined,
+            `draft at ${input.draft_path} has no parseable YAML frontmatter; required keys: target, draft_id`,
+          ),
+        );
+      }
+      const targetRaw = parsed.frontmatter['target'];
+      if (targetRaw == null || targetRaw.length === 0) {
+        return err(
+          McpErrors.unexpected(
+            'prepare_send',
+            undefined,
+            `draft at ${input.draft_path} is missing the required \`target:\` frontmatter field`,
+          ),
+        );
+      }
+      const target = parseTarget(targetRaw);
+      if (target === null) {
+        return err(
+          McpErrors.unexpected(
+            'prepare_send',
+            undefined,
+            `target "${targetRaw}" does not match any supported shape (slack:<channel>[/thread:<ts>], github:<owner>/<repo>/(pull|issue)/<n>, gmail:<thread_id>, linear:<issue_id>)`,
+          ),
+        );
+      }
+      const body = parsed.body.trim();
+      if (body.length === 0) {
+        return err(McpErrors.unexpected('prepare_send', undefined, `draft at ${input.draft_path} has an empty body`));
+      }
+      const draftId = parsed.frontmatter['draft_id'];
+      return ok({
+        ...(draftId != null && draftId.length > 0 && { draft_id: draftId }),
+        target,
+        body,
+        instructions: buildInstructions({ target, body, draftPath: input.draft_path }),
+        generated_at: new Date(now()).toISOString(),
+      });
+    },
+  });
+}
+
+function buildInstructions(args: {
+  target: ReturnType<typeof parseTarget> & object;
+  body: string;
+  draftPath: string;
+}): string {
+  const lead = `# Send the draft\n\nA draft is ready at \`${args.draftPath}\`. Before invoking the send tool, surface this one-liner to the user:\n\n> Sending to ${describeTarget(args.target)} in 5 seconds. Reply with \`undo\` to cancel.\n\nWait for either an \`undo\` (in which case call \`record_send_outcome\` with status \`cancelled\` and stop) or 5 seconds of silence.\n\n`;
+  const exec = renderExec(args.target);
+  const post = `\nAfter the send tool returns, call \`record_send_outcome({ draft_path: "${args.draftPath}", status: "sent", sent_url: <permalink-from-send-response> })\`. If the send tool errors, call it with status \`failed\` and the error message.\n`;
+  return `${lead}${exec}${post}`;
+}
+
+function describeTarget(target: ReturnType<typeof parseTarget> & object): string {
+  if (target.platform === 'slack') {
+    return target.thread_ts != null
+      ? `Slack thread ${target.thread_ts} in channel ${target.channel}`
+      : `Slack channel ${target.channel}`;
+  }
+  if (target.platform === 'github') {
+    return `GitHub ${target.kind} #${target.number} in ${target.owner}/${target.repo}`;
+  }
+  if (target.platform === 'gmail') {
+    return `Gmail thread ${target.thread_id}`;
+  }
+  return `Linear issue ${target.issue_id}`;
+}
+
+function renderExec(target: ReturnType<typeof parseTarget> & object): string {
+  if (target.platform === 'slack') {
+    const threadLine = target.thread_ts != null ? `, thread_ts: "${target.thread_ts}"` : '';
+    return `\`\`\`\nslack_send_message({ channel_id: "${target.channel}"${threadLine}, text: <body> })\n\`\`\`\n`;
+  }
+  if (target.platform === 'github') {
+    return `\`\`\`\ngh api -X POST /repos/${target.owner}/${target.repo}/issues/${target.number}/comments -F body=<body>\n\`\`\`\n(Or use the equivalent github MCP tool if one is connected.)\n`;
+  }
+  if (target.platform === 'gmail') {
+    return `\`\`\`\nmcp__gmail__send_message({ thread_id: "${target.thread_id}", body: <body> })\n\`\`\`\n(Send via reply to existing thread.)\n`;
+  }
+  return `\`\`\`\nmcp__linear__create_comment({ issueId: "${target.issue_id}", body: <body> })\n\`\`\`\n`;
+}

--- a/packages/mcp-server/src/tools/builtin/send/record-send-outcome.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/record-send-outcome.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RecordSendOutcomeArgs, RecordSendOutcomeResult } from '@slopweaver/contracts';
+import { createDb } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRecordSendOutcomeTool } from './record-send-outcome.ts';
+
+const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
+
+describe('createRecordSendOutcomeTool', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+  let tempDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+    tempDir = mkdtempSync(join(tmpdir(), 'slop-sends-'));
+    logPath = join(tempDir, 'sends.jsonl');
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('appends a sent outcome with permalink', async () => {
+    const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecordSendOutcomeArgs.parse({
+        draft_path: '/tmp/d.md',
+        status: 'sent',
+        sent_url: 'https://slack.com/archives/C1/p123',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const parsed = RecordSendOutcomeResult.parse(result.value);
+      expect(parsed.line_number).toBe(1);
+    }
+    const onDisk = readFileSync(logPath, 'utf-8');
+    const parsed = JSON.parse(onDisk.trim()) as Record<string, unknown>;
+    expect(parsed['status']).toBe('sent');
+    expect(parsed['sent_url']).toBe('https://slack.com/archives/C1/p123');
+  });
+
+  it('appends a failed outcome with error', async () => {
+    const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    await tool.handler({
+      input: RecordSendOutcomeArgs.parse({
+        draft_path: '/tmp/d.md',
+        status: 'failed',
+        error: 'rate limited',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    const onDisk = readFileSync(logPath, 'utf-8');
+    const parsed = JSON.parse(onDisk.trim()) as Record<string, unknown>;
+    expect(parsed['status']).toBe('failed');
+    expect(parsed['error']).toBe('rate limited');
+  });
+
+  it('appends a cancelled outcome with neither url nor error', async () => {
+    const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    await tool.handler({
+      input: RecordSendOutcomeArgs.parse({
+        draft_path: '/tmp/d.md',
+        status: 'cancelled',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    const onDisk = readFileSync(logPath, 'utf-8');
+    const parsed = JSON.parse(onDisk.trim()) as Record<string, unknown>;
+    expect(parsed['status']).toBe('cancelled');
+    expect(parsed).not.toHaveProperty('sent_url');
+    expect(parsed).not.toHaveProperty('error');
+  });
+
+  it('appends multiple lines and reports incrementing line numbers', async () => {
+    const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    for (let i = 1; i <= 3; i += 1) {
+      const r = await tool.handler({
+        input: RecordSendOutcomeArgs.parse({
+          draft_path: `/tmp/d${i}.md`,
+          status: 'cancelled',
+        }),
+        ctx: { db: dbHandle.db },
+      });
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) expect(r.value.line_number).toBe(i);
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/builtin/send/record-send-outcome.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/record-send-outcome.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { RecordSendOutcomeArgs, RecordSendOutcomeResult } from '@slopweaver/contracts';
 import { createDb } from '@slopweaver/db';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { hashFrontmatter, parseFrontmatter } from './parse-frontmatter.ts';
 import { createRecordSendOutcomeTool } from './record-send-outcome.ts';
 
 const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
@@ -12,11 +13,13 @@ describe('createRecordSendOutcomeTool', () => {
   let dbHandle: ReturnType<typeof createDb>;
   let tempDir: string;
   let logPath: string;
+  let draftPath: string;
 
   beforeEach(() => {
     dbHandle = createDb({ path: ':memory:' });
     tempDir = mkdtempSync(join(tmpdir(), 'slop-sends-'));
     logPath = join(tempDir, 'sends.jsonl');
+    draftPath = join(tempDir, 'draft.md');
   });
 
   afterEach(() => {
@@ -24,11 +27,35 @@ describe('createRecordSendOutcomeTool', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('appends a sent outcome with permalink', async () => {
+  /** Helper: write a draft with the canonical frontmatter shape and return the matching hash. */
+  function seedDraft({
+    draftId,
+    target,
+    body = 'reply body',
+    status,
+  }: {
+    draftId: string;
+    target: string;
+    body?: string;
+    status?: string;
+  }): string {
+    const fmLines: string[] = [`draft_id: ${draftId}`, `target: ${target}`];
+    if (status != null) fmLines.push(`status: ${status}`);
+    const content = `---\n${fmLines.join('\n')}\n---\n${body}\n`;
+    writeFileSync(draftPath, content, 'utf-8');
+    const parsed = parseFrontmatter({ input: content });
+    if (parsed === null) throw new Error('seedDraft produced unparseable content');
+    return hashFrontmatter({ frontmatter: parsed.frontmatter });
+  }
+
+  it('appends a sent outcome with permalink and rewrites the draft status', async () => {
+    const hash = seedDraft({ draftId: 'd1', target: 'slack:C1' });
     const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
     const result = await tool.handler({
       input: RecordSendOutcomeArgs.parse({
-        draft_path: '/tmp/d.md',
+        draft_path: draftPath,
+        draft_id: 'd1',
+        frontmatter_hash: hash,
         status: 'sent',
         sent_url: 'https://slack.com/archives/C1/p123',
       }),
@@ -38,18 +65,32 @@ describe('createRecordSendOutcomeTool', () => {
     if (result.isOk()) {
       const parsed = RecordSendOutcomeResult.parse(result.value);
       expect(parsed.line_number).toBe(1);
+      expect(parsed.draft_status).toBe('sent');
     }
+
     const onDisk = readFileSync(logPath, 'utf-8');
     const parsed = JSON.parse(onDisk.trim()) as Record<string, unknown>;
     expect(parsed['status']).toBe('sent');
     expect(parsed['sent_url']).toBe('https://slack.com/archives/C1/p123');
+    expect(parsed['draft_id']).toBe('d1');
+    expect(parsed['frontmatter_hash']).toBe(hash);
+
+    // The draft on disk has been atomically rewritten to include `status: sent`.
+    const updatedDraft = readFileSync(draftPath, 'utf-8');
+    const updatedParsed = parseFrontmatter({ input: updatedDraft });
+    expect(updatedParsed?.frontmatter['status']).toBe('sent');
+    expect(updatedParsed?.frontmatter['draft_id']).toBe('d1');
+    expect(updatedParsed?.frontmatter['target']).toBe('slack:C1');
   });
 
   it('appends a failed outcome with error', async () => {
+    const hash = seedDraft({ draftId: 'd1', target: 'slack:C1' });
     const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
     await tool.handler({
       input: RecordSendOutcomeArgs.parse({
-        draft_path: '/tmp/d.md',
+        draft_path: draftPath,
+        draft_id: 'd1',
+        frontmatter_hash: hash,
         status: 'failed',
         error: 'rate limited',
       }),
@@ -62,10 +103,13 @@ describe('createRecordSendOutcomeTool', () => {
   });
 
   it('appends a cancelled outcome with neither url nor error', async () => {
+    const hash = seedDraft({ draftId: 'd1', target: 'slack:C1' });
     const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
     await tool.handler({
       input: RecordSendOutcomeArgs.parse({
-        draft_path: '/tmp/d.md',
+        draft_path: draftPath,
+        draft_id: 'd1',
+        frontmatter_hash: hash,
         status: 'cancelled',
       }),
       ctx: { db: dbHandle.db },
@@ -77,18 +121,133 @@ describe('createRecordSendOutcomeTool', () => {
     expect(parsed).not.toHaveProperty('error');
   });
 
+  it('rejects when draft_id on disk does not match input', async () => {
+    const hash = seedDraft({ draftId: 'on-disk', target: 'slack:C1' });
+    const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecordSendOutcomeArgs.parse({
+        draft_path: draftPath,
+        draft_id: 'different',
+        frontmatter_hash: hash,
+        status: 'cancelled',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toContain('draft_id mismatch');
+  });
+
+  it('rejects when frontmatter_hash does not match the on-disk frontmatter', async () => {
+    seedDraft({ draftId: 'd1', target: 'slack:C1' });
+    const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecordSendOutcomeArgs.parse({
+        draft_path: draftPath,
+        draft_id: 'd1',
+        frontmatter_hash: 'deadbeefdeadbeef',
+        status: 'cancelled',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toContain('frontmatter_hash mismatch');
+  });
+
+  it('rejects an attempt to overwrite a terminal status with a different one', async () => {
+    const hash = seedDraft({ draftId: 'd1', target: 'slack:C1', status: 'sent' });
+    const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecordSendOutcomeArgs.parse({
+        draft_path: draftPath,
+        draft_id: 'd1',
+        frontmatter_hash: hash,
+        status: 'failed',
+        error: 'after-the-fact',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toContain('already has terminal status');
+  });
+
+  it('is idempotent when called twice with the same terminal status', async () => {
+    const hash = seedDraft({ draftId: 'd1', target: 'slack:C1' });
+    const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const first = await tool.handler({
+      input: RecordSendOutcomeArgs.parse({
+        draft_path: draftPath,
+        draft_id: 'd1',
+        frontmatter_hash: hash,
+        status: 'cancelled',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(first.isOk()).toBe(true);
+
+    const second = await tool.handler({
+      input: RecordSendOutcomeArgs.parse({
+        draft_path: draftPath,
+        draft_id: 'd1',
+        frontmatter_hash: hash,
+        status: 'cancelled',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(second.isOk()).toBe(true);
+    if (second.isOk()) expect(second.value['line_number']).toBe(2);
+  });
+
   it('appends multiple lines and reports incrementing line numbers', async () => {
     const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
     for (let i = 1; i <= 3; i += 1) {
+      // Each iteration overwrites the draft (the previous record_send_outcome
+      // added `status: cancelled`, which is then re-applied in this loop).
+      const hash = seedDraft({ draftId: `d${i}`, target: 'slack:C1' });
       const r = await tool.handler({
         input: RecordSendOutcomeArgs.parse({
-          draft_path: `/tmp/d${i}.md`,
+          draft_path: draftPath,
+          draft_id: `d${i}`,
+          frontmatter_hash: hash,
           status: 'cancelled',
         }),
         ctx: { db: dbHandle.db },
       });
       expect(r.isOk()).toBe(true);
-      if (r.isOk()) expect(r.value.line_number).toBe(i);
+      if (r.isOk()) expect(r.value['line_number']).toBe(i);
     }
+  });
+
+  it('rejects the Zod schema for status=sent without sent_url', () => {
+    const parsed = RecordSendOutcomeArgs.safeParse({
+      draft_path: '/tmp/d.md',
+      draft_id: 'd1',
+      frontmatter_hash: 'abcdef0123456789',
+      status: 'sent',
+      // sent_url omitted
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects the Zod schema for status=failed without error', () => {
+    const parsed = RecordSendOutcomeArgs.safeParse({
+      draft_path: '/tmp/d.md',
+      draft_id: 'd1',
+      frontmatter_hash: 'abcdef0123456789',
+      status: 'failed',
+      // error omitted
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects the Zod schema for status=cancelled with extraneous sent_url', () => {
+    const parsed = RecordSendOutcomeArgs.safeParse({
+      draft_path: '/tmp/d.md',
+      draft_id: 'd1',
+      frontmatter_hash: 'abcdef0123456789',
+      status: 'cancelled',
+      sent_url: 'https://slack.com/x',
+    });
+    // `.strict()` on the cancelled variant rejects unknown keys.
+    expect(parsed.success).toBe(false);
   });
 });

--- a/packages/mcp-server/src/tools/builtin/send/record-send-outcome.test.ts
+++ b/packages/mcp-server/src/tools/builtin/send/record-send-outcome.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { RecordSendOutcomeArgs, RecordSendOutcomeResult } from '@slopweaver/contracts';
 import { createDb } from '@slopweaver/db';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { hashFrontmatter, parseFrontmatter } from './parse-frontmatter.ts';
+import { hashContent, parseFrontmatter } from './parse-frontmatter.ts';
 import { createRecordSendOutcomeTool } from './record-send-outcome.ts';
 
 const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
@@ -45,7 +45,7 @@ describe('createRecordSendOutcomeTool', () => {
     writeFileSync(draftPath, content, 'utf-8');
     const parsed = parseFrontmatter({ input: content });
     if (parsed === null) throw new Error('seedDraft produced unparseable content');
-    return hashFrontmatter({ frontmatter: parsed.frontmatter });
+    return hashContent({ frontmatter: parsed.frontmatter, body: parsed.body });
   }
 
   it('appends a sent outcome with permalink and rewrites the draft status', async () => {
@@ -55,7 +55,7 @@ describe('createRecordSendOutcomeTool', () => {
       input: RecordSendOutcomeArgs.parse({
         draft_path: draftPath,
         draft_id: 'd1',
-        frontmatter_hash: hash,
+        content_hash: hash,
         status: 'sent',
         sent_url: 'https://slack.com/archives/C1/p123',
       }),
@@ -73,7 +73,7 @@ describe('createRecordSendOutcomeTool', () => {
     expect(parsed['status']).toBe('sent');
     expect(parsed['sent_url']).toBe('https://slack.com/archives/C1/p123');
     expect(parsed['draft_id']).toBe('d1');
-    expect(parsed['frontmatter_hash']).toBe(hash);
+    expect(parsed['content_hash']).toBe(hash);
 
     // The draft on disk has been atomically rewritten to include `status: sent`.
     const updatedDraft = readFileSync(draftPath, 'utf-8');
@@ -90,7 +90,7 @@ describe('createRecordSendOutcomeTool', () => {
       input: RecordSendOutcomeArgs.parse({
         draft_path: draftPath,
         draft_id: 'd1',
-        frontmatter_hash: hash,
+        content_hash: hash,
         status: 'failed',
         error: 'rate limited',
       }),
@@ -109,7 +109,7 @@ describe('createRecordSendOutcomeTool', () => {
       input: RecordSendOutcomeArgs.parse({
         draft_path: draftPath,
         draft_id: 'd1',
-        frontmatter_hash: hash,
+        content_hash: hash,
         status: 'cancelled',
       }),
       ctx: { db: dbHandle.db },
@@ -128,7 +128,7 @@ describe('createRecordSendOutcomeTool', () => {
       input: RecordSendOutcomeArgs.parse({
         draft_path: draftPath,
         draft_id: 'different',
-        frontmatter_hash: hash,
+        content_hash: hash,
         status: 'cancelled',
       }),
       ctx: { db: dbHandle.db },
@@ -137,20 +137,47 @@ describe('createRecordSendOutcomeTool', () => {
     if (result.isErr()) expect(result.error.message).toContain('draft_id mismatch');
   });
 
-  it('rejects when frontmatter_hash does not match the on-disk frontmatter', async () => {
+  it('rejects when content_hash does not match the on-disk content', async () => {
     seedDraft({ draftId: 'd1', target: 'slack:C1' });
     const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
     const result = await tool.handler({
       input: RecordSendOutcomeArgs.parse({
         draft_path: draftPath,
         draft_id: 'd1',
-        frontmatter_hash: 'deadbeefdeadbeef',
+        content_hash: 'deadbeefdeadbeef',
         status: 'cancelled',
       }),
       ctx: { db: dbHandle.db },
     });
     expect(result.isErr()).toBe(true);
-    if (result.isErr()) expect(result.error.message).toContain('frontmatter_hash mismatch');
+    if (result.isErr()) expect(result.error.message).toContain('content_hash mismatch');
+  });
+
+  /**
+   * Iter-3 P1: drift detection must cover body, not just frontmatter.
+   * If the body changes on disk between prepare_send and
+   * record_send_outcome, the previously-issued content_hash must no
+   * longer match — otherwise calibration data would log an outcome
+   * against a draft body the model didn't actually approve to send.
+   */
+  it('rejects when only the body has drifted (body is part of content_hash)', async () => {
+    const originalHash = seedDraft({ draftId: 'd1', target: 'slack:C1', body: 'original body text' });
+    // Rewrite the draft body but keep frontmatter intact.
+    const drifted = '---\ndraft_id: d1\ntarget: slack:C1\n---\nEDITED body text\n';
+    writeFileSync(draftPath, drifted, 'utf-8');
+
+    const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
+    const result = await tool.handler({
+      input: RecordSendOutcomeArgs.parse({
+        draft_path: draftPath,
+        draft_id: 'd1',
+        content_hash: originalHash,
+        status: 'cancelled',
+      }),
+      ctx: { db: dbHandle.db },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.message).toContain('content_hash mismatch');
   });
 
   it('rejects an attempt to overwrite a terminal status with a different one', async () => {
@@ -160,7 +187,7 @@ describe('createRecordSendOutcomeTool', () => {
       input: RecordSendOutcomeArgs.parse({
         draft_path: draftPath,
         draft_id: 'd1',
-        frontmatter_hash: hash,
+        content_hash: hash,
         status: 'failed',
         error: 'after-the-fact',
       }),
@@ -170,31 +197,47 @@ describe('createRecordSendOutcomeTool', () => {
     if (result.isErr()) expect(result.error.message).toContain('already has terminal status');
   });
 
-  it('is idempotent when called twice with the same terminal status', async () => {
+  /**
+   * Iter-3 P1: idempotent on (draft_id, status, content_hash). A
+   * retry after the model loses the first response (transport
+   * ambiguity, network blip) must NOT append a duplicate JSONL row —
+   * the calibration loop would otherwise double-count send outcomes.
+   * The second call returns the existing line_number unchanged and
+   * does not write to disk.
+   */
+  it('is idempotent when called twice with the same (draft_id, status, content_hash)', async () => {
     const hash = seedDraft({ draftId: 'd1', target: 'slack:C1' });
     const tool = createRecordSendOutcomeTool({ logPathOverride: logPath, now: () => FIXED_NOW });
     const first = await tool.handler({
       input: RecordSendOutcomeArgs.parse({
         draft_path: draftPath,
         draft_id: 'd1',
-        frontmatter_hash: hash,
+        content_hash: hash,
         status: 'cancelled',
       }),
       ctx: { db: dbHandle.db },
     });
     expect(first.isOk()).toBe(true);
+    if (!first.isOk()) return;
+    const firstLine = first.value['line_number'];
+    expect(firstLine).toBe(1);
 
     const second = await tool.handler({
       input: RecordSendOutcomeArgs.parse({
         draft_path: draftPath,
         draft_id: 'd1',
-        frontmatter_hash: hash,
+        content_hash: hash,
         status: 'cancelled',
       }),
       ctx: { db: dbHandle.db },
     });
     expect(second.isOk()).toBe(true);
-    if (second.isOk()) expect(second.value['line_number']).toBe(2);
+    if (second.isOk()) expect(second.value['line_number']).toBe(firstLine);
+
+    // On disk there should still be exactly one JSONL row — no duplicate.
+    const onDisk = readFileSync(logPath, 'utf-8');
+    const rows = onDisk.split('\n').filter((l) => l.trim().length > 0);
+    expect(rows.length).toBe(1);
   });
 
   it('appends multiple lines and reports incrementing line numbers', async () => {
@@ -207,7 +250,7 @@ describe('createRecordSendOutcomeTool', () => {
         input: RecordSendOutcomeArgs.parse({
           draft_path: draftPath,
           draft_id: `d${i}`,
-          frontmatter_hash: hash,
+          content_hash: hash,
           status: 'cancelled',
         }),
         ctx: { db: dbHandle.db },
@@ -221,7 +264,7 @@ describe('createRecordSendOutcomeTool', () => {
     const parsed = RecordSendOutcomeArgs.safeParse({
       draft_path: '/tmp/d.md',
       draft_id: 'd1',
-      frontmatter_hash: 'abcdef0123456789',
+      content_hash: 'abcdef0123456789',
       status: 'sent',
       // sent_url omitted
     });
@@ -232,7 +275,7 @@ describe('createRecordSendOutcomeTool', () => {
     const parsed = RecordSendOutcomeArgs.safeParse({
       draft_path: '/tmp/d.md',
       draft_id: 'd1',
-      frontmatter_hash: 'abcdef0123456789',
+      content_hash: 'abcdef0123456789',
       status: 'failed',
       // error omitted
     });
@@ -243,7 +286,7 @@ describe('createRecordSendOutcomeTool', () => {
     const parsed = RecordSendOutcomeArgs.safeParse({
       draft_path: '/tmp/d.md',
       draft_id: 'd1',
-      frontmatter_hash: 'abcdef0123456789',
+      content_hash: 'abcdef0123456789',
       status: 'cancelled',
       sent_url: 'https://slack.com/x',
     });

--- a/packages/mcp-server/src/tools/builtin/send/record-send-outcome.ts
+++ b/packages/mcp-server/src/tools/builtin/send/record-send-outcome.ts
@@ -1,0 +1,119 @@
+/**
+ * `record_send_outcome` — append a JSONL entry to
+ * `<data-dir>/sends.jsonl` recording the outcome of an attempted send.
+ *
+ * Companion to `prepare_send`. The model calls this after invoking the
+ * source-platform send tool — once for success, once for failure, once
+ * for user-cancelled-via-undo. Plays the same role for sends that
+ * `log_walk_feedback` plays for /lock-in walks: durable training data
+ * for the calibration loop.
+ */
+
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { RecordSendOutcomeArgs, RecordSendOutcomeResult } from '@slopweaver/contracts';
+import { resolveDataDir } from '@slopweaver/db';
+import { err, ok } from '@slopweaver/errors';
+import { McpErrors } from '../../../errors.ts';
+import { defineTool, type Tool } from '../../registry.ts';
+
+const SENDS_LOG_FILENAME = 'sends.jsonl';
+
+export type CreateRecordSendOutcomeToolArgs = {
+  /** Override the JSONL path (tests). */
+  logPathOverride?: string;
+  /** Clock injection for tests. */
+  now?: () => number;
+};
+
+export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArgs = {}): Tool {
+  const now = args.now ?? Date.now;
+  const logPathOverride = args.logPathOverride;
+
+  return defineTool({
+    name: 'record_send_outcome',
+    description:
+      'Append one outcome entry to <data-dir>/sends.jsonl. Call after `prepare_send` + the actual send tool to record what happened (sent / failed / cancelled). Required for the calibration loop to track send hit-rate.',
+    inputSchema: RecordSendOutcomeArgs,
+    outputSchema: RecordSendOutcomeResult,
+    handler: async ({ input }) => {
+      const resolved =
+        logPathOverride != null ? ok(logPathOverride) : resolveDataDir().map((dir) => join(dir, SENDS_LOG_FILENAME));
+      if (resolved.isErr()) {
+        return err(McpErrors.unexpected('record_send_outcome', undefined, resolved.error.message));
+      }
+      const logPath = resolved.value;
+
+      const line: Record<string, unknown> = {
+        ts: new Date(now()).toISOString(),
+        draft_path: input.draft_path,
+        status: input.status,
+      };
+      if (input.sent_url !== undefined) line['sent_url'] = input.sent_url;
+      if (input.error !== undefined) line['error'] = input.error;
+      const encoded = `${JSON.stringify(line)}\n`;
+
+      let existingLines = 0;
+      try {
+        const content = await readFile(logPath, 'utf-8');
+        existingLines = content.split('\n').filter((l) => l.trim().length > 0).length;
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+          return err(
+            McpErrors.unexpected(
+              'record_send_outcome',
+              undefined,
+              `failed to read ${logPath}: ${e instanceof Error ? e.message : String(e)}`,
+            ),
+          );
+        }
+      }
+
+      const parent = dirname(logPath);
+      try {
+        await mkdir(parent, { recursive: true });
+      } catch (e) {
+        return err(
+          McpErrors.unexpected(
+            'record_send_outcome',
+            undefined,
+            `failed to mkdir ${parent}: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+      }
+      let next = encoded;
+      try {
+        const existing = await stat(logPath);
+        if (existing.isFile()) {
+          const prev = await readFile(logPath, 'utf-8');
+          next = prev.endsWith('\n') || prev.length === 0 ? `${prev}${encoded}` : `${prev}\n${encoded}`;
+        }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+          return err(
+            McpErrors.unexpected(
+              'record_send_outcome',
+              undefined,
+              `failed to stat ${logPath}: ${e instanceof Error ? e.message : String(e)}`,
+            ),
+          );
+        }
+      }
+      try {
+        await writeFile(logPath, next, { encoding: 'utf-8', mode: 0o644 });
+      } catch (e) {
+        return err(
+          McpErrors.unexpected(
+            'record_send_outcome',
+            undefined,
+            `failed to write ${logPath}: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+      }
+      return ok({
+        log_path: logPath,
+        line_number: existingLines + 1,
+      });
+    },
+  });
+}

--- a/packages/mcp-server/src/tools/builtin/send/record-send-outcome.ts
+++ b/packages/mcp-server/src/tools/builtin/send/record-send-outcome.ts
@@ -9,15 +9,20 @@
  *
  * Responsibilities (Codex P1):
  *  1. Load the draft file at `draft_path`.
- *  2. Validate the draft frontmatter still matches what `prepare_send`
- *     saw — same `draft_id`, same `frontmatter_hash`. Mismatch ⇒ drift,
- *     reject the call so the calibration log can't be poisoned with a
- *     payload that no longer matches the draft on disk.
+ *  2. Validate the draft still matches what `prepare_send` saw —
+ *     same `draft_id`, same `content_hash` (covering frontmatter +
+ *     body). Mismatch ⇒ drift, reject the call so the calibration
+ *     log can't be poisoned with a payload that no longer matches
+ *     the draft on disk.
  *  3. Atomically rewrite the draft's `status:` field (temp-file +
  *     rename, never an in-place write). Reject repeat calls that would
  *     overwrite a terminal status with a different terminal status —
  *     `cancelled` -> `sent` is meaningless.
  *  4. Append a JSONL entry to `<data-dir>/sends.jsonl` for calibration.
+ *     Idempotent on `(draft_id, status, content_hash)` — repeat calls
+ *     with the same triple return the existing line_number without
+ *     writing a new row, so a retry after transport ambiguity can't
+ *     double-count calibration data.
  *
  * `safeQuery`/Result patterns from `@slopweaver/errors` are used at the
  * boundary; the tool itself uses local `try/catch` around fs calls to
@@ -33,7 +38,7 @@ import { resolveDataDir } from '@slopweaver/db';
 import { err, ok } from '@slopweaver/errors';
 import { McpErrors } from '../../../errors.ts';
 import { defineTool, type Tool } from '../../registry.ts';
-import { hashFrontmatter, parseFrontmatter, serializeDraft } from './parse-frontmatter.ts';
+import { hashContent, parseFrontmatter, serializeDraft } from './parse-frontmatter.ts';
 
 const SENDS_LOG_FILENAME = 'sends.jsonl';
 
@@ -62,7 +67,7 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
   return defineTool({
     name: 'record_send_outcome',
     description:
-      'Record the outcome of a send attempt. Loads the draft at `draft_path`, validates `draft_id` + `frontmatter_hash` still match what `prepare_send` saw (drift detection), atomically rewrites the draft frontmatter `status:` field, and appends a JSONL entry to <data-dir>/sends.jsonl. Rejects repeat calls that would overwrite a terminal status with a different one. Required for the calibration loop to track send hit-rate.',
+      'Record the outcome of a send attempt. Loads the draft at `draft_path`, validates `draft_id` + `content_hash` (frontmatter + body) still match what `prepare_send` saw (drift detection), atomically rewrites the draft frontmatter `status:` field, and appends a JSONL entry to <data-dir>/sends.jsonl. Rejects repeat calls that would overwrite a terminal status with a different one; idempotent for repeat calls with the same `(draft_id, status, content_hash)` triple. Required for the calibration loop to track send hit-rate.',
     inputSchema: RecordSendOutcomeArgs,
     outputSchema: RecordSendOutcomeResult,
     handler: async ({ input }) => {
@@ -101,13 +106,13 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
           ),
         );
       }
-      const hashOnDisk = hashFrontmatter({ frontmatter: parsedDraft.frontmatter });
-      if (hashOnDisk !== input.frontmatter_hash) {
+      const hashOnDisk = hashContent({ frontmatter: parsedDraft.frontmatter, body: parsedDraft.body });
+      if (hashOnDisk !== input.content_hash) {
         return err(
           McpErrors.unexpected(
             'record_send_outcome',
             undefined,
-            `frontmatter_hash mismatch — input \`${input.frontmatter_hash}\`, on-disk \`${hashOnDisk}\`. The draft frontmatter was edited between prepare_send and record_send_outcome; re-run prepare_send to refresh.`,
+            `content_hash mismatch — input \`${input.content_hash}\`, on-disk \`${hashOnDisk}\`. The draft (frontmatter or body) was edited between prepare_send and record_send_outcome; re-run prepare_send to refresh.`,
           ),
         );
       }
@@ -161,11 +166,17 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
         );
       }
 
-      // 6. Read existing log line count, append the new JSONL entry.
-      let existingLines = 0;
+      // 6. Read existing log, check idempotency, append the new JSONL entry.
+      //
+      // Idempotency: if a row already exists with the same
+      // (draft_id, status, content_hash) triple, return that row's
+      // line_number instead of writing a new row. Without this, a
+      // retry after transport ambiguity (the model never saw the
+      // tool's response and called record_send_outcome a second time)
+      // would double-count the outcome in the calibration log.
+      let prevContent = '';
       try {
-        const content = await readImpl(logPath);
-        existingLines = content.split('\n').filter((l) => l.trim().length > 0).length;
+        prevContent = await readImpl(logPath);
       } catch (e) {
         if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
           return err(
@@ -176,6 +187,20 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
             ),
           );
         }
+      }
+      const existingLines = prevContent.length === 0 ? [] : prevContent.split('\n').filter((l) => l.trim().length > 0);
+      const duplicateLineNumber = findIdempotentMatch({
+        lines: existingLines,
+        draftId: input.draft_id,
+        status: input.status,
+        contentHash: input.content_hash,
+      });
+      if (duplicateLineNumber != null) {
+        return ok({
+          log_path: logPath,
+          line_number: duplicateLineNumber,
+          draft_status: input.status,
+        });
       }
 
       const parent = dirname(logPath);
@@ -195,7 +220,7 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
         ts: new Date(now()).toISOString(),
         draft_path: input.draft_path,
         draft_id: input.draft_id,
-        frontmatter_hash: input.frontmatter_hash,
+        content_hash: input.content_hash,
         status: input.status,
       };
       if (input.status === 'sent') line['sent_url'] = input.sent_url;
@@ -206,8 +231,10 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
       try {
         const existing = await stat(logPath);
         if (existing.isFile()) {
-          const prev = await readImpl(logPath);
-          next = prev.endsWith('\n') || prev.length === 0 ? `${prev}${encoded}` : `${prev}\n${encoded}`;
+          next =
+            prevContent.endsWith('\n') || prevContent.length === 0
+              ? `${prevContent}${encoded}`
+              : `${prevContent}\n${encoded}`;
         }
       } catch (e) {
         if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -234,9 +261,46 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
 
       return ok({
         log_path: logPath,
-        line_number: existingLines + 1,
+        line_number: existingLines.length + 1,
         draft_status: input.status,
       });
     },
   });
+}
+
+/**
+ * Scan the existing JSONL log for a row matching
+ * `(draft_id, status, content_hash)`. Returns the 1-based line number
+ * of the first match (or `null` if no match). Malformed lines are
+ * skipped — a corrupted historical row should never block a new
+ * append. Used to make `record_send_outcome` idempotent across
+ * retries.
+ */
+function findIdempotentMatch({
+  lines,
+  draftId,
+  status,
+  contentHash,
+}: {
+  lines: readonly string[];
+  draftId: string;
+  status: string;
+  contentHash: string;
+}): number | null {
+  for (let i = 0; i < lines.length; i += 1) {
+    const raw = lines[i];
+    if (raw == null) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== 'object' || parsed === null) continue;
+    const row = parsed as Record<string, unknown>;
+    if (row['draft_id'] === draftId && row['status'] === status && row['content_hash'] === contentHash) {
+      return i + 1;
+    }
+  }
+  return null;
 }

--- a/packages/mcp-server/src/tools/builtin/send/record-send-outcome.ts
+++ b/packages/mcp-server/src/tools/builtin/send/record-send-outcome.ts
@@ -1,42 +1,130 @@
 /**
- * `record_send_outcome` — append a JSONL entry to
- * `<data-dir>/sends.jsonl` recording the outcome of an attempted send.
+ * `record_send_outcome` — durable record of an attempted send.
  *
  * Companion to `prepare_send`. The model calls this after invoking the
  * source-platform send tool — once for success, once for failure, once
  * for user-cancelled-via-undo. Plays the same role for sends that
  * `log_walk_feedback` plays for /lock-in walks: durable training data
  * for the calibration loop.
+ *
+ * Responsibilities (Codex P1):
+ *  1. Load the draft file at `draft_path`.
+ *  2. Validate the draft frontmatter still matches what `prepare_send`
+ *     saw — same `draft_id`, same `frontmatter_hash`. Mismatch ⇒ drift,
+ *     reject the call so the calibration log can't be poisoned with a
+ *     payload that no longer matches the draft on disk.
+ *  3. Atomically rewrite the draft's `status:` field (temp-file +
+ *     rename, never an in-place write). Reject repeat calls that would
+ *     overwrite a terminal status with a different terminal status —
+ *     `cancelled` -> `sent` is meaningless.
+ *  4. Append a JSONL entry to `<data-dir>/sends.jsonl` for calibration.
+ *
+ * `safeQuery`/Result patterns from `@slopweaver/errors` are used at the
+ * boundary; the tool itself uses local `try/catch` around fs calls to
+ * map into the McpToolError union per
+ * `.claude/rules/error-handling.md` (the service-boundary scanner only
+ * flags `throw` statements; classification catches are allowed).
  */
 
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { RecordSendOutcomeArgs, RecordSendOutcomeResult } from '@slopweaver/contracts';
 import { resolveDataDir } from '@slopweaver/db';
 import { err, ok } from '@slopweaver/errors';
 import { McpErrors } from '../../../errors.ts';
 import { defineTool, type Tool } from '../../registry.ts';
+import { hashFrontmatter, parseFrontmatter, serializeDraft } from './parse-frontmatter.ts';
 
 const SENDS_LOG_FILENAME = 'sends.jsonl';
+
+const TERMINAL_STATUSES = new Set(['sent', 'failed', 'cancelled']);
 
 export type CreateRecordSendOutcomeToolArgs = {
   /** Override the JSONL path (tests). */
   logPathOverride?: string;
   /** Clock injection for tests. */
   now?: () => number;
+  /** Override the fs reader (tests). */
+  readFileImpl?: (path: string) => Promise<string>;
+  /** Override the fs writer (tests). */
+  writeFileImpl?: (path: string, content: string) => Promise<void>;
+  /** Override the atomic rename (tests). */
+  renameImpl?: (from: string, to: string) => Promise<void>;
 };
 
 export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArgs = {}): Tool {
   const now = args.now ?? Date.now;
   const logPathOverride = args.logPathOverride;
+  const readImpl = args.readFileImpl ?? ((p) => readFile(p, 'utf-8'));
+  const writeImpl = args.writeFileImpl ?? ((p, content) => writeFile(p, content, { encoding: 'utf-8', mode: 0o644 }));
+  const renameFn = args.renameImpl ?? rename;
 
   return defineTool({
     name: 'record_send_outcome',
     description:
-      'Append one outcome entry to <data-dir>/sends.jsonl. Call after `prepare_send` + the actual send tool to record what happened (sent / failed / cancelled). Required for the calibration loop to track send hit-rate.',
+      'Record the outcome of a send attempt. Loads the draft at `draft_path`, validates `draft_id` + `frontmatter_hash` still match what `prepare_send` saw (drift detection), atomically rewrites the draft frontmatter `status:` field, and appends a JSONL entry to <data-dir>/sends.jsonl. Rejects repeat calls that would overwrite a terminal status with a different one. Required for the calibration loop to track send hit-rate.',
     inputSchema: RecordSendOutcomeArgs,
     outputSchema: RecordSendOutcomeResult,
     handler: async ({ input }) => {
+      // 1. Read + parse the draft.
+      let draftContent: string;
+      try {
+        draftContent = await readImpl(input.draft_path);
+      } catch (e) {
+        return err(
+          McpErrors.unexpected(
+            'record_send_outcome',
+            undefined,
+            `failed to read draft at ${input.draft_path}: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+      }
+      const parsedDraft = parseFrontmatter({ input: draftContent });
+      if (parsedDraft === null) {
+        return err(
+          McpErrors.unexpected(
+            'record_send_outcome',
+            undefined,
+            `draft at ${input.draft_path} has no parseable YAML frontmatter — refusing to record outcome against a draft that prepare_send could not have produced`,
+          ),
+        );
+      }
+
+      // 2. Validate the draft hasn't drifted since prepare_send.
+      const draftIdOnDisk = parsedDraft.frontmatter['draft_id'];
+      if (draftIdOnDisk !== input.draft_id) {
+        return err(
+          McpErrors.unexpected(
+            'record_send_outcome',
+            undefined,
+            `draft_id mismatch — input \`${input.draft_id}\`, on-disk \`${draftIdOnDisk ?? '(missing)'}\`. The draft was either edited or replaced between prepare_send and record_send_outcome; re-run prepare_send to refresh.`,
+          ),
+        );
+      }
+      const hashOnDisk = hashFrontmatter({ frontmatter: parsedDraft.frontmatter });
+      if (hashOnDisk !== input.frontmatter_hash) {
+        return err(
+          McpErrors.unexpected(
+            'record_send_outcome',
+            undefined,
+            `frontmatter_hash mismatch — input \`${input.frontmatter_hash}\`, on-disk \`${hashOnDisk}\`. The draft frontmatter was edited between prepare_send and record_send_outcome; re-run prepare_send to refresh.`,
+          ),
+        );
+      }
+
+      // 3. Reject conflicting terminal-status overwrites.
+      const existingStatus = parsedDraft.frontmatter['status'];
+      if (existingStatus != null && TERMINAL_STATUSES.has(existingStatus) && existingStatus !== input.status) {
+        return err(
+          McpErrors.unexpected(
+            'record_send_outcome',
+            undefined,
+            `draft at ${input.draft_path} already has terminal status \`${existingStatus}\`; refusing to overwrite with \`${input.status}\`. record_send_outcome is meant to be called once per send attempt.`,
+          ),
+        );
+      }
+
+      // 4. Resolve the JSONL log path.
       const resolved =
         logPathOverride != null ? ok(logPathOverride) : resolveDataDir().map((dir) => join(dir, SENDS_LOG_FILENAME));
       if (resolved.isErr()) {
@@ -44,18 +132,39 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
       }
       const logPath = resolved.value;
 
-      const line: Record<string, unknown> = {
-        ts: new Date(now()).toISOString(),
-        draft_path: input.draft_path,
-        status: input.status,
-      };
-      if (input.sent_url !== undefined) line['sent_url'] = input.sent_url;
-      if (input.error !== undefined) line['error'] = input.error;
-      const encoded = `${JSON.stringify(line)}\n`;
+      // 5. Atomically rewrite the draft with the new status. Write to a
+      // sibling temp file and rename — `rename` is atomic on the same
+      // filesystem, so a crash mid-write can't leave a half-written draft.
+      const updatedFrontmatter: Record<string, string> = { ...parsedDraft.frontmatter, status: input.status };
+      const updatedDraft = serializeDraft({ frontmatter: updatedFrontmatter, body: parsedDraft.body });
+      const tempDraftPath = `${input.draft_path}.tmp-${now()}`;
+      try {
+        await writeImpl(tempDraftPath, updatedDraft);
+      } catch (e) {
+        return err(
+          McpErrors.unexpected(
+            'record_send_outcome',
+            undefined,
+            `failed to write temp draft ${tempDraftPath}: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+      }
+      try {
+        await renameFn(tempDraftPath, input.draft_path);
+      } catch (e) {
+        return err(
+          McpErrors.unexpected(
+            'record_send_outcome',
+            undefined,
+            `failed to atomically rename ${tempDraftPath} -> ${input.draft_path}: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+      }
 
+      // 6. Read existing log line count, append the new JSONL entry.
       let existingLines = 0;
       try {
-        const content = await readFile(logPath, 'utf-8');
+        const content = await readImpl(logPath);
         existingLines = content.split('\n').filter((l) => l.trim().length > 0).length;
       } catch (e) {
         if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -81,11 +190,23 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
           ),
         );
       }
+
+      const line: Record<string, unknown> = {
+        ts: new Date(now()).toISOString(),
+        draft_path: input.draft_path,
+        draft_id: input.draft_id,
+        frontmatter_hash: input.frontmatter_hash,
+        status: input.status,
+      };
+      if (input.status === 'sent') line['sent_url'] = input.sent_url;
+      if (input.status === 'failed') line['error'] = input.error;
+      const encoded = `${JSON.stringify(line)}\n`;
+
       let next = encoded;
       try {
         const existing = await stat(logPath);
         if (existing.isFile()) {
-          const prev = await readFile(logPath, 'utf-8');
+          const prev = await readImpl(logPath);
           next = prev.endsWith('\n') || prev.length === 0 ? `${prev}${encoded}` : `${prev}\n${encoded}`;
         }
       } catch (e) {
@@ -100,7 +221,7 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
         }
       }
       try {
-        await writeFile(logPath, next, { encoding: 'utf-8', mode: 0o644 });
+        await writeImpl(logPath, next);
       } catch (e) {
         return err(
           McpErrors.unexpected(
@@ -110,9 +231,11 @@ export function createRecordSendOutcomeTool(args: CreateRecordSendOutcomeToolArg
           ),
         );
       }
+
       return ok({
         log_path: logPath,
         line_number: existingLines + 1,
+        draft_status: input.status,
       });
     },
   });


### PR DESCRIPTION
Closes #59.

**Problem**

`/draft` (PR #71) wrote draft files, but there was no path to actually send one without dropping back into raw `mcp__*` calls. The model had nothing telling it which platform tool to invoke, no human-readable undo gate, and nowhere to log what happened for calibration.

**Solution**

Two new MCP tools close the loop. `prepare_send` parses the draft frontmatter, resolves the `target:` to a typed destination, and returns structured `server` / `tool_name` / `tool_args` behind a two-step confirmation gate. `record_send_outcome` then validates the draft hasn't drifted, atomically rewrites `status:` on disk, and appends one JSONL row to `sends.jsonl`.

**Proof this works**

_pending local verification_

**How to test**

1. `pnpm install && pnpm compile`
2. Start the binary against a draft file written by `/draft` (or hand-roll one with `target: slack:C123` and a body)
3. Call `prepare_send({ draft_path })`; confirm response has `requires_confirmation: true`, a `confirmation_token`, and no `tool_args`
4. Re-call `prepare_send({ draft_path, confirmed: true, confirmation_token })`; confirm `tool_args` is now populated
5. Edit just the body between the two calls and re-confirm; the token should be rejected
6. Call `record_send_outcome({ draft_path, draft_id, content_hash, status: 'sent', sent_url })`; confirm the draft's `status:` is rewritten and one row lands in `sends.jsonl`
7. Call `record_send_outcome` again with the same triple; confirm the existing `line_number` is returned and no duplicate row is appended
8. `pnpm validate`

<details>
<summary>Implementation notes</summary>

Three commits stacked on this branch:

- `d83d5f8` (iter-1): initial `prepare_send` + `record_send_outcome` with free-form instructions string.
- `a583910` (iter-2, Codex P1+P2): structured `server` / `tool_name` / `tool_args` routing, two-step confirmation token, drift detection on `record_send_outcome`, atomic temp-file + rename of the draft's `status:` field, `.superRefine` on the args (`sent` requires `sent_url`, `failed` requires `error`, `cancelled` allows neither).
- `b114367` (iter-3, Codex P1): confirmation hash now covers the trimmed body as well as sorted frontmatter (was frontmatter-only, which let a model edit the body between unconfirmed and confirmed calls and slip the edited text past the undo gate). `record_send_outcome` is now idempotent on an exact `(draft_id, status, content_hash)` repeat. Contract rename: `frontmatter_hash` → `content_hash` on both the result and the args.

Target syntax accepted by the parser:

- `slack:<channel_id>[/thread:<ts>]`
- `github:<owner>/<repo>/(pull|pulls|issue|issues)/<number>`
- `gmail:<thread_id>`
- `linear:<issue_id>`

Plural `pulls` / `issues` is accepted to match the template `/draft` emits.

Why "prepare, not send": SlopWeaver's MCP server can't call across the SDK boundary into other MCP servers. Only the client can. So the shape is parse and route here, send from the model, then log the outcome back here.

</details>
