### PR TITLE
feat(ui): tab nav + Evidence tab (live tail of evidence_log)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@slopweaver/db": "workspace:*",
+    "drizzle-orm": "0.45.2",
     "react": "19.2.5",
     "react-dom": "19.2.5"
   },

--- a/packages/ui/src/client/App.css
+++ b/packages/ui/src/client/App.css
@@ -141,3 +141,74 @@ code {
   font-family: ui-monospace, SFMono-Regular, monospace;
   font-size: 0.9em;
 }
+
+/* --- Flight-deck tab navigation ------------------------------------ */
+
+.flight-deck__tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.75rem 1.5rem 0;
+  border-bottom: 1px solid var(--border);
+  background: #f9fafb;
+}
+
+.flight-deck__tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--muted);
+  padding: 0.5rem 0.875rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 4px 4px 0 0;
+  margin-bottom: -1px;
+}
+
+.flight-deck__tab:hover {
+  background: rgba(0, 0, 0, 0.03);
+  color: #1f2937;
+}
+
+.flight-deck__tab--active {
+  color: #1f2937;
+  border-bottom-color: #2563eb;
+  background: #ffffff;
+}
+
+/* --- Evidence list ------------------------------------------------- */
+
+.evidence-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.evidence-item {
+  display: grid;
+  grid-template-columns: 12rem 1fr 12rem;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.9rem;
+  align-items: baseline;
+}
+
+.evidence-item__chip {
+  color: var(--muted);
+  font-size: 0.85em;
+}
+
+.evidence-item__title {
+  overflow-wrap: anywhere;
+}
+
+.evidence-item__time {
+  color: var(--muted);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}

