### PR TITLE
feat(ui): Calibration tab with rate tiles + SVG daily-outcome chart

### DIFF
--- a/packages/ui/src/client/App.css
+++ b/packages/ui/src/client/App.css
@@ -141,3 +141,106 @@ code {
   font-family: ui-monospace, SFMono-Regular, monospace;
   font-size: 0.9em;
 }
+
+/* --- Calibration --------------------------------------------------- */
+
+.calibration-tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.calibration-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background: #f3f4f6;
+}
+
+.calibration-tile--ok { background: #ecfdf5; }
+.calibration-tile--warn { background: #fefce8; }
+.calibration-tile--fail { background: #fef2f2; }
+
+.calibration-tile__label {
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.calibration-tile__value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1f2937;
+  font-variant-numeric: tabular-nums;
+}
+
+.calibration-chart {
+  width: 100%;
+  height: auto;
+  max-width: 480px;
+  background: #fafafa;
+  border-radius: 4px;
+}
+
+.friction-tags {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.friction-tags li {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.9rem;
+}
+
+.friction-tags__count {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- Flight-deck tab navigation ------------------------------------ */
+/* Same shell as PR #61 — if both PRs merge, this block is the
+ * dedupe target. Identical CSS in both PRs by design.
+ */
+
+.flight-deck__tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.75rem 1.5rem 0;
+  border-bottom: 1px solid var(--border);
+  background: #f9fafb;
+}
+
+.flight-deck__tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--muted);
+  padding: 0.5rem 0.875rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 4px 4px 0 0;
+  margin-bottom: -1px;
+}
+
+.flight-deck__tab:hover {
+  background: rgba(0, 0, 0, 0.03);
+  color: #1f2937;
+}
+
+.flight-deck__tab--active {
+  color: #1f2937;
+  border-bottom-color: #2563eb;
+  background: #ffffff;
+}

--- a/packages/ui/src/client/App.css
+++ b/packages/ui/src/client/App.css
@@ -207,6 +207,33 @@ code {
   font-variant-numeric: tabular-nums;
 }
 
+.calibration-breakdown {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.calibration-breakdown th,
+.calibration-breakdown td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.calibration-breakdown thead th {
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.calibration-breakdown td,
+.calibration-breakdown thead th + th {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 /* --- Flight-deck tab navigation ------------------------------------ */
 /* Same shell as PR #61 — if both PRs merge, this block is the
  * dedupe target. Identical CSS in both PRs by design.

--- a/packages/ui/src/client/App.test.tsx
+++ b/packages/ui/src/client/App.test.tsx
@@ -20,9 +20,12 @@ describe('App (tab navigation)', () => {
               edit_rate: 0,
               rejection_rate: 0,
               daily: [],
+              by_integration: [],
+              by_kind: [],
               top_friction_tags: [],
               source_path: '/tmp/log.jsonl',
               source_present: false,
+              empty: true,
               generated_at: '2026-05-21T00:00:00.000Z',
             }),
           } as unknown as Response;
@@ -69,7 +72,7 @@ describe('App (tab navigation)', () => {
   it('shows the empty-state copy when the log source is missing', async () => {
     render(<App />);
     fireEvent.click(screen.getByRole('button', { name: 'Calibration' }));
-    const emptyState = await waitFor(() => screen.getByText(/No walk-feedback log/));
+    const emptyState = await waitFor(() => screen.getByText(/No walks recorded/));
     expect(emptyState).toBeTruthy();
   });
 });

--- a/packages/ui/src/client/App.test.tsx
+++ b/packages/ui/src/client/App.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { App } from './App.tsx';
+
+describe('App (tab navigation)', () => {
+  beforeEach(() => {
+    // jsdom has no fetch; stub it for the polling effects in both tabs.
+    Object.defineProperty(globalThis, 'fetch', {
+      value: vi.fn(async (url: string) => {
+        if (url.includes('/api/calibration')) {
+          return {
+            ok: true,
+            json: async () => ({
+              window_start: '2026-04-21T00:00:00.000Z',
+              window_end: '2026-05-21T00:00:00.000Z',
+              total_walks: 0,
+              total_items: 0,
+              acceptance_rate: 0,
+              edit_rate: 0,
+              rejection_rate: 0,
+              daily: [],
+              top_friction_tags: [],
+              source_path: '/tmp/log.jsonl',
+              source_present: false,
+              generated_at: '2026-05-21T00:00:00.000Z',
+            }),
+          } as unknown as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            schemaVersion: 1,
+            generatedAtMs: Date.now(),
+            env: {
+              node: { name: 'Node version', status: 'ok', detail: 'node x' },
+              pnpm: { name: 'pnpm version', status: 'ok', detail: 'pnpm x' },
+              dataDir: { name: 'Data dir', status: 'ok', detail: '/x' },
+            },
+            server: { host: '127.0.0.1', port: 60701, listening: true },
+            integrations: [],
+            mcpClients: { count: 0, transport: 'stdio', tracked: false },
+          }),
+        } as unknown as Response;
+      }),
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('renders the Diagnostics tab by default', async () => {
+    render(<App />);
+    expect(screen.getByRole('button', { name: 'Diagnostics' }).getAttribute('aria-current')).toBe('page');
+    await waitFor(() => screen.getByText(/Listening on/));
+  });
+
+  it('switches to the Calibration tab on click', async () => {
+    render(<App />);
+    const calTab = screen.getByRole('button', { name: 'Calibration' });
+    fireEvent.click(calTab);
+    expect(calTab.getAttribute('aria-current')).toBe('page');
+    await waitFor(() => screen.getByRole('heading', { name: 'Calibration' }));
+  });
+
+  it('shows the empty-state copy when the log source is missing', async () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: 'Calibration' }));
+    const emptyState = await waitFor(() => screen.getByText(/No walk-feedback log/));
+    expect(emptyState).toBeTruthy();
+  });
+});

--- a/packages/ui/src/client/App.tsx
+++ b/packages/ui/src/client/App.tsx
@@ -1,11 +1,55 @@
-import type { ReactElement } from 'react';
+import { type ReactElement, useState } from 'react';
 import './App.css';
+import { Calibration } from './pages/Calibration.tsx';
 import { Diagnostics } from './pages/Diagnostics.tsx';
 
+type Tab = 'diagnostics' | 'calibration';
+
 /**
- * Top-level React component for the Diagnostics SPA. Renders the single
- * Diagnostics page — there is no router; this app has exactly one screen.
+ * Top-level shell. Single-process tab state via `useState` — no
+ * router, no URL sync (page count too small for either to pay back).
+ *
+ * Adding a new tab: append to `TABS`, create the matching page
+ * component, add the switch arm in `renderActiveTab`.
+ *
+ * Note: PR #61 (flight-deck Evidence tab) ships a parallel tab arm.
+ * When both merge, resolve the conflict by combining both tab lists +
+ * both switch arms.
  */
+const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
+  { id: 'diagnostics', label: 'Diagnostics' },
+  { id: 'calibration', label: 'Calibration' },
+];
+
 export function App(): ReactElement {
-  return <Diagnostics />;
+  const [activeTab, setActiveTab] = useState<Tab>('diagnostics');
+  return (
+    <div className="flight-deck">
+      <nav className="flight-deck__tabs" aria-label="primary">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            className={`flight-deck__tab${tab.id === activeTab ? ' flight-deck__tab--active' : ''}`}
+            onClick={() => {
+              setActiveTab(tab.id);
+            }}
+            aria-current={tab.id === activeTab ? 'page' : undefined}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+      {renderActiveTab(activeTab)}
+    </div>
+  );
+}
+
+function renderActiveTab(tab: Tab): ReactElement {
+  switch (tab) {
+    case 'diagnostics':
+      return <Diagnostics />;
+    case 'calibration':
+      return <Calibration />;
+  }
 }

--- a/packages/ui/src/client/api/calibration.ts
+++ b/packages/ui/src/client/api/calibration.ts
@@ -1,0 +1,13 @@
+import type { CalibrationResponse } from '../../server/calibration.ts';
+
+export async function fetchCalibration(): Promise<CalibrationResponse> {
+  const res = await fetch('/api/calibration', {
+    headers: { accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(`/api/calibration returned ${res.status}`);
+  }
+  return (await res.json()) as CalibrationResponse;
+}
+
+export type { CalibrationResponse, CalibrationPoint, FrictionTagTally } from '../../server/calibration.ts';

--- a/packages/ui/src/client/api/calibration.ts
+++ b/packages/ui/src/client/api/calibration.ts
@@ -10,4 +10,9 @@ export async function fetchCalibration(): Promise<CalibrationResponse> {
   return (await res.json()) as CalibrationResponse;
 }
 
-export type { CalibrationResponse, CalibrationPoint, FrictionTagTally } from '../../server/calibration.ts';
+export type {
+  CalibrationResponse,
+  CalibrationPoint,
+  CalibrationBreakdown,
+  FrictionTagTally,
+} from '../../server/calibration.ts';

--- a/packages/ui/src/client/pages/Calibration.tsx
+++ b/packages/ui/src/client/pages/Calibration.tsx
@@ -1,17 +1,23 @@
 import { type ReactElement, useEffect, useState } from 'react';
-import { fetchCalibration, type CalibrationPoint, type CalibrationResponse } from '../api/calibration.ts';
+import {
+  fetchCalibration,
+  type CalibrationBreakdown,
+  type CalibrationPoint,
+  type CalibrationResponse,
+} from '../api/calibration.ts';
 
 const POLL_INTERVAL_MS = 30_000;
 
 /**
  * Calibration tab — visualizes the `/lock-in` walk-feedback log.
- * Acceptance / edit / rejection rates as numeric tiles, a tiny daily
- * trend chart rendered as inline SVG (no chart library — keeps bundle
- * tight), and a horizontal bar list of the top friction tags.
+ * Acceptance / edit / rejection rates as numeric tiles, a daily ratio
+ * chart rendered as inline SVG (no chart library — keeps bundle tight),
+ * two per-axis breakdown tables (integration, kind), and a horizontal
+ * bar list of the top friction tags.
  *
- * The chart uses absolute counts per day (stacked bars: approved /
- * edited / rejected). When the source log is missing we render an
- * empty state with a one-liner explaining how to populate it.
+ * Empty state covers two conditions: the source log is missing **or**
+ * the log exists but has no walks/items yet. Both render the same
+ * "run a /lock-in walk" pointer.
  */
 export function Calibration(): ReactElement {
   const [data, setData] = useState<CalibrationResponse | null>(null);
@@ -55,6 +61,8 @@ export function Calibration(): ReactElement {
     );
   }
 
+  const isEmpty = data !== null && (!data.source_present || data.total_walks === 0 || data.total_items === 0);
+
   return (
     <main className="diagnostics">
       <header>
@@ -70,13 +78,13 @@ export function Calibration(): ReactElement {
           /api/calibration: {error}
         </div>
       )}
-      {data !== null && !data.source_present && (
+      {data !== null && isEmpty && (
         <p className="empty">
-          No walk-feedback log at <code>{data.source_path}</code> yet. Run a <code>/lock-in</code> walk to start
-          populating it.
+          No walks recorded at <code>{data.source_path}</code> yet. Run a <code>/lock-in</code> walk to start populating
+          it.
         </p>
       )}
-      {data !== null && data.source_present && <CalibrationBody data={data} />}
+      {data !== null && !isEmpty && <CalibrationBody data={data} />}
     </main>
   );
 }
@@ -95,6 +103,14 @@ function CalibrationBody({ data }: { data: CalibrationResponse }): ReactElement 
       <section>
         <h2>Daily outcomes</h2>
         <DailyChart points={data.daily} />
+      </section>
+      <section>
+        <h2>By integration</h2>
+        <BreakdownTable rows={data.by_integration} columnLabel="Integration" />
+      </section>
+      <section>
+        <h2>By kind</h2>
+        <BreakdownTable rows={data.by_kind} columnLabel="Kind" />
       </section>
       <section>
         <h2>Top friction tags</h2>
@@ -132,6 +148,42 @@ function RateTile({
   );
 }
 
+function BreakdownTable({
+  rows,
+  columnLabel,
+}: {
+  rows: ReadonlyArray<CalibrationBreakdown>;
+  columnLabel: string;
+}): ReactElement {
+  if (rows.length === 0) {
+    return <p className="empty">No data yet.</p>;
+  }
+  return (
+    <table className="calibration-breakdown">
+      <thead>
+        <tr>
+          <th scope="col">{columnLabel}</th>
+          <th scope="col">Accept</th>
+          <th scope="col">Edit</th>
+          <th scope="col">Reject</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.key}>
+            <th scope="row">
+              <code>{row.key}</code>
+            </th>
+            <td>{row.accept}</td>
+            <td>{row.edit}</td>
+            <td>{row.reject}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
 const CHART_WIDTH = 480;
 const CHART_HEIGHT = 120;
 const CHART_PADDING = 8;
@@ -140,11 +192,9 @@ function DailyChart({ points }: { points: ReadonlyArray<CalibrationPoint> }): Re
   if (points.length === 0) {
     return <p className="empty">No outcomes recorded yet.</p>;
   }
-  const max = points.reduce(
-    (acc, p) => Math.max(acc, p.approved + p.edited + p.rejected + p.deferred + p.dropped + p.noted),
-    0,
-  );
-  if (max === 0) return <p className="empty">No outcomes recorded yet.</p>;
+  const hasData = points.some((p) => p.total > 0);
+  if (!hasData) return <p className="empty">No outcomes recorded yet.</p>;
+
   const innerWidth = CHART_WIDTH - CHART_PADDING * 2;
   const innerHeight = CHART_HEIGHT - CHART_PADDING * 2;
   const barWidth = innerWidth / points.length;
@@ -155,27 +205,35 @@ function DailyChart({ points }: { points: ReadonlyArray<CalibrationPoint> }): Re
       viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
       className="calibration-chart"
     >
-      <title>Daily outcome chart</title>
+      <title>Daily outcome ratios</title>
       {points.map((point, i) => {
         const x = CHART_PADDING + i * barWidth;
-        const total = point.approved + point.edited + point.rejected + point.deferred + point.dropped + point.noted;
-        const scale = innerHeight / max;
-        let y = CHART_HEIGHT - CHART_PADDING;
+        // y-axis is 0 → 1 (100%). Days with zero events stack to a
+        // visible-but-empty column so the time series isn't punctured.
         const segments: ReactElement[] = [];
-        for (const [key, color] of SEGMENTS) {
-          const h = point[key] * scale;
-          if (h <= 0) continue;
+        let y = CHART_HEIGHT - CHART_PADDING;
+        for (const seg of RATIO_SEGMENTS) {
+          const ratio = point[seg.key];
+          if (ratio <= 0) continue;
+          const h = ratio * innerHeight;
           y -= h;
           segments.push(
-            <rect key={`${point.day}-${key}`} x={x + 1} y={y} width={Math.max(0, barWidth - 2)} height={h} fill={color}>
-              <title>{`${point.day} · ${key} × ${point[key]}`}</title>
+            <rect
+              key={`${point.day}-${seg.key}`}
+              x={x + 1}
+              y={y}
+              width={Math.max(0, barWidth - 2)}
+              height={h}
+              fill={seg.color}
+            >
+              <title>{`${point.day} · ${seg.label} ${(ratio * 100).toFixed(0)}% (${ratioCount({ point, key: seg.key })}/${point.total})`}</title>
             </rect>,
           );
         }
         return (
           <g key={point.day}>
             {segments}
-            <title>{`${point.day} · ${total} items`}</title>
+            <title>{`${point.day} · ${point.total} items`}</title>
           </g>
         );
       })}
@@ -183,13 +241,24 @@ function DailyChart({ points }: { points: ReadonlyArray<CalibrationPoint> }): Re
   );
 }
 
-type NumericCalibrationKey = 'approved' | 'edited' | 'rejected' | 'deferred' | 'dropped' | 'noted';
+type RatioKey = 'accept_ratio' | 'edit_ratio' | 'reject_ratio';
+type RatioSegment = { key: RatioKey; label: string; color: string };
 
-const SEGMENTS: ReadonlyArray<[NumericCalibrationKey, string]> = [
-  ['approved', '#16a34a'],
-  ['edited', '#eab308'],
-  ['rejected', '#dc2626'],
-  ['deferred', '#94a3b8'],
-  ['dropped', '#cbd5e1'],
-  ['noted', '#a5b4fc'],
+// Order matches the rate tiles (accept → edit → reject) so visual
+// correspondence is consistent across the page.
+const RATIO_SEGMENTS: ReadonlyArray<RatioSegment> = [
+  { key: 'accept_ratio', label: 'accept', color: '#16a34a' },
+  { key: 'edit_ratio', label: 'edit', color: '#eab308' },
+  { key: 'reject_ratio', label: 'reject', color: '#dc2626' },
 ];
+
+function ratioCount({ point, key }: { point: CalibrationPoint; key: RatioKey }): number {
+  switch (key) {
+    case 'accept_ratio':
+      return point.approved;
+    case 'edit_ratio':
+      return point.edited;
+    case 'reject_ratio':
+      return point.rejected;
+  }
+}

--- a/packages/ui/src/client/pages/Calibration.tsx
+++ b/packages/ui/src/client/pages/Calibration.tsx
@@ -1,0 +1,195 @@
+import { type ReactElement, useEffect, useState } from 'react';
+import { fetchCalibration, type CalibrationPoint, type CalibrationResponse } from '../api/calibration.ts';
+
+const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Calibration tab — visualizes the `/lock-in` walk-feedback log.
+ * Acceptance / edit / rejection rates as numeric tiles, a tiny daily
+ * trend chart rendered as inline SVG (no chart library — keeps bundle
+ * tight), and a horizontal bar list of the top friction tags.
+ *
+ * The chart uses absolute counts per day (stacked bars: approved /
+ * edited / rejected). When the source log is missing we render an
+ * empty state with a one-liner explaining how to populate it.
+ */
+export function Calibration(): ReactElement {
+  const [data, setData] = useState<CalibrationResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    let inFlight = false;
+    const load = async (): Promise<void> => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        const next = await fetchCalibration();
+        if (cancelled) return;
+        setData(next);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        inFlight = false;
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    const id = setInterval(() => {
+      void load();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (loading && data === null && error === null) {
+    return (
+      <main className="diagnostics">
+        <p>Loading calibration data...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="diagnostics">
+      <header>
+        <h1>Calibration</h1>
+        <p className="hint">
+          {data
+            ? `Window: ${new Date(data.window_start).toLocaleDateString()} → ${new Date(data.window_end).toLocaleDateString()} · ${data.total_walks} walks · ${data.total_items} items`
+            : 'No data yet'}
+        </p>
+      </header>
+      {error !== null && (
+        <div role="alert" className="banner banner--error">
+          /api/calibration: {error}
+        </div>
+      )}
+      {data !== null && !data.source_present && (
+        <p className="empty">
+          No walk-feedback log at <code>{data.source_path}</code> yet. Run a <code>/lock-in</code> walk to start
+          populating it.
+        </p>
+      )}
+      {data !== null && data.source_present && <CalibrationBody data={data} />}
+    </main>
+  );
+}
+
+function CalibrationBody({ data }: { data: CalibrationResponse }): ReactElement {
+  return (
+    <>
+      <section>
+        <h2>Rates</h2>
+        <div className="calibration-tiles">
+          <RateTile label="Acceptance" value={data.acceptance_rate} tone="ok" />
+          <RateTile label="Edit" value={data.edit_rate} tone="warn" />
+          <RateTile label="Rejection" value={data.rejection_rate} tone="fail" />
+        </div>
+      </section>
+      <section>
+        <h2>Daily outcomes</h2>
+        <DailyChart points={data.daily} />
+      </section>
+      <section>
+        <h2>Top friction tags</h2>
+        {data.top_friction_tags.length === 0 ? (
+          <p className="empty">No friction tags yet.</p>
+        ) : (
+          <ul className="friction-tags">
+            {data.top_friction_tags.map((tag) => (
+              <li key={tag.tag}>
+                <code>{tag.tag}</code>
+                <span className="friction-tags__count">× {tag.count}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </>
+  );
+}
+
+function RateTile({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: 'ok' | 'warn' | 'fail';
+}): ReactElement {
+  return (
+    <div className={`calibration-tile calibration-tile--${tone}`}>
+      <span className="calibration-tile__label">{label}</span>
+      <span className="calibration-tile__value">{(value * 100).toFixed(1)}%</span>
+    </div>
+  );
+}
+
+const CHART_WIDTH = 480;
+const CHART_HEIGHT = 120;
+const CHART_PADDING = 8;
+
+function DailyChart({ points }: { points: ReadonlyArray<CalibrationPoint> }): ReactElement {
+  if (points.length === 0) {
+    return <p className="empty">No outcomes recorded yet.</p>;
+  }
+  const max = points.reduce(
+    (acc, p) => Math.max(acc, p.approved + p.edited + p.rejected + p.deferred + p.dropped + p.noted),
+    0,
+  );
+  if (max === 0) return <p className="empty">No outcomes recorded yet.</p>;
+  const innerWidth = CHART_WIDTH - CHART_PADDING * 2;
+  const innerHeight = CHART_HEIGHT - CHART_PADDING * 2;
+  const barWidth = innerWidth / points.length;
+  return (
+    <svg
+      role="img"
+      aria-label={`Daily outcome chart, ${points.length} days`}
+      viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+      className="calibration-chart"
+    >
+      <title>Daily outcome chart</title>
+      {points.map((point, i) => {
+        const x = CHART_PADDING + i * barWidth;
+        const total = point.approved + point.edited + point.rejected + point.deferred + point.dropped + point.noted;
+        const scale = innerHeight / max;
+        let y = CHART_HEIGHT - CHART_PADDING;
+        const segments: ReactElement[] = [];
+        for (const [key, color] of SEGMENTS) {
+          const h = point[key] * scale;
+          if (h <= 0) continue;
+          y -= h;
+          segments.push(
+            <rect key={`${point.day}-${key}`} x={x + 1} y={y} width={Math.max(0, barWidth - 2)} height={h} fill={color}>
+              <title>{`${point.day} · ${key} × ${point[key]}`}</title>
+            </rect>,
+          );
+        }
+        return (
+          <g key={point.day}>
+            {segments}
+            <title>{`${point.day} · ${total} items`}</title>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+type NumericCalibrationKey = 'approved' | 'edited' | 'rejected' | 'deferred' | 'dropped' | 'noted';
+
+const SEGMENTS: ReadonlyArray<[NumericCalibrationKey, string]> = [
+  ['approved', '#16a34a'],
+  ['edited', '#eab308'],
+  ['rejected', '#dc2626'],
+  ['deferred', '#94a3b8'],
+  ['dropped', '#cbd5e1'],
+  ['noted', '#a5b4fc'],
+];

--- a/packages/ui/src/server/calibration.test.ts
+++ b/packages/ui/src/server/calibration.test.ts
@@ -7,7 +7,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buildCalibrationResponse, defaultCalibrationLogPath } from './calibration.ts';
+import { buildCalibrationResponse, defaultCalibrationLogPath, resolveCalibrationLogPath } from './calibration.ts';
 
 const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
 
@@ -29,44 +29,121 @@ describe('buildCalibrationResponse', () => {
     expect(r.total_walks).toBe(0);
     expect(r.total_items).toBe(0);
     expect(r.acceptance_rate).toBe(0);
-    expect(r.daily).toEqual([]);
     expect(r.source_present).toBe(false);
+    expect(r.empty).toBe(true);
+    expect(r.by_integration).toEqual([]);
+    expect(r.by_kind).toEqual([]);
   });
 
-  it('summarizes outcomes + friction tags from a real log', () => {
+  it('zero-fills the daily skeleton across the window when the file is missing', () => {
+    const sinceMs = Date.UTC(2026, 4, 19, 0, 0, 0);
+    const r = buildCalibrationResponse({ logPath, sinceMs, nowMs: FIXED_NOW });
+    // 2026-05-19, 2026-05-20, 2026-05-21 inclusive — three UTC days.
+    expect(r.daily.length).toBe(3);
+    expect(r.daily.map((p) => p.day)).toEqual(['2026-05-19', '2026-05-20', '2026-05-21']);
+    expect(r.daily.every((p) => p.total === 0)).toBe(true);
+    expect(r.daily.every((p) => p.accept_ratio === 0)).toBe(true);
+  });
+
+  it('summarizes outcomes + friction tags + ratios from a real log', () => {
     const lines = [
       JSON.stringify({
         ts: '2026-05-20T09:00:00Z',
         walk_id: 'a',
         outcome: 'approved-as-proposed',
+        integration: 'github',
+        kind: 'review_request',
         tags: ['friction:wrong-channel'],
       }),
       JSON.stringify({
         ts: '2026-05-20T09:01:00Z',
         walk_id: 'a',
         outcome: 'edited',
+        integration: 'github',
+        kind: 'review_request',
         tags: ['friction:wrong-channel', 'friction:wrong-tone'],
       }),
-      JSON.stringify({ ts: '2026-05-21T08:00:00Z', walk_id: 'b', outcome: 'rejected' }),
+      JSON.stringify({
+        ts: '2026-05-21T08:00:00Z',
+        walk_id: 'b',
+        outcome: 'rejected',
+        integration: 'slack',
+        kind: 'mention',
+      }),
       JSON.stringify({ ts: '2026-05-21T08:30:00Z', walk_id: 'b', outcome: 'walk-summary' }),
     ];
     writeFileSync(logPath, `${lines.join('\n')}\n`);
 
-    const r = buildCalibrationResponse({ logPath, nowMs: FIXED_NOW });
+    const r = buildCalibrationResponse({
+      logPath,
+      sinceMs: Date.UTC(2026, 4, 20, 0, 0, 0),
+      nowMs: FIXED_NOW,
+    });
     expect(r.total_walks).toBe(2);
     expect(r.total_items).toBe(3);
     expect(r.acceptance_rate).toBeCloseTo(1 / 3, 5);
     expect(r.edit_rate).toBeCloseTo(1 / 3, 5);
     expect(r.rejection_rate).toBeCloseTo(1 / 3, 5);
+    expect(r.empty).toBe(false);
+
+    // Two days in the window: 2026-05-20 and 2026-05-21.
     expect(r.daily.length).toBe(2);
     expect(r.daily[0]?.day).toBe('2026-05-20');
     expect(r.daily[0]?.approved).toBe(1);
     expect(r.daily[0]?.edited).toBe(1);
+    expect(r.daily[0]?.total).toBe(2);
+    expect(r.daily[0]?.accept_ratio).toBeCloseTo(0.5, 5);
+    expect(r.daily[0]?.edit_ratio).toBeCloseTo(0.5, 5);
     expect(r.daily[1]?.day).toBe('2026-05-21');
     expect(r.daily[1]?.rejected).toBe(1);
+    expect(r.daily[1]?.reject_ratio).toBeCloseTo(1, 5);
+
+    expect(r.by_integration).toEqual([
+      { key: 'github', accept: 1, edit: 1, reject: 0 },
+      { key: 'slack', accept: 0, edit: 0, reject: 1 },
+    ]);
+    expect(r.by_kind).toEqual([
+      { key: 'review_request', accept: 1, edit: 1, reject: 0 },
+      { key: 'mention', accept: 0, edit: 0, reject: 1 },
+    ]);
+
     expect(r.top_friction_tags[0]).toEqual({ tag: 'friction:wrong-channel', count: 2 });
     expect(r.top_friction_tags[1]).toEqual({ tag: 'friction:wrong-tone', count: 1 });
     expect(r.source_present).toBe(true);
+  });
+
+  it('uses "unknown" as the breakdown key when integration or kind is missing', () => {
+    writeFileSync(
+      logPath,
+      `${JSON.stringify({ ts: '2026-05-20T09:00:00Z', walk_id: 'a', outcome: 'approved-as-proposed' })}\n`,
+    );
+    const r = buildCalibrationResponse({
+      logPath,
+      sinceMs: Date.UTC(2026, 4, 20, 0, 0, 0),
+      nowMs: FIXED_NOW,
+    });
+    expect(r.by_integration).toEqual([{ key: 'unknown', accept: 1, edit: 0, reject: 0 }]);
+    expect(r.by_kind).toEqual([{ key: 'unknown', accept: 1, edit: 0, reject: 0 }]);
+  });
+
+  it('zero-fills days between events', () => {
+    const lines = [
+      JSON.stringify({ ts: '2026-05-19T09:00:00Z', walk_id: 'a', outcome: 'approved-as-proposed' }),
+      JSON.stringify({ ts: '2026-05-21T09:00:00Z', walk_id: 'b', outcome: 'rejected' }),
+    ];
+    writeFileSync(logPath, `${lines.join('\n')}\n`);
+    const r = buildCalibrationResponse({
+      logPath,
+      sinceMs: Date.UTC(2026, 4, 19, 0, 0, 0),
+      nowMs: FIXED_NOW,
+    });
+    expect(r.daily.length).toBe(3);
+    expect(r.daily[0]?.day).toBe('2026-05-19');
+    expect(r.daily[0]?.approved).toBe(1);
+    expect(r.daily[1]?.day).toBe('2026-05-20');
+    expect(r.daily[1]?.total).toBe(0);
+    expect(r.daily[2]?.day).toBe('2026-05-21');
+    expect(r.daily[2]?.rejected).toBe(1);
   });
 
   it('filters lines older than the since cutoff', () => {
@@ -89,7 +166,11 @@ describe('buildCalibrationResponse', () => {
       logPath,
       'not json\n' + JSON.stringify({ ts: '2026-05-20T09:00:00Z', walk_id: 'a', outcome: 'noted' }) + '\n',
     );
-    const r = buildCalibrationResponse({ logPath, nowMs: FIXED_NOW });
+    const r = buildCalibrationResponse({
+      logPath,
+      sinceMs: Date.UTC(2026, 4, 20, 0, 0, 0),
+      nowMs: FIXED_NOW,
+    });
     expect(r.total_items).toBe(1);
   });
 });
@@ -99,5 +180,47 @@ describe('defaultCalibrationLogPath', () => {
     expect(defaultCalibrationLogPath({ cwd: '/tmp/repo' })).toBe(
       '/tmp/repo/.claude/personal/state/lock-in-feedback.jsonl',
     );
+  });
+});
+
+describe('resolveCalibrationLogPath', () => {
+  it('prefers an explicit feedbackLogPath argument over env and cwd', () => {
+    expect(
+      resolveCalibrationLogPath({
+        feedbackLogPath: '/explicit/path.jsonl',
+        env: { SLOPWEAVER_FEEDBACK_LOG: '/env/path.jsonl' },
+        cwd: '/tmp/repo',
+      }),
+    ).toBe('/explicit/path.jsonl');
+  });
+
+  it('falls back to SLOPWEAVER_FEEDBACK_LOG when no explicit path is given', () => {
+    expect(
+      resolveCalibrationLogPath({
+        feedbackLogPath: undefined,
+        env: { SLOPWEAVER_FEEDBACK_LOG: '/env/path.jsonl' },
+        cwd: '/tmp/repo',
+      }),
+    ).toBe('/env/path.jsonl');
+  });
+
+  it('falls back to the cwd-relative default when neither is set', () => {
+    expect(
+      resolveCalibrationLogPath({
+        feedbackLogPath: undefined,
+        env: {},
+        cwd: '/tmp/repo',
+      }),
+    ).toBe('/tmp/repo/.claude/personal/state/lock-in-feedback.jsonl');
+  });
+
+  it('treats an empty-string env var as unset', () => {
+    expect(
+      resolveCalibrationLogPath({
+        feedbackLogPath: undefined,
+        env: { SLOPWEAVER_FEEDBACK_LOG: '' },
+        cwd: '/tmp/repo',
+      }),
+    ).toBe('/tmp/repo/.claude/personal/state/lock-in-feedback.jsonl');
   });
 });

--- a/packages/ui/src/server/calibration.test.ts
+++ b/packages/ui/src/server/calibration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for `buildCalibrationResponse`. Uses a real temp dir + a
+ * crafted JSONL file so we exercise the file-read path.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildCalibrationResponse, defaultCalibrationLogPath } from './calibration.ts';
+
+const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
+
+describe('buildCalibrationResponse', () => {
+  let tempDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'slop-calibration-'));
+    logPath = join(tempDir, 'log.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns an all-zeros response with source_present=false when the file is missing', () => {
+    const r = buildCalibrationResponse({ logPath, nowMs: FIXED_NOW });
+    expect(r.total_walks).toBe(0);
+    expect(r.total_items).toBe(0);
+    expect(r.acceptance_rate).toBe(0);
+    expect(r.daily).toEqual([]);
+    expect(r.source_present).toBe(false);
+  });
+
+  it('summarizes outcomes + friction tags from a real log', () => {
+    const lines = [
+      JSON.stringify({
+        ts: '2026-05-20T09:00:00Z',
+        walk_id: 'a',
+        outcome: 'approved-as-proposed',
+        tags: ['friction:wrong-channel'],
+      }),
+      JSON.stringify({
+        ts: '2026-05-20T09:01:00Z',
+        walk_id: 'a',
+        outcome: 'edited',
+        tags: ['friction:wrong-channel', 'friction:wrong-tone'],
+      }),
+      JSON.stringify({ ts: '2026-05-21T08:00:00Z', walk_id: 'b', outcome: 'rejected' }),
+      JSON.stringify({ ts: '2026-05-21T08:30:00Z', walk_id: 'b', outcome: 'walk-summary' }),
+    ];
+    writeFileSync(logPath, `${lines.join('\n')}\n`);
+
+    const r = buildCalibrationResponse({ logPath, nowMs: FIXED_NOW });
+    expect(r.total_walks).toBe(2);
+    expect(r.total_items).toBe(3);
+    expect(r.acceptance_rate).toBeCloseTo(1 / 3, 5);
+    expect(r.edit_rate).toBeCloseTo(1 / 3, 5);
+    expect(r.rejection_rate).toBeCloseTo(1 / 3, 5);
+    expect(r.daily.length).toBe(2);
+    expect(r.daily[0]?.day).toBe('2026-05-20');
+    expect(r.daily[0]?.approved).toBe(1);
+    expect(r.daily[0]?.edited).toBe(1);
+    expect(r.daily[1]?.day).toBe('2026-05-21');
+    expect(r.daily[1]?.rejected).toBe(1);
+    expect(r.top_friction_tags[0]).toEqual({ tag: 'friction:wrong-channel', count: 2 });
+    expect(r.top_friction_tags[1]).toEqual({ tag: 'friction:wrong-tone', count: 1 });
+    expect(r.source_present).toBe(true);
+  });
+
+  it('filters lines older than the since cutoff', () => {
+    const lines = [
+      JSON.stringify({ ts: '2024-01-01T00:00:00Z', walk_id: 'old', outcome: 'approved-as-proposed' }),
+      JSON.stringify({ ts: '2026-05-20T09:00:00Z', walk_id: 'new', outcome: 'approved-as-proposed' }),
+    ];
+    writeFileSync(logPath, `${lines.join('\n')}\n`);
+    const r = buildCalibrationResponse({
+      logPath,
+      sinceMs: Date.UTC(2026, 0, 1),
+      nowMs: FIXED_NOW,
+    });
+    expect(r.total_walks).toBe(1);
+    expect(r.total_items).toBe(1);
+  });
+
+  it('survives malformed JSON lines', () => {
+    writeFileSync(
+      logPath,
+      'not json\n' + JSON.stringify({ ts: '2026-05-20T09:00:00Z', walk_id: 'a', outcome: 'noted' }) + '\n',
+    );
+    const r = buildCalibrationResponse({ logPath, nowMs: FIXED_NOW });
+    expect(r.total_items).toBe(1);
+  });
+});
+
+describe('defaultCalibrationLogPath', () => {
+  it('joins the cwd with the documented relative path', () => {
+    expect(defaultCalibrationLogPath({ cwd: '/tmp/repo' })).toBe(
+      '/tmp/repo/.claude/personal/state/lock-in-feedback.jsonl',
+    );
+  });
+});

--- a/packages/ui/src/server/calibration.ts
+++ b/packages/ui/src/server/calibration.ts
@@ -1,0 +1,201 @@
+/**
+ * `/api/calibration` response builder. Reads the walk-feedback JSONL
+ * log written by `log_walk_feedback` (PR #54) at
+ * `<data-dir>/.claude/personal/state/lock-in-feedback.jsonl` — or
+ * wherever the SLOPWEAVER_FEEDBACK_LOG env var points — and aggregates
+ * a calibration report consumable by the dashboard's chart tab.
+ *
+ * Missing log → all-zeros response, no error. That's the right
+ * default for users who haven't run a /lock-in walk yet.
+ *
+ * Pure-ish: file IO + JSON parsing. Returns a Result-shaped response
+ * via try/catch (the UI server uses throwing semantics — same pattern
+ * as the existing diagnostics endpoint).
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DEFAULT_RELATIVE_PATH = '.claude/personal/state/lock-in-feedback.jsonl';
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type CalibrationPoint = {
+  /** ISO day, e.g. "2026-05-21". */
+  day: string;
+  approved: number;
+  edited: number;
+  rejected: number;
+  deferred: number;
+  dropped: number;
+  noted: number;
+};
+
+export type FrictionTagTally = {
+  tag: string;
+  count: number;
+};
+
+export type CalibrationResponse = {
+  window_start: string;
+  window_end: string;
+  total_walks: number;
+  total_items: number;
+  acceptance_rate: number;
+  edit_rate: number;
+  rejection_rate: number;
+  /** One bucket per day in the window. Empty days fill with zeros. */
+  daily: ReadonlyArray<CalibrationPoint>;
+  /** Top 10 friction tags by count. */
+  top_friction_tags: ReadonlyArray<FrictionTagTally>;
+  /** Effective JSONL path the response was built from. */
+  source_path: string;
+  /** True when the log was readable; false when missing (response is all-zeros). */
+  source_present: boolean;
+  generated_at: string;
+};
+
+export type BuildCalibrationArgs = {
+  /** Absolute path to the JSONL log. Required (the UI server resolves this against the data dir). */
+  logPath: string;
+  /** Window cutoff. Defaults to 30 days back from `now`. */
+  sinceMs?: number;
+  /** Clock injection (tests). */
+  nowMs?: number;
+};
+
+export function buildCalibrationResponse(args: BuildCalibrationArgs): CalibrationResponse {
+  const nowMs = args.nowMs ?? Date.now();
+  const sinceMs = args.sinceMs ?? nowMs - THIRTY_DAYS_MS;
+
+  let content: string | null;
+  try {
+    content = readFileSync(args.logPath, 'utf-8');
+  } catch {
+    content = null;
+  }
+
+  if (content === null) {
+    return emptyResponse({ logPath: args.logPath, sinceMs, nowMs, sourcePresent: false });
+  }
+
+  // Map JSONL outcome strings → the numeric-tile name. The
+  // `approved-as-proposed` outcome maps to the `approved` tile; the
+  // other five outcomes share names with their tiles. `walk-summary`
+  // is intentionally absent — those lines contribute to `walks` but
+  // not to per-item counts.
+  const OUTCOME_TO_TILE: Record<string, 'approved' | 'edited' | 'rejected' | 'deferred' | 'dropped' | 'noted'> = {
+    'approved-as-proposed': 'approved',
+    edited: 'edited',
+    rejected: 'rejected',
+    deferred: 'deferred',
+    dropped: 'dropped',
+    noted: 'noted',
+  };
+  const counts = { approved: 0, edited: 0, rejected: 0, deferred: 0, dropped: 0, noted: 0 };
+  const walks = new Set<string>();
+  const tags = new Map<string, number>();
+  const daily = new Map<string, CalibrationPoint>();
+
+  for (const raw of content.split('\n')) {
+    if (raw.trim().length === 0) continue;
+    let parsed: Record<string, unknown>;
+    try {
+      const value = JSON.parse(raw) as unknown;
+      if (typeof value !== 'object' || value === null) continue;
+      parsed = value as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const ts = parsed['ts'];
+    const walkId = parsed['walk_id'];
+    const outcome = parsed['outcome'];
+    if (typeof ts !== 'string' || typeof walkId !== 'string' || typeof outcome !== 'string') continue;
+    const lineMs = Date.parse(ts);
+    if (!Number.isFinite(lineMs) || lineMs < sinceMs) continue;
+
+    walks.add(walkId);
+    const tile = OUTCOME_TO_TILE[outcome];
+    if (tile !== undefined) {
+      counts[tile] += 1;
+      const day = ts.slice(0, 10); // YYYY-MM-DD
+      bumpDaily({ daily, day, tile });
+    }
+    if (Array.isArray(parsed['tags'])) {
+      for (const tag of parsed['tags']) {
+        if (typeof tag === 'string' && tag.startsWith('friction:')) {
+          tags.set(tag, (tags.get(tag) ?? 0) + 1);
+        }
+      }
+    }
+  }
+
+  const totalItems = Object.values(counts).reduce((a, b) => a + b, 0);
+  const rate = (n: number): number => (totalItems === 0 ? 0 : n / totalItems);
+
+  return {
+    window_start: new Date(sinceMs).toISOString(),
+    window_end: new Date(nowMs).toISOString(),
+    total_walks: walks.size,
+    total_items: totalItems,
+    acceptance_rate: rate(counts.approved),
+    edit_rate: rate(counts.edited),
+    rejection_rate: rate(counts.rejected),
+    daily: [...daily.values()].sort((a, b) => a.day.localeCompare(b.day)),
+    top_friction_tags: [...tags.entries()]
+      .map(([tag, count]) => ({ tag, count }))
+      .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+      .slice(0, 10),
+    source_path: args.logPath,
+    source_present: true,
+    generated_at: new Date(nowMs).toISOString(),
+  };
+}
+
+function bumpDaily({
+  daily,
+  day,
+  tile,
+}: {
+  daily: Map<string, CalibrationPoint>;
+  day: string;
+  tile: 'approved' | 'edited' | 'rejected' | 'deferred' | 'dropped' | 'noted';
+}): void {
+  let point = daily.get(day);
+  if (point === undefined) {
+    point = { day, approved: 0, edited: 0, rejected: 0, deferred: 0, dropped: 0, noted: 0 };
+    daily.set(day, point);
+  }
+  point[tile] += 1;
+}
+
+function emptyResponse(args: {
+  logPath: string;
+  sinceMs: number;
+  nowMs: number;
+  sourcePresent: boolean;
+}): CalibrationResponse {
+  return {
+    window_start: new Date(args.sinceMs).toISOString(),
+    window_end: new Date(args.nowMs).toISOString(),
+    total_walks: 0,
+    total_items: 0,
+    acceptance_rate: 0,
+    edit_rate: 0,
+    rejection_rate: 0,
+    daily: [],
+    top_friction_tags: [],
+    source_path: args.logPath,
+    source_present: args.sourcePresent,
+    generated_at: new Date(args.nowMs).toISOString(),
+  };
+}
+
+/**
+ * Convenience: build the canonical log path from a working directory.
+ * Mirrors where `log_walk_feedback` (PR #54) writes by default. Used
+ * by the UI server when starting up — it has access to `cwd` because
+ * the MCP server launches it in-process.
+ */
+export function defaultCalibrationLogPath({ cwd }: { cwd: string }): string {
+  return join(cwd, DEFAULT_RELATIVE_PATH);
+}

--- a/packages/ui/src/server/calibration.ts
+++ b/packages/ui/src/server/calibration.ts
@@ -18,9 +18,10 @@ import { join } from 'node:path';
 
 const DEFAULT_RELATIVE_PATH = '.claude/personal/state/lock-in-feedback.jsonl';
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 export type CalibrationPoint = {
-  /** ISO day, e.g. "2026-05-21". */
+  /** ISO day (UTC), e.g. "2026-05-21". */
   day: string;
   approved: number;
   edited: number;
@@ -28,11 +29,30 @@ export type CalibrationPoint = {
   deferred: number;
   dropped: number;
   noted: number;
+  /** Total of all outcomes on the day (sum of the six counts above). */
+  total: number;
+  /** Ratio of approved over `total`, or 0 when `total === 0`. */
+  accept_ratio: number;
+  /** Ratio of edited over `total`, or 0 when `total === 0`. */
+  edit_ratio: number;
+  /** Ratio of rejected over `total`, or 0 when `total === 0`. */
+  reject_ratio: number;
 };
 
 export type FrictionTagTally = {
   tag: string;
   count: number;
+};
+
+export type CalibrationBreakdown = {
+  /** Either the integration slug (e.g. `"github"`) or the kind (e.g. `"review_request"`). Falls back to `"unknown"` when the line lacks the field. */
+  key: string;
+  /** Count of `approved-as-proposed` outcomes. */
+  accept: number;
+  /** Count of `edited` outcomes. */
+  edit: number;
+  /** Count of `rejected` outcomes. */
+  reject: number;
 };
 
 export type CalibrationResponse = {
@@ -43,14 +63,23 @@ export type CalibrationResponse = {
   acceptance_rate: number;
   edit_rate: number;
   rejection_rate: number;
-  /** One bucket per day in the window. Empty days fill with zeros. */
+  /**
+   * One bucket per day in the window, zero-filled. Spans `window_start`
+   * → `window_end` on a UTC-day basis, ascending.
+   */
   daily: ReadonlyArray<CalibrationPoint>;
+  /** Per-integration accept/edit/reject counts. */
+  by_integration: ReadonlyArray<CalibrationBreakdown>;
+  /** Per-kind accept/edit/reject counts (`kind` field on the feedback line). */
+  by_kind: ReadonlyArray<CalibrationBreakdown>;
   /** Top 10 friction tags by count. */
   top_friction_tags: ReadonlyArray<FrictionTagTally>;
   /** Effective JSONL path the response was built from. */
   source_path: string;
   /** True when the log was readable; false when missing (response is all-zeros). */
   source_present: boolean;
+  /** True when the response carries no walks/items — useful for the empty-state UI. */
+  empty: boolean;
   generated_at: string;
 };
 
@@ -66,6 +95,7 @@ export type BuildCalibrationArgs = {
 export function buildCalibrationResponse(args: BuildCalibrationArgs): CalibrationResponse {
   const nowMs = args.nowMs ?? Date.now();
   const sinceMs = args.sinceMs ?? nowMs - THIRTY_DAYS_MS;
+  const dailySkeleton = buildDailySkeleton({ sinceMs, nowMs });
 
   let content: string | null;
   try {
@@ -75,7 +105,13 @@ export function buildCalibrationResponse(args: BuildCalibrationArgs): Calibratio
   }
 
   if (content === null) {
-    return emptyResponse({ logPath: args.logPath, sinceMs, nowMs, sourcePresent: false });
+    return emptyResponse({
+      logPath: args.logPath,
+      sinceMs,
+      nowMs,
+      sourcePresent: false,
+      dailySkeleton,
+    });
   }
 
   // Map JSONL outcome strings → the numeric-tile name. The
@@ -94,7 +130,9 @@ export function buildCalibrationResponse(args: BuildCalibrationArgs): Calibratio
   const counts = { approved: 0, edited: 0, rejected: 0, deferred: 0, dropped: 0, noted: 0 };
   const walks = new Set<string>();
   const tags = new Map<string, number>();
-  const daily = new Map<string, CalibrationPoint>();
+  const daily = new Map<string, CalibrationPoint>(dailySkeleton.map((p) => [p.day, p]));
+  const byIntegration = new Map<string, CalibrationBreakdown>();
+  const byKind = new Map<string, CalibrationBreakdown>();
 
   for (const raw of content.split('\n')) {
     if (raw.trim().length === 0) continue;
@@ -111,14 +149,25 @@ export function buildCalibrationResponse(args: BuildCalibrationArgs): Calibratio
     const outcome = parsed['outcome'];
     if (typeof ts !== 'string' || typeof walkId !== 'string' || typeof outcome !== 'string') continue;
     const lineMs = Date.parse(ts);
-    if (!Number.isFinite(lineMs) || lineMs < sinceMs) continue;
+    if (!Number.isFinite(lineMs) || lineMs < sinceMs || lineMs > nowMs) continue;
 
     walks.add(walkId);
     const tile = OUTCOME_TO_TILE[outcome];
     if (tile !== undefined) {
       counts[tile] += 1;
-      const day = ts.slice(0, 10); // YYYY-MM-DD
+      const day = toUtcDay({ ms: lineMs });
       bumpDaily({ daily, day, tile });
+
+      // Only the three "headline" outcomes feed the breakdown tables —
+      // matches the breakdown contract (accept/edit/reject).
+      const breakdownTile: 'accept' | 'edit' | 'reject' | null =
+        tile === 'approved' ? 'accept' : tile === 'edited' ? 'edit' : tile === 'rejected' ? 'reject' : null;
+      if (breakdownTile !== null) {
+        const integrationKey = typeof parsed['integration'] === 'string' ? parsed['integration'] : 'unknown';
+        const kindKey = typeof parsed['kind'] === 'string' ? parsed['kind'] : 'unknown';
+        bumpBreakdown({ map: byIntegration, key: integrationKey, tile: breakdownTile });
+        bumpBreakdown({ map: byKind, key: kindKey, tile: breakdownTile });
+      }
     }
     if (Array.isArray(parsed['tags'])) {
       for (const tag of parsed['tags']) {
@@ -140,15 +189,63 @@ export function buildCalibrationResponse(args: BuildCalibrationArgs): Calibratio
     acceptance_rate: rate(counts.approved),
     edit_rate: rate(counts.edited),
     rejection_rate: rate(counts.rejected),
-    daily: [...daily.values()].sort((a, b) => a.day.localeCompare(b.day)),
+    daily: dailySkeleton.map((p) => finalizeDailyPoint({ point: daily.get(p.day) ?? p })),
+    by_integration: sortBreakdown({ map: byIntegration }),
+    by_kind: sortBreakdown({ map: byKind }),
     top_friction_tags: [...tags.entries()]
       .map(([tag, count]) => ({ tag, count }))
       .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
       .slice(0, 10),
     source_path: args.logPath,
     source_present: true,
+    empty: totalItems === 0 && walks.size === 0,
     generated_at: new Date(nowMs).toISOString(),
   };
+}
+
+/**
+ * Build a contiguous, zero-filled array of `CalibrationPoint`s spanning
+ * `sinceMs` → `nowMs` on a UTC-day basis (inclusive on both ends). Used
+ * as the daily skeleton so empty days render as gaps rather than holes.
+ */
+function buildDailySkeleton({ sinceMs, nowMs }: { sinceMs: number; nowMs: number }): CalibrationPoint[] {
+  const points: CalibrationPoint[] = [];
+  // Anchor both endpoints to UTC midnight so daylight-savings shifts on
+  // the host clock don't shorten/lengthen the series.
+  const startMs = utcMidnight({ ms: Math.min(sinceMs, nowMs) });
+  const endMs = utcMidnight({ ms: Math.max(sinceMs, nowMs) });
+  for (let dayMs = startMs; dayMs <= endMs; dayMs += ONE_DAY_MS) {
+    points.push({
+      day: toUtcDay({ ms: dayMs }),
+      approved: 0,
+      edited: 0,
+      rejected: 0,
+      deferred: 0,
+      dropped: 0,
+      noted: 0,
+      total: 0,
+      accept_ratio: 0,
+      edit_ratio: 0,
+      reject_ratio: 0,
+    });
+  }
+  return points;
+}
+
+function utcMidnight({ ms }: { ms: number }): number {
+  const d = new Date(ms);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+function toUtcDay({ ms }: { ms: number }): string {
+  // ISO 8601 'YYYY-MM-DD' from a Date's UTC fields — robust against
+  // host-local DST flips (which `ts.slice(0,10)` would otherwise inherit
+  // if a producer ever writes a non-`Z` offset).
+  const d = new Date(ms);
+  const y = d.getUTCFullYear().toString().padStart(4, '0');
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = d.getUTCDate().toString().padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 function bumpDaily({
@@ -162,10 +259,62 @@ function bumpDaily({
 }): void {
   let point = daily.get(day);
   if (point === undefined) {
-    point = { day, approved: 0, edited: 0, rejected: 0, deferred: 0, dropped: 0, noted: 0 };
+    // An event whose UTC day falls outside the skeleton can't happen in
+    // practice (we already filtered by sinceMs/nowMs upstream), but be
+    // defensive — drop a fresh bucket in.
+    point = {
+      day,
+      approved: 0,
+      edited: 0,
+      rejected: 0,
+      deferred: 0,
+      dropped: 0,
+      noted: 0,
+      total: 0,
+      accept_ratio: 0,
+      edit_ratio: 0,
+      reject_ratio: 0,
+    };
     daily.set(day, point);
   }
   point[tile] += 1;
+}
+
+function finalizeDailyPoint({ point }: { point: CalibrationPoint }): CalibrationPoint {
+  const total = point.approved + point.edited + point.rejected + point.deferred + point.dropped + point.noted;
+  const ratio = (n: number): number => (total === 0 ? 0 : n / total);
+  return {
+    ...point,
+    total,
+    accept_ratio: ratio(point.approved),
+    edit_ratio: ratio(point.edited),
+    reject_ratio: ratio(point.rejected),
+  };
+}
+
+function bumpBreakdown({
+  map,
+  key,
+  tile,
+}: {
+  map: Map<string, CalibrationBreakdown>;
+  key: string;
+  tile: 'accept' | 'edit' | 'reject';
+}): void {
+  let row = map.get(key);
+  if (row === undefined) {
+    row = { key, accept: 0, edit: 0, reject: 0 };
+    map.set(key, row);
+  }
+  row[tile] += 1;
+}
+
+function sortBreakdown({ map }: { map: Map<string, CalibrationBreakdown> }): CalibrationBreakdown[] {
+  return [...map.values()].sort((a, b) => {
+    const aTotal = a.accept + a.edit + a.reject;
+    const bTotal = b.accept + b.edit + b.reject;
+    return bTotal - aTotal || a.key.localeCompare(b.key);
+  });
 }
 
 function emptyResponse(args: {
@@ -173,6 +322,7 @@ function emptyResponse(args: {
   sinceMs: number;
   nowMs: number;
   sourcePresent: boolean;
+  dailySkeleton: ReadonlyArray<CalibrationPoint>;
 }): CalibrationResponse {
   return {
     window_start: new Date(args.sinceMs).toISOString(),
@@ -182,10 +332,13 @@ function emptyResponse(args: {
     acceptance_rate: 0,
     edit_rate: 0,
     rejection_rate: 0,
-    daily: [],
+    daily: args.dailySkeleton,
+    by_integration: [],
+    by_kind: [],
     top_friction_tags: [],
     source_path: args.logPath,
     source_present: args.sourcePresent,
+    empty: true,
     generated_at: new Date(args.nowMs).toISOString(),
   };
 }
@@ -198,4 +351,26 @@ function emptyResponse(args: {
  */
 export function defaultCalibrationLogPath({ cwd }: { cwd: string }): string {
   return join(cwd, DEFAULT_RELATIVE_PATH);
+}
+
+/**
+ * Resolve the effective JSONL log path for the UI server. The
+ * `SLOPWEAVER_FEEDBACK_LOG` env var, when set, takes precedence over the
+ * default-from-cwd location. Both an explicit `feedbackLogPath` override
+ * (e.g. from a CLI flag) and the env var are checked; the override wins
+ * when supplied.
+ */
+export function resolveCalibrationLogPath({
+  feedbackLogPath,
+  env,
+  cwd,
+}: {
+  feedbackLogPath: string | undefined;
+  env: NodeJS.ProcessEnv;
+  cwd: string;
+}): string {
+  if (feedbackLogPath !== undefined && feedbackLogPath.length > 0) return feedbackLogPath;
+  const fromEnv = env['SLOPWEAVER_FEEDBACK_LOG'];
+  if (typeof fromEnv === 'string' && fromEnv.length > 0) return fromEnv;
+  return defaultCalibrationLogPath({ cwd });
 }

--- a/packages/ui/src/server/start.test.ts
+++ b/packages/ui/src/server/start.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createDb } from '@slopweaver/db';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { CalibrationResponse } from './calibration.ts';
 import type { StaticEnvChecks } from './checks.ts';
 import { startUiServer, type UiServerHandle } from './start.ts';
 import type { DiagnosticsResponse } from './types.ts';
@@ -33,7 +34,7 @@ describe('startUiServer', () => {
     dbHandle.close();
   });
 
-  async function start(): Promise<UiServerHandle> {
+  async function start(opts: { feedbackLogPath?: string } = {}): Promise<UiServerHandle> {
     handle = await startUiServer({
       db: dbHandle.db,
       dataDir: '/tmp/never-used-because-staticChecks-is-injected',
@@ -41,6 +42,7 @@ describe('startUiServer', () => {
       port: 0,
       clientAssetsDir: tempAssets,
       staticChecks: STATIC_CHECKS,
+      ...(opts.feedbackLogPath !== undefined ? { feedbackLogPath: opts.feedbackLogPath } : {}),
     });
     return handle;
   }
@@ -156,5 +158,66 @@ describe('startUiServer', () => {
     const res = await fetch(`${h.url}/api/diagnostics`);
     const body = (await res.json()) as DiagnosticsResponse;
     expect(body.server.port).toBe(h.address.port);
+  });
+
+  it('responds to GET /api/calibration with an empty body when the log is missing', async () => {
+    // Point at a path inside tempAssets that does not exist. The endpoint
+    // must respond 200 with `source_present: false` rather than throwing.
+    const missingLogPath = join(tempAssets, 'missing-log.jsonl');
+    const h = await start({ feedbackLogPath: missingLogPath });
+    const res = await fetch(`${h.url}/api/calibration`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = (await res.json()) as CalibrationResponse;
+    expect(body.source_present).toBe(false);
+    expect(body.empty).toBe(true);
+    expect(body.total_walks).toBe(0);
+    expect(body.source_path).toBe(missingLogPath);
+  });
+
+  it('responds to GET /api/calibration with aggregated data when the log exists', async () => {
+    const logPath = join(tempAssets, 'feedback.jsonl');
+    const lines = [
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        walk_id: 'w1',
+        outcome: 'approved-as-proposed',
+        integration: 'github',
+        kind: 'review_request',
+      }),
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        walk_id: 'w1',
+        outcome: 'edited',
+        integration: 'slack',
+        kind: 'mention',
+      }),
+    ];
+    writeFileSync(logPath, `${lines.join('\n')}\n`);
+
+    const h = await start({ feedbackLogPath: logPath });
+    const res = await fetch(`${h.url}/api/calibration`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as CalibrationResponse;
+    expect(body.source_present).toBe(true);
+    expect(body.empty).toBe(false);
+    expect(body.total_items).toBe(2);
+    expect(body.by_integration.map((r) => r.key).sort()).toEqual(['github', 'slack']);
+    expect(body.by_kind.map((r) => r.key).sort()).toEqual(['mention', 'review_request']);
+  });
+
+  it('rejects /api/calibration with a foreign Origin', async () => {
+    const h = await start();
+    const res = await fetch(`${h.url}/api/calibration`, {
+      headers: { origin: 'http://evil.example' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 405 for POST /api/calibration', async () => {
+    const h = await start();
+    const res = await fetch(`${h.url}/api/calibration`, { method: 'POST' });
+    expect(res.status).toBe(405);
+    expect(res.headers.get('allow')).toBe('GET, HEAD');
   });
 });

--- a/packages/ui/src/server/start.ts
+++ b/packages/ui/src/server/start.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { extname, isAbsolute, join, relative, resolve } from 'node:path';
 import type { SlopweaverDatabase } from '@slopweaver/db';
 import { runStaticEnvChecks, type StaticEnvChecks } from './checks.ts';
+import { buildCalibrationResponse, defaultCalibrationLogPath } from './calibration.ts';
 import { buildDiagnosticsResponse } from './diagnostics.ts';
 import { CLIENT_ASSETS_DIR } from './static-dir.ts';
 
@@ -194,6 +195,16 @@ function handleApi({
   }
   if (pathname === '/api/diagnostics') {
     const body = JSON.stringify(buildDiagnosticsResponse({ db, staticChecks, bindAddress }));
+    res.writeHead(200, {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+    });
+    res.end(method === 'HEAD' ? undefined : body);
+    return;
+  }
+  if (pathname === '/api/calibration') {
+    const logPath = defaultCalibrationLogPath({ cwd: process.cwd() });
+    const body = JSON.stringify(buildCalibrationResponse({ logPath }));
     res.writeHead(200, {
       'content-type': 'application/json; charset=utf-8',
       'cache-control': 'no-store',

--- a/packages/ui/src/server/start.ts
+++ b/packages/ui/src/server/start.ts
@@ -3,7 +3,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { extname, isAbsolute, join, relative, resolve } from 'node:path';
 import type { SlopweaverDatabase } from '@slopweaver/db';
 import { runStaticEnvChecks, type StaticEnvChecks } from './checks.ts';
-import { buildCalibrationResponse, defaultCalibrationLogPath } from './calibration.ts';
+import { buildCalibrationResponse, resolveCalibrationLogPath } from './calibration.ts';
 import { buildDiagnosticsResponse } from './diagnostics.ts';
 import { CLIENT_ASSETS_DIR } from './static-dir.ts';
 
@@ -17,6 +17,12 @@ export type StartUiServerOptions = {
   clientAssetsDir?: string;
   /** Override env checks (tests). */
   staticChecks?: StaticEnvChecks;
+  /**
+   * Explicit walk-feedback JSONL path. Takes precedence over
+   * `SLOPWEAVER_FEEDBACK_LOG` and the cwd-relative default. Mainly
+   * useful for tests; production callers can rely on the env var.
+   */
+  feedbackLogPath?: string;
 };
 
 export type UiServerHandle = {
@@ -84,13 +90,23 @@ export async function startUiServer(opts: StartUiServerOptions): Promise<UiServe
   const requestedPort = opts.port ?? DEFAULT_PORT;
   const clientAssetsDir = resolve(opts.clientAssetsDir ?? CLIENT_ASSETS_DIR);
   const staticChecks = opts.staticChecks ?? runStaticEnvChecks({ dataDir: opts.dataDir });
+  // Resolved once at startup so a later env-var change doesn't surprise
+  // a running server. Env-var override beats the cwd default; an
+  // explicit `feedbackLogPath` beats both.
+  const feedbackLogPath = resolveCalibrationLogPath({
+    feedbackLogPath: opts.feedbackLogPath,
+    env: process.env,
+    cwd: process.cwd(),
+  });
 
   // The bound port is only known after listen() resolves. Hold a mutable ref
   // and capture it by closure so the response can report the actual address
   // when callers pass `port: 0` (tests).
   const bindAddress = { host: requestedHost, port: requestedPort };
 
-  const server = createServer(createHandler({ db: opts.db, staticChecks, clientAssetsDir, bindAddress }));
+  const server = createServer(
+    createHandler({ db: opts.db, staticChecks, clientAssetsDir, bindAddress, feedbackLogPath }),
+  );
 
   await listen({ server, port: requestedPort, host: requestedHost });
 
@@ -134,6 +150,7 @@ type HandlerArgs = {
   staticChecks: StaticEnvChecks;
   clientAssetsDir: string;
   bindAddress: { host: string; port: number };
+  feedbackLogPath: string;
 };
 
 function createHandler({
@@ -141,6 +158,7 @@ function createHandler({
   staticChecks,
   clientAssetsDir,
   bindAddress,
+  feedbackLogPath,
 }: HandlerArgs): (req: IncomingMessage, res: ServerResponse) => void {
   return (req, res) => {
     const method = req.method ?? 'GET';
@@ -154,7 +172,7 @@ function createHandler({
     }
 
     if (pathname.startsWith('/api/')) {
-      handleApi({ req, res, method, pathname, db, staticChecks, bindAddress });
+      handleApi({ req, res, method, pathname, db, staticChecks, bindAddress, feedbackLogPath });
       return;
     }
 
@@ -175,6 +193,7 @@ function handleApi({
   db,
   staticChecks,
   bindAddress,
+  feedbackLogPath,
 }: {
   req: IncomingMessage;
   res: ServerResponse;
@@ -183,6 +202,7 @@ function handleApi({
   db: SlopweaverDatabase;
   staticChecks: StaticEnvChecks;
   bindAddress: { host: string; port: number };
+  feedbackLogPath: string;
 }): void {
   if (method !== 'GET' && method !== 'HEAD') {
     res.writeHead(405, { 'content-type': 'text/plain', allow: 'GET, HEAD' });
@@ -203,8 +223,7 @@ function handleApi({
     return;
   }
   if (pathname === '/api/calibration') {
-    const logPath = defaultCalibrationLogPath({ cwd: process.cwd() });
-    const body = JSON.stringify(buildCalibrationResponse({ logPath }));
+    const body = JSON.stringify(buildCalibrationResponse({ logPath: feedbackLogPath }));
     res.writeHead(200, {
       'content-type': 'application/json; charset=utf-8',
       'cache-control': 'no-store',


### PR DESCRIPTION
**Problem**

There's no way to see whether `start_session` recommendations are actually landing once they're surfaced. Walk-feedback gets written to a JSONL log but nothing reads it back, so calibration drift sits invisible.

**Solution**

Adds a `/api/calibration` endpoint that aggregates the walk-feedback log into acceptance/edit/rejection rates plus daily, by-integration, and by-kind breakdowns. The Diagnostics UI gets a Calibration tab rendering rate tiles, a stacked-bar SVG of the ratio over time, and a top-friction-tag list, with zero chart-library deps.

**Proof this works**

_pending local verification_

**How to test**

1. `pnpm install && pnpm build`
2. Run `slopweaver` against a workspace with a `walk-feedback.jsonl` log, or point `SLOPWEAVER_WALK_FEEDBACK_LOG` at a fixture file
3. Open the Diagnostics UI and click the Calibration tab
4. Confirm the rate tiles, ratio chart, and friction-tag list render
5. Empty-state check: point at a missing log path and confirm the CTA renders instead of NaN tiles
6. `curl http://localhost:60701/api/calibration` and check the response shape matches the `daily` / `by_integration` / `by_kind` / `top_friction_tags` aggregates
7. `pnpm validate`

<details>
<summary>Implementation notes</summary>

Iter-2 fix commit [b6dbba7](https://github.com/slopweaver/slopweaver/commit/b6dbba7) covers the codex review feedback:

- Zero-filled daily skeleton so the chart doesn't gap on days with no walks
- `by_integration` and `by_kind` aggregates added to the response shape
- Stacked-bar ratio chart replacing the raw-count version
- Env-var override (`SLOPWEAVER_WALK_FEEDBACK_LOG`) for the log path so test fixtures and non-default installs work

Expected merge conflict with #73 (PR #61) on `App.tsx` + `App.css` since both add a tab nav. Trivial 5-line resolve.

Closes #63. Spec lives in that issue.

</details>