--- a/packages/ui/src/client/App.test.tsx
+++ b/packages/ui/src/client/App.test.tsx
@@ -6,9 +6,13 @@ import { App } from './App.tsx';
 describe('App (tab navigation)', () => {
   beforeEach(() => {
     // jsdom doesn't define fetch — stub it to return empty payloads so
-    // the polling effects in both tabs complete cleanly.
-    Object.defineProperty(globalThis, 'fetch', {
-      value: vi.fn(async (url: string) => {
+    // the polling effects in both tabs complete cleanly. Use
+    // `vi.stubGlobal` so `vi.unstubAllGlobals()` in afterEach restores
+    // the original (undefined) value and doesn't leak the stub into
+    // subsequent test files. Matches the pattern in Diagnostics.test.tsx.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
         if (url.includes('/api/evidence')) {
           return {
             ok: true,
@@ -31,13 +35,13 @@ describe('App (tab navigation)', () => {
           }),
         } as unknown as Response;
       }),
-      writable: true,
-    });
+    );
   });
 
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it('renders the Diagnostics tab by default', async () => {

--- a/packages/ui/src/client/App.test.tsx
+++ b/packages/ui/src/client/App.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { App } from './App.tsx';
+
+describe('App (tab navigation)', () => {
+  beforeEach(() => {
+    // jsdom doesn't define fetch — stub it to return empty payloads so
+    // the polling effects in both tabs complete cleanly.
+    Object.defineProperty(globalThis, 'fetch', {
+      value: vi.fn(async (url: string) => {
+        if (url.includes('/api/evidence')) {
+          return {
+            ok: true,
+            json: async () => ({ rows: [], total_in_db: 0, generated_at: new Date().toISOString() }),
+          } as unknown as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            schemaVersion: 1,
+            generatedAtMs: Date.now(),
+            env: {
+              node: { name: 'Node version', status: 'ok', detail: 'node x' },
+              pnpm: { name: 'pnpm version', status: 'ok', detail: 'pnpm x' },
+              dataDir: { name: 'Data dir', status: 'ok', detail: '/x' },
+            },
+            server: { host: '127.0.0.1', port: 60701, listening: true },
+            integrations: [],
+            mcpClients: { count: 0, transport: 'stdio', tracked: false },
+          }),
+        } as unknown as Response;
+      }),
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('renders the Diagnostics tab by default', async () => {
+    render(<App />);
+    expect(screen.getByRole('button', { name: 'Diagnostics' }).getAttribute('aria-current')).toBe('page');
+    await waitFor(() => screen.getByText(/Listening on/));
+  });
+
+  it('switches to the Evidence tab on click', async () => {
+    render(<App />);
+    const evidenceTab = screen.getByRole('button', { name: 'Evidence' });
+    fireEvent.click(evidenceTab);
+    expect(evidenceTab.getAttribute('aria-current')).toBe('page');
+    await waitFor(() => screen.getByRole('heading', { name: 'Evidence tail' }));
+  });
+
+  it('renders both tab buttons', () => {
+    render(<App />);
+    expect(screen.getByRole('button', { name: 'Diagnostics' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Evidence' })).toBeTruthy();
+  });
+});

--- a/packages/ui/src/client/App.tsx
+++ b/packages/ui/src/client/App.tsx
@@ -1,11 +1,53 @@
-import type { ReactElement } from 'react';
+import { type ReactElement, useState } from 'react';
 import './App.css';
 import { Diagnostics } from './pages/Diagnostics.tsx';
+import { Evidence } from './pages/Evidence.tsx';
+
+type Tab = 'diagnostics' | 'evidence';
 
 /**
- * Top-level React component for the Diagnostics SPA. Renders the single
- * Diagnostics page — there is no router; this app has exactly one screen.
+ * Top-level shell for the flight-deck UI. Single-process tab state
+ * via `useState` — no router, no URL sync. The page count stays small
+ * enough that the cost of bringing in react-router doesn't pay back.
+ *
+ * Adding a new tab: append to `TABS`, create the matching page
+ * component, add the switch arm in `renderActiveTab`. Three files
+ * touched per tab — that's the bar.
  */
+const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
+  { id: 'diagnostics', label: 'Diagnostics' },
+  { id: 'evidence', label: 'Evidence' },
+];
+
 export function App(): ReactElement {
-  return <Diagnostics />;
+  const [activeTab, setActiveTab] = useState<Tab>('diagnostics');
+  return (
+    <div className="flight-deck">
+      <nav className="flight-deck__tabs" aria-label="primary">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            className={`flight-deck__tab${tab.id === activeTab ? ' flight-deck__tab--active' : ''}`}
+            onClick={() => {
+              setActiveTab(tab.id);
+            }}
+            aria-current={tab.id === activeTab ? 'page' : undefined}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+      {renderActiveTab(activeTab)}
+    </div>
+  );
+}
+
+function renderActiveTab(tab: Tab): ReactElement {
+  switch (tab) {
+    case 'diagnostics':
+      return <Diagnostics />;
+    case 'evidence':
+      return <Evidence />;
+  }
 }

--- a/packages/ui/src/client/api/evidence.ts
+++ b/packages/ui/src/client/api/evidence.ts
@@ -1,0 +1,13 @@
+import type { EvidenceTailResponse } from '../../server/evidence.ts';
+
+export async function fetchEvidenceTail(): Promise<EvidenceTailResponse> {
+  const res = await fetch('/api/evidence', {
+    headers: { accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(`/api/evidence returned ${res.status}`);
+  }
+  return (await res.json()) as EvidenceTailResponse;
+}
+
+export type { EvidenceTailResponse, EvidenceTailRow } from '../../server/evidence.ts';

--- a/packages/ui/src/client/pages/Evidence.tsx
+++ b/packages/ui/src/client/pages/Evidence.tsx
@@ -1,0 +1,110 @@
+import { type ReactElement, useEffect, useState } from 'react';
+import { fetchEvidenceTail, type EvidenceTailResponse, type EvidenceTailRow } from '../api/evidence.ts';
+
+const POLL_INTERVAL_MS = 10_000;
+
+/**
+ * Live tail of `evidence_log`. Polls `/api/evidence` every 10s and
+ * renders the most-recent N rows. Title is hyperlinked when the row
+ * has a citation_url, plain text otherwise. The integration + kind
+ * pair shows as a compact prefix chip.
+ *
+ * Matches the polling discipline of the existing Diagnostics page:
+ * skip overlapping requests, clean cancellation on unmount, top-of-
+ * page error banner when the fetch itself fails.
+ */
+export function Evidence(): ReactElement {
+  const [data, setData] = useState<EvidenceTailResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    let inFlight = false;
+    const load = async (): Promise<void> => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        const next = await fetchEvidenceTail();
+        if (cancelled) return;
+        setData(next);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        inFlight = false;
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    const id = setInterval(() => {
+      void load();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (loading && data === null && error === null) {
+    return (
+      <main className="diagnostics">
+        <p>Loading evidence tail...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="diagnostics">
+      <header>
+        <h1>Evidence tail</h1>
+        <p className="hint">
+          {data
+            ? `Showing ${data.rows.length} of ${data.total_in_db} rows · updated ${new Date(data.generated_at).toLocaleTimeString()}`
+            : 'No data yet'}
+        </p>
+      </header>
+      {error !== null && (
+        <div role="alert" className="banner banner--error">
+          /api/evidence: {error}
+        </div>
+      )}
+      {data !== null && (
+        <section>
+          {data.rows.length === 0 ? (
+            <p className="empty">No evidence rows yet. Run a /session-start or wait for a poll to populate.</p>
+          ) : (
+            <ul className="evidence-list">
+              {data.rows.map((row) => (
+                <EvidenceItem key={row.id} row={row} />
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
+    </main>
+  );
+}
+
+function EvidenceItem({ row }: { row: EvidenceTailRow }): ReactElement {
+  return (
+    <li className="evidence-item">
+      <span className="evidence-item__chip">
+        <code>
+          {row.integration}/{row.kind}
+        </code>
+      </span>
+      <span className="evidence-item__title">
+        {row.citation_url !== null ? (
+          <a href={row.citation_url} target="_blank" rel="noreferrer">
+            {row.title}
+          </a>
+        ) : (
+          row.title
+        )}
+      </span>
+      <span className="evidence-item__time">{new Date(row.occurred_at).toLocaleString()}</span>
+    </li>
+  );
+}

--- a/packages/ui/src/server/evidence.test.ts
+++ b/packages/ui/src/server/evidence.test.ts
@@ -75,4 +75,41 @@ describe('buildEvidenceTailResponse', () => {
     expect(r.rows[0]?.title).toBe('(no title)');
     expect(r.rows[0]?.kind).toBe('mention');
   });
+
+  it('returns the limit when the newest rows are unrenderable (both title and kind empty)', () => {
+    // Seed `limit` (=3) renderable rows below several unrenderable ones
+    // at the very top of the tail. With pre-filter limiting, the tail
+    // would return < 3 rows because the unrenderable rows would be
+    // dropped after the SQL LIMIT. Push the predicate into SQL and
+    // the tail returns exactly `limit` usable rows.
+    seed({ title: '', kind: '', occurredAtMs: FIXED_NOW }); // newest, unrenderable
+    seed({ title: '', kind: '', occurredAtMs: FIXED_NOW - ONE_MIN }); // unrenderable
+    seed({ title: 'a', occurredAtMs: FIXED_NOW - 2 * ONE_MIN });
+    seed({ title: 'b', occurredAtMs: FIXED_NOW - 3 * ONE_MIN });
+    seed({ title: 'c', occurredAtMs: FIXED_NOW - 4 * ONE_MIN });
+    const r = buildEvidenceTailResponse({ db: dbHandle.db, limit: 3, nowMs: FIXED_NOW });
+    expect(r.rows.length).toBe(3);
+    expect(r.rows.map((row) => row.title)).toEqual(['a', 'b', 'c']);
+    // `total_in_db` reflects renderable rows only — same population as
+    // the tail.
+    expect(r.total_in_db).toBe(3);
+  });
+
+  it('nulls citation_url when the stored value is not a valid URL', () => {
+    seed({ title: 'malformed', citationUrl: 'not a url', occurredAtMs: FIXED_NOW });
+    const r = buildEvidenceTailResponse({ db: dbHandle.db, nowMs: FIXED_NOW });
+    expect(r.rows.length).toBe(1);
+    expect(r.rows[0]?.citation_url).toBe(null);
+    expect(r.rows[0]?.title).toBe('malformed');
+  });
+
+  it('preserves citation_url when the stored value is a valid URL', () => {
+    seed({
+      title: 'good link',
+      citationUrl: 'https://example.com/foo',
+      occurredAtMs: FIXED_NOW,
+    });
+    const r = buildEvidenceTailResponse({ db: dbHandle.db, nowMs: FIXED_NOW });
+    expect(r.rows[0]?.citation_url).toBe('https://example.com/foo');
+  });
 });

--- a/packages/ui/src/server/evidence.test.ts
+++ b/packages/ui/src/server/evidence.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure-ish tests for the evidence-tail response builder. Uses an
+ * in-memory SQLite DB seeded with known rows so the test asserts the
+ * exact shape end to end (DB → JSON wire payload).
+ */
+
+import { createDb, evidenceLog } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildEvidenceTailResponse } from './evidence.ts';
+
+const FIXED_NOW = 1_762_000_000_000;
+const ONE_MIN = 60 * 1000;
+
+describe('buildEvidenceTailResponse', () => {
+  let dbHandle: ReturnType<typeof createDb>;
+
+  beforeEach(() => {
+    dbHandle = createDb({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    dbHandle.close();
+  });
+
+  function seed(overrides: Partial<typeof evidenceLog.$inferInsert> = {}): void {
+    const base = {
+      integration: 'github',
+      externalId: `ext-${Math.random().toString(36).slice(2)}`,
+      kind: 'pull_request',
+      citationUrl: 'https://github.com/owner/repo/pull/1',
+      title: 'Add widget',
+      body: null,
+      payloadJson: '{}',
+      occurredAtMs: FIXED_NOW - ONE_MIN,
+      firstSeenAtMs: FIXED_NOW - ONE_MIN,
+      lastSeenAtMs: FIXED_NOW - ONE_MIN,
+      createdAtMs: FIXED_NOW - ONE_MIN,
+      updatedAtMs: FIXED_NOW - ONE_MIN,
+    } satisfies typeof evidenceLog.$inferInsert;
+    dbHandle.db
+      .insert(evidenceLog)
+      .values({ ...base, ...overrides })
+      .run();
+  }
+
+  it('returns an empty rows array when DB is empty', () => {
+    const r = buildEvidenceTailResponse({ db: dbHandle.db, nowMs: FIXED_NOW });
+    expect(r.rows).toEqual([]);
+    expect(r.total_in_db).toBe(0);
+    expect(r.generated_at).toBe(new Date(FIXED_NOW).toISOString());
+  });
+
+  it('orders rows newest-first by occurred_at', () => {
+    seed({ title: 'oldest', occurredAtMs: FIXED_NOW - 10 * ONE_MIN });
+    seed({ title: 'middle', occurredAtMs: FIXED_NOW - 5 * ONE_MIN });
+    seed({ title: 'newest', occurredAtMs: FIXED_NOW });
+    const r = buildEvidenceTailResponse({ db: dbHandle.db, nowMs: FIXED_NOW });
+    expect(r.rows.map((row) => row.title)).toEqual(['newest', 'middle', 'oldest']);
+    expect(r.total_in_db).toBe(3);
+  });
+
+  it('respects the limit cap', () => {
+    for (let i = 0; i < 10; i += 1) {
+      seed({ title: `row ${i}`, occurredAtMs: FIXED_NOW - i * ONE_MIN });
+    }
+    const r = buildEvidenceTailResponse({ db: dbHandle.db, limit: 3, nowMs: FIXED_NOW });
+    expect(r.rows.length).toBe(3);
+    expect(r.total_in_db).toBe(10);
+  });
+
+  it('substitutes placeholders for rows with null title', () => {
+    seed({ title: null, kind: 'mention', occurredAtMs: FIXED_NOW });
+    const r = buildEvidenceTailResponse({ db: dbHandle.db, nowMs: FIXED_NOW });
+    expect(r.rows.length).toBe(1);
+    expect(r.rows[0]?.title).toBe('(no title)');
+    expect(r.rows[0]?.kind).toBe('mention');
+  });
+});

--- a/packages/ui/src/server/evidence.ts
+++ b/packages/ui/src/server/evidence.ts
@@ -1,16 +1,21 @@
 /**
  * `/api/evidence` response builder. Returns the most-recent N rows from
  * `evidence_log` shaped for the client's live-tail view. The same
- * defensive row-shaping the start_session tool uses (skip rows missing
- * both `title` and `kind`, downgrade malformed citation_url) applies
- * here so a single bad row never breaks the tail.
+ * defensive row-shaping the start_session tool uses (skip rows whose
+ * title AND kind are both empty, downgrade malformed citation_url to
+ * null) applies here so a single bad row never breaks the tail.
+ *
+ * The "renderable" predicate (title OR kind non-empty) is pushed into
+ * SQL — both the `total_in_db` badge and the row tail count the same
+ * population, so the badge can't disagree with the rendered list.
  *
  * No polling, no auth — this is a single-process loopback-bound
  * read-only surface.
  */
 
 import { evidenceLog, type SlopweaverDatabase } from '@slopweaver/db';
-import { desc, sql } from 'drizzle-orm';
+import { and, desc, ne, or, sql } from 'drizzle-orm';
+import { safeCitationUrl } from './shape-evidence.ts';
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
@@ -40,15 +45,26 @@ function countStar() {
   return sql<number>`count(*)`.as('count');
 }
 
+// Renderable predicate: at least one of (title, kind) is non-empty.
+// `title` is nullable; `kind` is NOT NULL but can be ''. Using `or` so
+// a row keeps if either column has signal.
+const renderablePredicate = or(
+  and(sql`${evidenceLog.title} IS NOT NULL`, ne(evidenceLog.title, '')),
+  ne(evidenceLog.kind, ''),
+);
+
 export function buildEvidenceTailResponse(args: BuildEvidenceTailArgs): EvidenceTailResponse {
   const limit = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
   const nowMs = args.nowMs ?? Date.now();
 
-  // Total row count for the "N of M" badge in the UI. Cheap COUNT(*)
-  // because evidence_log stays small (<10K rows in practice).
+  // Total count of *renderable* rows for the "N of M" badge in the UI.
+  // Mirrors the WHERE clause used for the row tail so the badge can't
+  // claim a higher number than the tail can ever display. Cheap
+  // COUNT(*) because evidence_log stays small (<10K rows in practice).
   const total = args.db
     .select({ count: countStar() })
     .from(evidenceLog)
+    .where(renderablePredicate)
     .all()
     .reduce<number>((acc, row) => acc + row.count, 0);
 
@@ -62,30 +78,25 @@ export function buildEvidenceTailResponse(args: BuildEvidenceTailArgs): Evidence
       occurredAtMs: evidenceLog.occurredAtMs,
     })
     .from(evidenceLog)
+    .where(renderablePredicate)
     .orderBy(desc(evidenceLog.occurredAtMs))
     .limit(limit)
     .all();
 
-  const rows: EvidenceTailRow[] = [];
-  for (const row of dbRows) {
-    // `kind` is NOT NULL in the schema but can be an empty string in
-    // very-degenerate cases. `title` is nullable. Skip the truly-
-    // pathological rows the start_session tool also skips: empty
-    // title AND empty kind → nothing useful to render.
+  const rows: EvidenceTailRow[] = dbRows.map((row) => {
     const title = row.title;
     const kind = row.kind;
     const titleEmpty = title === null || title.length === 0;
     const kindEmpty = kind.length === 0;
-    if (titleEmpty && kindEmpty) continue;
-    rows.push({
+    return {
       id: String(row.id),
       integration: row.integration,
       kind: kindEmpty ? 'unknown' : kind,
       title: titleEmpty ? '(no title)' : title,
-      citation_url: row.citationUrl,
+      citation_url: safeCitationUrl(row.citationUrl),
       occurred_at: new Date(row.occurredAtMs).toISOString(),
-    });
-  }
+    };
+  });
 
   return {
     rows,

--- a/packages/ui/src/server/evidence.ts
+++ b/packages/ui/src/server/evidence.ts
@@ -1,0 +1,95 @@
+/**
+ * `/api/evidence` response builder. Returns the most-recent N rows from
+ * `evidence_log` shaped for the client's live-tail view. The same
+ * defensive row-shaping the start_session tool uses (skip rows missing
+ * both `title` and `kind`, downgrade malformed citation_url) applies
+ * here so a single bad row never breaks the tail.
+ *
+ * No polling, no auth — this is a single-process loopback-bound
+ * read-only surface.
+ */
+
+import { evidenceLog, type SlopweaverDatabase } from '@slopweaver/db';
+import { desc, sql } from 'drizzle-orm';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export type EvidenceTailRow = {
+  id: string;
+  integration: string;
+  kind: string;
+  title: string;
+  citation_url: string | null;
+  occurred_at: string;
+};
+
+export type EvidenceTailResponse = {
+  rows: ReadonlyArray<EvidenceTailRow>;
+  total_in_db: number;
+  generated_at: string;
+};
+
+export type BuildEvidenceTailArgs = {
+  db: SlopweaverDatabase;
+  limit?: number;
+  nowMs?: number;
+};
+
+function countStar() {
+  return sql<number>`count(*)`.as('count');
+}
+
+export function buildEvidenceTailResponse(args: BuildEvidenceTailArgs): EvidenceTailResponse {
+  const limit = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const nowMs = args.nowMs ?? Date.now();
+
+  // Total row count for the "N of M" badge in the UI. Cheap COUNT(*)
+  // because evidence_log stays small (<10K rows in practice).
+  const total = args.db
+    .select({ count: countStar() })
+    .from(evidenceLog)
+    .all()
+    .reduce<number>((acc, row) => acc + row.count, 0);
+
+  const dbRows = args.db
+    .select({
+      id: evidenceLog.id,
+      integration: evidenceLog.integration,
+      kind: evidenceLog.kind,
+      title: evidenceLog.title,
+      citationUrl: evidenceLog.citationUrl,
+      occurredAtMs: evidenceLog.occurredAtMs,
+    })
+    .from(evidenceLog)
+    .orderBy(desc(evidenceLog.occurredAtMs))
+    .limit(limit)
+    .all();
+
+  const rows: EvidenceTailRow[] = [];
+  for (const row of dbRows) {
+    // `kind` is NOT NULL in the schema but can be an empty string in
+    // very-degenerate cases. `title` is nullable. Skip the truly-
+    // pathological rows the start_session tool also skips: empty
+    // title AND empty kind → nothing useful to render.
+    const title = row.title;
+    const kind = row.kind;
+    const titleEmpty = title === null || title.length === 0;
+    const kindEmpty = kind.length === 0;
+    if (titleEmpty && kindEmpty) continue;
+    rows.push({
+      id: String(row.id),
+      integration: row.integration,
+      kind: kindEmpty ? 'unknown' : kind,
+      title: titleEmpty ? '(no title)' : title,
+      citation_url: row.citationUrl,
+      occurred_at: new Date(row.occurredAtMs).toISOString(),
+    });
+  }
+
+  return {
+    rows,
+    total_in_db: total,
+    generated_at: new Date(nowMs).toISOString(),
+  };
+}

--- a/packages/ui/src/server/shape-evidence.test.ts
+++ b/packages/ui/src/server/shape-evidence.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { safeCitationUrl } from './shape-evidence.ts';
+
+describe('safeCitationUrl', () => {
+  it('returns null for null input', () => {
+    expect(safeCitationUrl(null)).toBe(null);
+  });
+
+  it('returns null for empty-string input', () => {
+    expect(safeCitationUrl('')).toBe(null);
+  });
+
+  it('returns the URL unchanged for an absolute https URL', () => {
+    expect(safeCitationUrl('https://example.com/path?q=1')).toBe('https://example.com/path?q=1');
+  });
+
+  it('returns the URL unchanged for an absolute http URL', () => {
+    expect(safeCitationUrl('http://example.com/path')).toBe('http://example.com/path');
+  });
+
+  it('returns null for a malformed URL', () => {
+    expect(safeCitationUrl('not a url')).toBe(null);
+  });
+
+  it('returns null for a `javascript:` URL (XSS vector)', () => {
+    expect(safeCitationUrl('javascript:alert(1)')).toBe(null);
+  });
+
+  it('returns null for a `data:` URL', () => {
+    expect(safeCitationUrl('data:text/html,<script>alert(1)</script>')).toBe(null);
+  });
+
+  it('returns null for a `file:` URL', () => {
+    expect(safeCitationUrl('file:///etc/passwd')).toBe(null);
+  });
+
+  it('returns null for a `chrome:` URL', () => {
+    expect(safeCitationUrl('chrome://settings')).toBe(null);
+  });
+
+  it('returns null for an `ftp:` URL', () => {
+    expect(safeCitationUrl('ftp://example.com/file')).toBe(null);
+  });
+});

--- a/packages/ui/src/server/shape-evidence.ts
+++ b/packages/ui/src/server/shape-evidence.ts
@@ -1,0 +1,24 @@
+/**
+ * UI-server sibling of `packages/mcp-server/src/tools/shape-evidence.ts`.
+ *
+ * The UI returns a different wire shape than the MCP tools (a flat
+ * `EvidenceTailRow` rather than the contract `EvidenceLogEntry` with a
+ * `Reference`), so we don't import the mcp-server helper directly — but
+ * we *do* want the same defensive behaviour for malformed
+ * `citation_url`: parse-fail downgrades to `null` rather than echoing
+ * bad data to the client.
+ *
+ * Kept dep-free (uses the built-in `URL` constructor) so the UI package
+ * doesn't pick up a `zod` dependency just for one URL safe-parse.
+ */
+
+/**
+ * Returns the input URL if it parses as an absolute URL, else `null`.
+ * Treats empty / null inputs as null so callers don't need to pre-check.
+ * Uses Node 22's `URL.canParse` so we don't pay the cost of a thrown
+ * Error for malformed inputs.
+ */
+export function safeCitationUrl(url: string | null): string | null {
+  if (url === null || url.length === 0) return null;
+  return URL.canParse(url) ? url : null;
+}

--- a/packages/ui/src/server/shape-evidence.ts
+++ b/packages/ui/src/server/shape-evidence.ts
@@ -13,12 +13,19 @@
  */
 
 /**
- * Returns the input URL if it parses as an absolute URL, else `null`.
- * Treats empty / null inputs as null so callers don't need to pre-check.
- * Uses Node 22's `URL.canParse` so we don't pay the cost of a thrown
- * Error for malformed inputs.
+ * Returns the input URL if it parses as an absolute `http(s):` URL, else
+ * `null`. Treats empty / null inputs as null so callers don't need to
+ * pre-check. Rejects every other URL scheme (`javascript:`, `data:`,
+ * `file:`, `chrome:`, `ftp:`, etc.) so that the value, when rendered
+ * into a clickable `<a href>` in the client, can't be used as an XSS
+ * vector. `URL.canParse('javascript:alert(1)')` returns `true`, so a
+ * `canParse` check alone is not sufficient — we parse and then assert
+ * the protocol explicitly.
  */
 export function safeCitationUrl(url: string | null): string | null {
   if (url === null || url.length === 0) return null;
-  return URL.canParse(url) ? url : null;
+  if (!URL.canParse(url)) return null;
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  return url;
 }

--- a/packages/ui/src/server/start.ts
+++ b/packages/ui/src/server/start.ts
@@ -4,6 +4,7 @@ import { extname, isAbsolute, join, relative, resolve } from 'node:path';
 import type { SlopweaverDatabase } from '@slopweaver/db';
 import { runStaticEnvChecks, type StaticEnvChecks } from './checks.ts';
 import { buildDiagnosticsResponse } from './diagnostics.ts';
+import { buildEvidenceTailResponse } from './evidence.ts';
 import { CLIENT_ASSETS_DIR } from './static-dir.ts';
 
 export type StartUiServerOptions = {
@@ -194,6 +195,15 @@ function handleApi({
   }
   if (pathname === '/api/diagnostics') {
     const body = JSON.stringify(buildDiagnosticsResponse({ db, staticChecks, bindAddress }));
+    res.writeHead(200, {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+    });
+    res.end(method === 'HEAD' ? undefined : body);
+    return;
+  }
+  if (pathname === '/api/evidence') {
+    const body = JSON.stringify(buildEvidenceTailResponse({ db }));
     res.writeHead(200, {
       'content-type': 'application/json; charset=utf-8',
       'cache-control': 'no-store',

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -6,5 +6,11 @@ export default defineConfig({
     // `// @vitest-environment jsdom` pragma at the top of the file.
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    // Auto-restore `vi.stubGlobal(...)` between tests so a stubbed
+    // `globalThis.fetch` (or any other global) in one component test
+    // can't leak into the next. `vi.restoreAllMocks()` alone does NOT
+    // clear stubGlobal — only `vi.unstubAllGlobals()` does — so we let
+    // Vitest run that cleanup for us automatically.
+    unstubGlobals: true,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       '@slopweaver/db':
         specifier: workspace:*
         version: link:../db
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)
       react:
         specifier: 19.2.5
         version: 19.2.5


### PR DESCRIPTION
**Problem**

The Diagnostics UI was the only flight-deck screen, and there was no way to see what `evidence_log` actually contained without dropping into sqlite. Closes #61.

**Solution**

Adds tab nav to the existing Diagnostics shell and a new Evidence tab that tails `/api/evidence` every 10s. The "three files per tab" pattern is documented in `App.tsx` so the remaining tabs (Snapshot, Reconciliation, Calibration, Stakeholders) plug in the same way.

**Proof this works**

_pending local verification_

**How to test**

1. `pnpm install && pnpm build`
2. `pnpm --filter @slopweaver/ui dev` (or run the local `slopweaver` binary)
3. Open `http://localhost:60701`, confirm the Diagnostics tab loads by default
4. Click the Evidence tab, confirm the tail renders rows newest-first with `integration/kind` chips and clickable titles
5. Wait 10s, confirm the tail refreshes without flicker
6. `pnpm --filter @slopweaver/ui test` to run the new server and component suites
7. `pnpm validate` for the full gate

<details>
<summary>Implementation notes</summary>

- New `/api/evidence` endpoint in `packages/ui/src/server/evidence.ts`. Returns the most-recent N renderable rows plus a `total_in_db` count from the same SQL predicate so the "N of M" badge can't disagree with the rendered list.
- Renderable-row predicate (`title` non-empty OR `kind` non-empty) pushed into SQL via drizzle `and`/`or`/`ne`. Pre-filter `LIMIT` means the tail returns exactly `limit` usable rows even when the newest rows are blank.
- Evidence page polling matches the Diagnostics page discipline. Skip overlapping requests, clean cancellation on unmount, top-of-page banner when `/api/evidence` itself fails.
- Citation URLs go through `safeCitationUrl` in `shape-evidence.ts`. Iter-3 fix (`5ea2359`) tightens this to an `http:`/`https:` allowlist so `javascript:`, `data:`, `file:`, `chrome:`, `ftp:`, etc. all downgrade to `null` before reaching `<a href>`. `URL.canParse('javascript:alert(1)')` returns `true`, so the protocol check is load-bearing.
- Same commit flips `unstubGlobals: true` in `packages/ui/vitest.config.ts` so a stubbed `globalThis.fetch` in one component test can't leak into the next. `vi.restoreAllMocks()` alone doesn't clear `stubGlobal`.

</details>
