### PR TITLE
feat(cli): add slopweaver walk subcommand for the lock-in queue

### DIFF
--- a/apps/mcp-local/README.md
+++ b/apps/mcp-local/README.md
@@ -67,5 +67,7 @@ over stdio.
 
 In: stdio MCP server, `ping` tool, `--version` / `--help` / `--no-web-ui`,
 the local Diagnostics web UI on `127.0.0.1:60701`, the `init` first-run
-wizard, and the `connect <integration>` subcommands. Out: `doctor`. That
-ships in a follow-up issue.
+wizard, the `connect <integration>` subcommands, and the `walk` subcommand
+(read-only: prints the ranked `/lock-in` queue from
+`.claude/personal/state/reconciliation.md`; the interactive TUI verb-loop
+ships in a follow-up PR). Out: `doctor`. That ships in a follow-up issue.

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -448,7 +448,7 @@ cli
   .action(async () => {
     try {
       const { runWalk } = await import('./walk/index.ts');
-      const code = await runWalk({ cwd: processCwd(), stdout });
+      const code = await runWalk({ cwd: processCwd(), stdout, stderr });
       exit(code);
     } catch (error: unknown) {
       stderr.write(`slopweaver: ${asMessage({ error })}\n`);

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -443,6 +443,20 @@ cli
   });
 
 cli
+  .command('walk', 'Print the ranked /lock-in walk queue from the local reconciliation file')
+  .example('  slopweaver walk')
+  .action(async () => {
+    try {
+      const { runWalk } = await import('./walk/index.ts');
+      const code = await runWalk({ cwd: processCwd(), stdout });
+      exit(code);
+    } catch (error: unknown) {
+      stderr.write(`slopweaver: ${asMessage({ error })}\n`);
+      exit(1);
+    }
+  });
+
+cli
   .command('', 'Run the MCP server over stdio (default)')
   .option('--no-web-ui', 'Disable the local Diagnostics web UI on 127.0.0.1:60701')
   .action((options: { webUi: boolean }) => {

--- a/apps/mcp-local/src/walk/index.test.ts
+++ b/apps/mcp-local/src/walk/index.test.ts
@@ -30,7 +30,7 @@ describe('renderWalkQueue', () => {
     );
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) return;
-    const out = renderWalkQueue(result.value);
+    const out = renderWalkQueue(result.value.items);
     expect(out).toContain('Walking 1 item(s)');
     expect(out).toContain('[PR-1]');
     expect(out).toContain('priority-0-LIVE');
@@ -40,9 +40,9 @@ describe('renderWalkQueue', () => {
 
   it('renders exact 1-digit numbering for a queue of ≤9 items', () => {
     const items: WalkItem[] = [
-      makeItem({ id: '3', anchor: 'A', description: 'first' }),
-      makeItem({ id: '4', anchor: 'B', description: 'second' }),
-      makeItem({ id: '5', anchor: 'C', description: 'third' }),
+      makeItem({ id: 'aaaaaaaa', anchor: 'A', description: 'first' }),
+      makeItem({ id: 'bbbbbbbb', anchor: 'B', description: 'second' }),
+      makeItem({ id: 'cccccccc', anchor: 'C', description: 'third' }),
     ];
     const out = renderWalkQueue(items);
     expect(out).toBe(
@@ -67,7 +67,7 @@ describe('renderWalkQueue', () => {
 
   it('renders exact 2-digit padding for a queue of 10+ items', () => {
     const items: WalkItem[] = Array.from({ length: 10 }, (_, i) =>
-      makeItem({ id: String(i + 3), anchor: `A${i + 1}`, description: `item ${i + 1}` }),
+      makeItem({ id: `id${i + 1}`.padStart(8, '0'), anchor: `A${i + 1}`, description: `item ${i + 1}` }),
     );
     const out = renderWalkQueue(items);
     const expected = [
@@ -159,5 +159,40 @@ describe('runWalk', () => {
     expect(code).toBe(1);
     const payload = stdout.write.mock.calls[0]?.[0] ?? '';
     expect(payload).toContain('duplicate');
+  });
+
+  it('forwards parse warnings to stderr while still printing the queue', async () => {
+    const stdout = { write: vi.fn() };
+    const stderr = { write: vi.fn() };
+    const code = await runWalk({
+      cwd: '/tmp/repo',
+      readFile: async () =>
+        ['## Walk order', '', '1. ', '2. **[X](https://x/)** real item', '3. **[Y](https://y/)**'].join('\n'),
+      stdout,
+      stderr,
+    });
+    expect(code).toBe(0);
+    const stdoutPayload = stdout.write.mock.calls[0]?.[0] ?? '';
+    expect(stdoutPayload).toContain('real item');
+    // Two malformed numbered rows (the bare `1.` and the anchor-only
+    // `3. **[Y](https://y/)**`) each produce a warning.
+    expect(stderr.write).toHaveBeenCalledTimes(2);
+    const warnings = stderr.write.mock.calls.map((call) => call[0]);
+    expect(warnings[0]).toContain('line 3');
+    expect(warnings[0]).toContain('no description after stripping metadata');
+    expect(warnings[1]).toContain('line 5');
+  });
+
+  it('does not emit anything to stderr when there are no warnings', async () => {
+    const stdout = { write: vi.fn() };
+    const stderr = { write: vi.fn() };
+    const code = await runWalk({
+      cwd: '/tmp/repo',
+      readFile: async () => '## Walk order\n\n1. **[X](https://x/)** clean item',
+      stdout,
+      stderr,
+    });
+    expect(code).toBe(0);
+    expect(stderr.write).not.toHaveBeenCalled();
   });
 });

--- a/apps/mcp-local/src/walk/index.test.ts
+++ b/apps/mcp-local/src/walk/index.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderWalkQueue, runWalk } from './index.ts';
+import { parseWalkOrder } from './parse-walk-order.ts';
+
+describe('renderWalkQueue', () => {
+  it('renders the empty-queue helper text', () => {
+    const out = renderWalkQueue([]);
+    expect(out).toContain('No items in the walk queue.');
+    expect(out).toContain('/reconcile');
+  });
+
+  it('renders a multi-line numbered list', () => {
+    const items = parseWalkOrder(
+      [
+        '## Walk order',
+        '',
+        '1. **[PR-1](https://x/1)** — `[priority-0-LIVE]` — chase reviewer. *(reconciliation/inbox)*',
+      ].join('\n'),
+    );
+    const out = renderWalkQueue(items);
+    expect(out).toContain('Walking 1 item(s)');
+    expect(out).toContain('[PR-1]');
+    expect(out).toContain('priority-0-LIVE');
+    expect(out).toContain('https://x/1');
+    expect(out).toContain('(reconciliation/inbox)');
+  });
+});
+
+describe('runWalk', () => {
+  it('prints the queue when the reconciliation file exists', async () => {
+    const stdout = { write: vi.fn() };
+    const code = await runWalk({
+      cwd: '/tmp/repo',
+      readFile: async () => '## Walk order\n\n1. test item',
+      stdout,
+    });
+    expect(code).toBe(0);
+    expect(stdout.write).toHaveBeenCalledOnce();
+    const payload = stdout.write.mock.calls[0]?.[0] ?? '';
+    expect(payload).toContain('test item');
+  });
+
+  it('prints the empty-state helper when the file is missing', async () => {
+    const stdout = { write: vi.fn() };
+    const code = await runWalk({
+      cwd: '/tmp/repo',
+      readFile: async () => {
+        const err = new Error('not found') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        throw err;
+      },
+      stdout,
+    });
+    expect(code).toBe(0);
+    const payload = stdout.write.mock.calls[0]?.[0] ?? '';
+    expect(payload).toContain('No items');
+  });
+
+  it('returns non-zero on unexpected read failures', async () => {
+    const stdout = { write: vi.fn() };
+    const code = await runWalk({
+      cwd: '/tmp/repo',
+      readFile: async () => {
+        throw new Error('permission denied');
+      },
+      stdout,
+    });
+    expect(code).toBe(1);
+    const payload = stdout.write.mock.calls[0]?.[0] ?? '';
+    expect(payload).toContain('failed to read');
+  });
+});

--- a/apps/mcp-local/src/walk/index.test.ts
+++ b/apps/mcp-local/src/walk/index.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 import { renderWalkQueue, runWalk } from './index.ts';
-import { parseWalkOrder } from './parse-walk-order.ts';
+import { type WalkItem, parseWalkOrder } from './parse-walk-order.ts';
+
+function makeItem({ id, anchor, description }: { id: string; anchor: string; description: string }): WalkItem {
+  return {
+    id,
+    anchor,
+    anchor_url: `https://example.com/${anchor}`,
+    priority: null,
+    description,
+    source_bucket: null,
+  };
+}
 
 describe('renderWalkQueue', () => {
   it('renders the empty-queue helper text', () => {
@@ -10,19 +21,86 @@ describe('renderWalkQueue', () => {
   });
 
   it('renders a multi-line numbered list', () => {
-    const items = parseWalkOrder(
+    const result = parseWalkOrder(
       [
         '## Walk order',
         '',
         '1. **[PR-1](https://x/1)** — `[priority-0-LIVE]` — chase reviewer. *(reconciliation/inbox)*',
       ].join('\n'),
     );
-    const out = renderWalkQueue(items);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    const out = renderWalkQueue(result.value);
     expect(out).toContain('Walking 1 item(s)');
     expect(out).toContain('[PR-1]');
     expect(out).toContain('priority-0-LIVE');
     expect(out).toContain('https://x/1');
     expect(out).toContain('(reconciliation/inbox)');
+  });
+
+  it('renders exact 1-digit numbering for a queue of ≤9 items', () => {
+    const items: WalkItem[] = [
+      makeItem({ id: '3', anchor: 'A', description: 'first' }),
+      makeItem({ id: '4', anchor: 'B', description: 'second' }),
+      makeItem({ id: '5', anchor: 'C', description: 'third' }),
+    ];
+    const out = renderWalkQueue(items);
+    expect(out).toBe(
+      [
+        'slopweaver walk',
+        '',
+        'Walking 3 item(s). Per-item actions in /lock-in:',
+        '  do | agent | handoff | defer | skip | note | open-question | jump N',
+        '',
+        '(Interactive loop ships in a follow-up PR — for now this is read-only.)',
+        '',
+        '1. [A] first',
+        '    https://example.com/A',
+        '2. [B] second',
+        '    https://example.com/B',
+        '3. [C] third',
+        '    https://example.com/C',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('renders exact 2-digit padding for a queue of 10+ items', () => {
+    const items: WalkItem[] = Array.from({ length: 10 }, (_, i) =>
+      makeItem({ id: String(i + 3), anchor: `A${i + 1}`, description: `item ${i + 1}` }),
+    );
+    const out = renderWalkQueue(items);
+    const expected = [
+      'slopweaver walk',
+      '',
+      'Walking 10 item(s). Per-item actions in /lock-in:',
+      '  do | agent | handoff | defer | skip | note | open-question | jump N',
+      '',
+      '(Interactive loop ships in a follow-up PR — for now this is read-only.)',
+      '',
+      ' 1. [A1] item 1',
+      '    https://example.com/A1',
+      ' 2. [A2] item 2',
+      '    https://example.com/A2',
+      ' 3. [A3] item 3',
+      '    https://example.com/A3',
+      ' 4. [A4] item 4',
+      '    https://example.com/A4',
+      ' 5. [A5] item 5',
+      '    https://example.com/A5',
+      ' 6. [A6] item 6',
+      '    https://example.com/A6',
+      ' 7. [A7] item 7',
+      '    https://example.com/A7',
+      ' 8. [A8] item 8',
+      '    https://example.com/A8',
+      ' 9. [A9] item 9',
+      '    https://example.com/A9',
+      '10. [A10] item 10',
+      '    https://example.com/A10',
+      '',
+    ].join('\n');
+    expect(out).toBe(expected);
   });
 });
 
@@ -31,7 +109,7 @@ describe('runWalk', () => {
     const stdout = { write: vi.fn() };
     const code = await runWalk({
       cwd: '/tmp/repo',
-      readFile: async () => '## Walk order\n\n1. test item',
+      readFile: async () => '## Walk order\n\n1. **[X](https://x/)** test item',
       stdout,
     });
     expect(code).toBe(0);
@@ -68,5 +146,18 @@ describe('runWalk', () => {
     expect(code).toBe(1);
     const payload = stdout.write.mock.calls[0]?.[0] ?? '';
     expect(payload).toContain('failed to read');
+  });
+
+  it('returns non-zero and prints the parse-error message on duplicate items', async () => {
+    const stdout = { write: vi.fn() };
+    const code = await runWalk({
+      cwd: '/tmp/repo',
+      readFile: async () =>
+        ['## Walk order', '', '1. **[X](https://x/1)** first', '2. **[X](https://x/1)** dup'].join('\n'),
+      stdout,
+    });
+    expect(code).toBe(1);
+    const payload = stdout.write.mock.calls[0]?.[0] ?? '';
+    expect(payload).toContain('duplicate');
   });
 });

--- a/apps/mcp-local/src/walk/index.ts
+++ b/apps/mcp-local/src/walk/index.ts
@@ -1,0 +1,45 @@
+/**
+ * `slopweaver walk` CLI runner. Reads the local
+ * `.claude/personal/state/reconciliation.md`, parses the `## Walk
+ * order` section, prints the queue to stdout. Read-only first cut —
+ * the interactive verb-loop (do / agent / handoff / etc) lands in a
+ * follow-up PR.
+ *
+ * Every side effect is injected so the runner is fully testable
+ * without a real filesystem.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parseWalkOrder } from './parse-walk-order.ts';
+import { renderWalkQueue } from './render-walk-queue.ts';
+
+const DEFAULT_REL_PATH = '.claude/personal/state/reconciliation.md';
+
+export type RunWalkDeps = {
+  cwd: string;
+  readFile?: (absPath: string) => Promise<string>;
+  stdout: { write: (s: string) => void };
+};
+
+export async function runWalk(deps: RunWalkDeps): Promise<number> {
+  const reader = deps.readFile ?? ((p) => readFile(p, 'utf-8'));
+  const path = join(deps.cwd, DEFAULT_REL_PATH);
+  let content: string;
+  try {
+    content = await reader(path);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      deps.stdout.write(renderWalkQueue([]));
+      return 0;
+    }
+    deps.stdout.write(`slopweaver walk: failed to read ${path}: ${e instanceof Error ? e.message : String(e)}\n`);
+    return 1;
+  }
+  const items = parseWalkOrder(content);
+  deps.stdout.write(renderWalkQueue(items));
+  return 0;
+}
+
+export { renderWalkQueue } from './render-walk-queue.ts';
+export type { WalkItem } from './parse-walk-order.ts';

--- a/apps/mcp-local/src/walk/index.ts
+++ b/apps/mcp-local/src/walk/index.ts
@@ -5,6 +5,11 @@
  * the interactive verb-loop (do / agent / handoff / etc) lands in a
  * follow-up PR.
  *
+ * Parse warnings (e.g. numbered rows with empty descriptions) are
+ * emitted to stderr so the upstream malformation doesn't disappear
+ * silently from the queue — see parse-walk-order.ts for the warning
+ * shapes.
+ *
  * Every side effect is injected so the runner is fully testable
  * without a real filesystem.
  */
@@ -20,10 +25,12 @@ export type RunWalkDeps = {
   cwd: string;
   readFile?: (absPath: string) => Promise<string>;
   stdout: { write: (s: string) => void };
+  stderr?: { write: (s: string) => void };
 };
 
 export async function runWalk(deps: RunWalkDeps): Promise<number> {
   const reader = deps.readFile ?? ((p) => readFile(p, 'utf-8'));
+  const stderr = deps.stderr ?? { write: () => {} };
   const path = join(deps.cwd, DEFAULT_REL_PATH);
   let content: string;
   try {
@@ -41,7 +48,10 @@ export async function runWalk(deps: RunWalkDeps): Promise<number> {
     deps.stdout.write(`slopweaver walk: ${result.error.message}\n`);
     return 1;
   }
-  deps.stdout.write(renderWalkQueue(result.value));
+  for (const warning of result.value.warnings) {
+    stderr.write(`slopweaver walk: warning: ${warning}\n`);
+  }
+  deps.stdout.write(renderWalkQueue(result.value.items));
   return 0;
 }
 

--- a/apps/mcp-local/src/walk/index.ts
+++ b/apps/mcp-local/src/walk/index.ts
@@ -36,8 +36,12 @@ export async function runWalk(deps: RunWalkDeps): Promise<number> {
     deps.stdout.write(`slopweaver walk: failed to read ${path}: ${e instanceof Error ? e.message : String(e)}\n`);
     return 1;
   }
-  const items = parseWalkOrder(content);
-  deps.stdout.write(renderWalkQueue(items));
+  const result = parseWalkOrder(content);
+  if (result.isErr()) {
+    deps.stdout.write(`slopweaver walk: ${result.error.message}\n`);
+    return 1;
+  }
+  deps.stdout.write(renderWalkQueue(result.value));
   return 0;
 }
 

--- a/apps/mcp-local/src/walk/parse-walk-order.test.ts
+++ b/apps/mcp-local/src/walk/parse-walk-order.test.ts
@@ -4,7 +4,11 @@ import { parseWalkOrder } from './parse-walk-order.ts';
 describe('parseWalkOrder', () => {
   it('returns empty when the section is absent', () => {
     const md = '# Reconciliation\n\nSome other content.';
-    expect(parseWalkOrder(md)).toEqual([]);
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([]);
+    }
   });
 
   it('parses a fully-formed item line', () => {
@@ -13,42 +17,155 @@ describe('parseWalkOrder', () => {
       '',
       '1. **[PR-123](https://example.com/123)** — `[priority-2]` — reply to thread. *(reconciliation/inbox)*',
     ].join('\n');
-    const items = parseWalkOrder(md);
-    expect(items.length).toBe(1);
-    expect(items[0]).toEqual({
-      index: 1,
-      anchor: 'PR-123',
-      anchor_url: 'https://example.com/123',
-      priority: 'priority-2',
-      description: 'reply to thread.',
-      source_bucket: 'reconciliation/inbox',
-    });
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.length).toBe(1);
+      expect(result.value[0]).toEqual({
+        id: '3',
+        anchor: 'PR-123',
+        anchor_url: 'https://example.com/123',
+        priority: 'priority-2',
+        description: 'reply to thread.',
+        source_bucket: 'reconciliation/inbox',
+      });
+    }
   });
 
   it('parses an item without priority or source bucket', () => {
     const md = ['## Walk order', '', '1. **[X](https://x/)** — needs a poke.'].join('\n');
-    const items = parseWalkOrder(md);
-    expect(items[0]?.priority).toBe(null);
-    expect(items[0]?.source_bucket).toBe(null);
-    expect(items[0]?.description).toBe('needs a poke.');
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value[0]?.priority).toBe(null);
+      expect(result.value[0]?.source_bucket).toBe(null);
+      expect(result.value[0]?.description).toBe('needs a poke.');
+    }
   });
 
-  it('numbers items sequentially regardless of source numbering', () => {
-    const md = ['## Walk order', '', '1. one', '2. two', '7. seven (renumbered)'].join('\n');
-    const items = parseWalkOrder(md);
-    expect(items.map((i) => i.index)).toEqual([1, 2, 3]);
-    expect(items.map((i) => i.description)).toEqual(['one', 'two', 'seven (renumbered)']);
+  it('assigns ids from the source-line numbers (1-based)', () => {
+    const md = [
+      '## Walk order',
+      '',
+      '1. **[A](https://a/)** one',
+      '2. **[B](https://b/)** two',
+      '7. **[C](https://c/)** seven (renumbered)',
+    ].join('\n');
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.map((i) => i.id)).toEqual(['3', '4', '5']);
+      expect(result.value.map((i) => i.description)).toEqual(['one', 'two', 'seven (renumbered)']);
+    }
   });
 
   it('stops at the next ## heading', () => {
-    const md = ['## Walk order', '', '1. one', '', '## Apply these', '', '1. should be ignored'].join('\n');
-    const items = parseWalkOrder(md);
-    expect(items.length).toBe(1);
+    const md = [
+      '## Walk order',
+      '',
+      '1. **[X](https://x/)** one',
+      '',
+      '## Apply these',
+      '',
+      '1. **[Y](https://y/)** should be ignored',
+    ].join('\n');
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.length).toBe(1);
+    }
   });
 
   it('ignores non-numbered lines inside the section', () => {
-    const md = ['## Walk order', '', '> Single flat list across all buckets.', '', '1. real item'].join('\n');
-    const items = parseWalkOrder(md);
-    expect(items.length).toBe(1);
+    const md = [
+      '## Walk order',
+      '',
+      '> Single flat list across all buckets.',
+      '',
+      '1. **[X](https://x/)** real item',
+    ].join('\n');
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.length).toBe(1);
+    }
+  });
+
+  it('returns Err when two rows share the same anchor URL', () => {
+    const md = [
+      '## Walk order',
+      '',
+      '1. **[PR-1](https://example.com/1)** — reply',
+      '2. **[Also PR-1](https://example.com/1)** — duplicate URL',
+    ].join('\n');
+    const result = parseWalkOrder(md);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('WALK_ORDER_DUPLICATE');
+      expect(result.error.duplicates.length).toBe(2);
+      expect(result.error.duplicates.map((d) => d.id)).toEqual(['3', '4']);
+    }
+  });
+
+  it('returns Err when two rows share the same anchor text and neither has a URL', () => {
+    const md = ['## Walk order', '', '1. **[Topic]** explore the thing', '2. **[Topic]** explore it again'].join('\n');
+    const result = parseWalkOrder(md);
+    // Anchor-without-URL is intentionally a non-match for ANCHOR_RE (the
+    // regex requires the `(url)` group), so these rows have null anchor
+    // and null anchor_url; they should be allowed (no duplicate detected).
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('does not flag rows that share only description text as duplicates', () => {
+    const md = ['## Walk order', '', '1. **[A](https://a/)** follow up', '2. **[B](https://b/)** follow up'].join('\n');
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.length).toBe(2);
+    }
+  });
+
+  it('skips rows whose stripped description is empty', () => {
+    const md = ['## Walk order', '', '1. ', '2. **[X](https://x/)** real item', '3.   '].join('\n');
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.length).toBe(1);
+      expect(result.value[0]?.description).toBe('real item');
+    }
+  });
+
+  it('skips rows that are only an anchor with no description payload', () => {
+    const md = ['## Walk order', '', '1. **[X](https://x/)**'].join('\n');
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.length).toBe(0);
+    }
+  });
+
+  it('parses mixed CRLF and LF line endings identically to LF-only', () => {
+    const lfMd = ['## Walk order', '', '1. **[A](https://a/)** one', '2. **[B](https://b/)** two'].join('\n');
+    const crlfMd = lfMd.replace(/\n/g, '\r\n');
+    const lfResult = parseWalkOrder(lfMd);
+    const crlfResult = parseWalkOrder(crlfMd);
+    expect(lfResult.isOk()).toBe(true);
+    expect(crlfResult.isOk()).toBe(true);
+    if (lfResult.isOk() && crlfResult.isOk()) {
+      expect(crlfResult.value).toEqual(lfResult.value);
+    }
+  });
+
+  it('preserves unicode (emoji, RTL) in descriptions and anchors', () => {
+    const md = ['## Walk order', '', '1. **[شكرا 🙏](https://example.com/rtl)** — review الترجمة 🎉. *(inbox)*'].join(
+      '\n',
+    );
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.length).toBe(1);
+      expect(result.value[0]?.anchor).toBe('شكرا 🙏');
+      expect(result.value[0]?.description).toBe('review الترجمة 🎉.');
+    }
   });
 });

--- a/apps/mcp-local/src/walk/parse-walk-order.test.ts
+++ b/apps/mcp-local/src/walk/parse-walk-order.test.ts
@@ -69,6 +69,26 @@ describe('parseWalkOrder', () => {
     }
   });
 
+  it('keeps the id stable when only the description changes on a row that has an anchor_url', () => {
+    // URL is canonical identity for anchored rows — editing prose around
+    // the same URL should NOT shift the id (the state machine treats the
+    // URL as the row's identity).
+    const before = ['## Walk order', '', '1. **[PR-1](https://example.com/1)** — reply to thread.'].join('\n');
+    const after = ['## Walk order', '', '1. **[PR-1](https://example.com/1)** — actually, draft a reply tonight.'].join(
+      '\n',
+    );
+    const beforeResult = parseWalkOrder(before);
+    const afterResult = parseWalkOrder(after);
+    expect(beforeResult.isOk()).toBe(true);
+    expect(afterResult.isOk()).toBe(true);
+    if (beforeResult.isOk() && afterResult.isOk()) {
+      expect(beforeResult.value.items[0]?.id).toBe(expectedId('https://example.com/1'));
+      expect(afterResult.value.items[0]?.id).toBe(expectedId('https://example.com/1'));
+      expect(beforeResult.value.items[0]?.id).toBe(afterResult.value.items[0]?.id);
+      expect(beforeResult.value.items[0]?.description).not.toBe(afterResult.value.items[0]?.description);
+    }
+  });
+
   it('keeps ids stable when blank lines are inserted above an item', () => {
     const compact = ['## Walk order', '', '1. **[A](https://a/)** one', '2. **[B](https://b/)** two'].join('\n');
     const reformatted = [

--- a/apps/mcp-local/src/walk/parse-walk-order.test.ts
+++ b/apps/mcp-local/src/walk/parse-walk-order.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { parseWalkOrder } from './parse-walk-order.ts';
+
+describe('parseWalkOrder', () => {
+  it('returns empty when the section is absent', () => {
+    const md = '# Reconciliation\n\nSome other content.';
+    expect(parseWalkOrder(md)).toEqual([]);
+  });
+
+  it('parses a fully-formed item line', () => {
+    const md = [
+      '## Walk order (priority-ranked)',
+      '',
+      '1. **[PR-123](https://example.com/123)** — `[priority-2]` — reply to thread. *(reconciliation/inbox)*',
+    ].join('\n');
+    const items = parseWalkOrder(md);
+    expect(items.length).toBe(1);
+    expect(items[0]).toEqual({
+      index: 1,
+      anchor: 'PR-123',
+      anchor_url: 'https://example.com/123',
+      priority: 'priority-2',
+      description: 'reply to thread.',
+      source_bucket: 'reconciliation/inbox',
+    });
+  });
+
+  it('parses an item without priority or source bucket', () => {
+    const md = ['## Walk order', '', '1. **[X](https://x/)** — needs a poke.'].join('\n');
+    const items = parseWalkOrder(md);
+    expect(items[0]?.priority).toBe(null);
+    expect(items[0]?.source_bucket).toBe(null);
+    expect(items[0]?.description).toBe('needs a poke.');
+  });
+
+  it('numbers items sequentially regardless of source numbering', () => {
+    const md = ['## Walk order', '', '1. one', '2. two', '7. seven (renumbered)'].join('\n');
+    const items = parseWalkOrder(md);
+    expect(items.map((i) => i.index)).toEqual([1, 2, 3]);
+    expect(items.map((i) => i.description)).toEqual(['one', 'two', 'seven (renumbered)']);
+  });
+
+  it('stops at the next ## heading', () => {
+    const md = ['## Walk order', '', '1. one', '', '## Apply these', '', '1. should be ignored'].join('\n');
+    const items = parseWalkOrder(md);
+    expect(items.length).toBe(1);
+  });
+
+  it('ignores non-numbered lines inside the section', () => {
+    const md = ['## Walk order', '', '> Single flat list across all buckets.', '', '1. real item'].join('\n');
+    const items = parseWalkOrder(md);
+    expect(items.length).toBe(1);
+  });
+});

--- a/apps/mcp-local/src/walk/parse-walk-order.test.ts
+++ b/apps/mcp-local/src/walk/parse-walk-order.test.ts
@@ -1,5 +1,10 @@
+import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { parseWalkOrder } from './parse-walk-order.ts';
+
+function expectedId(seed: string): string {
+  return createHash('sha1').update(seed).digest('hex').slice(0, 8);
+}
 
 describe('parseWalkOrder', () => {
   it('returns empty when the section is absent', () => {
@@ -7,7 +12,8 @@ describe('parseWalkOrder', () => {
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toEqual([]);
+      expect(result.value.items).toEqual([]);
+      expect(result.value.warnings).toEqual([]);
     }
   });
 
@@ -20,9 +26,9 @@ describe('parseWalkOrder', () => {
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.length).toBe(1);
-      expect(result.value[0]).toEqual({
-        id: '3',
+      expect(result.value.items.length).toBe(1);
+      expect(result.value.items[0]).toEqual({
+        id: expectedId('https://example.com/123'),
         anchor: 'PR-123',
         anchor_url: 'https://example.com/123',
         priority: 'priority-2',
@@ -37,13 +43,13 @@ describe('parseWalkOrder', () => {
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value[0]?.priority).toBe(null);
-      expect(result.value[0]?.source_bucket).toBe(null);
-      expect(result.value[0]?.description).toBe('needs a poke.');
+      expect(result.value.items[0]?.priority).toBe(null);
+      expect(result.value.items[0]?.source_bucket).toBe(null);
+      expect(result.value.items[0]?.description).toBe('needs a poke.');
     }
   });
 
-  it('assigns ids from the source-line numbers (1-based)', () => {
+  it('derives item ids from content (anchor_url > anchor > description) so they survive input reformatting', () => {
     const md = [
       '## Walk order',
       '',
@@ -54,8 +60,50 @@ describe('parseWalkOrder', () => {
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.map((i) => i.id)).toEqual(['3', '4', '5']);
-      expect(result.value.map((i) => i.description)).toEqual(['one', 'two', 'seven (renumbered)']);
+      expect(result.value.items.map((i) => i.id)).toEqual([
+        expectedId('https://a/'),
+        expectedId('https://b/'),
+        expectedId('https://c/'),
+      ]);
+      expect(result.value.items.map((i) => i.description)).toEqual(['one', 'two', 'seven (renumbered)']);
+    }
+  });
+
+  it('keeps ids stable when blank lines are inserted above an item', () => {
+    const compact = ['## Walk order', '', '1. **[A](https://a/)** one', '2. **[B](https://b/)** two'].join('\n');
+    const reformatted = [
+      '## Walk order',
+      '',
+      '',
+      '',
+      '> a comment',
+      '',
+      '1. **[A](https://a/)** one',
+      '',
+      '2. **[B](https://b/)** two',
+    ].join('\n');
+    const compactResult = parseWalkOrder(compact);
+    const reformattedResult = parseWalkOrder(reformatted);
+    expect(compactResult.isOk()).toBe(true);
+    expect(reformattedResult.isOk()).toBe(true);
+    if (compactResult.isOk() && reformattedResult.isOk()) {
+      expect(compactResult.value.items.map((i) => i.id)).toEqual(reformattedResult.value.items.map((i) => i.id));
+    }
+  });
+
+  it('falls back to description text for the id when no URL/anchor is parsed', () => {
+    const md = ['## Walk order', '', '1. **[Topic]** explore the thing'].join('\n');
+    const result = parseWalkOrder(md);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      // ANCHOR_RE requires `(url)`, so `**[Topic]**` is a non-match —
+      // anchor + anchor_url are both null. The row's full body
+      // (including the unparsed `**[Topic]**`) becomes the description,
+      // and that's what seeds the id.
+      expect(result.value.items[0]?.anchor).toBe(null);
+      expect(result.value.items[0]?.anchor_url).toBe(null);
+      expect(result.value.items[0]?.description).toBe('**[Topic]** explore the thing');
+      expect(result.value.items[0]?.id).toBe(expectedId('**[Topic]** explore the thing'));
     }
   });
 
@@ -72,7 +120,7 @@ describe('parseWalkOrder', () => {
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.length).toBe(1);
+      expect(result.value.items.length).toBe(1);
     }
   });
 
@@ -87,7 +135,7 @@ describe('parseWalkOrder', () => {
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.length).toBe(1);
+      expect(result.value.items.length).toBe(1);
     }
   });
 
@@ -103,7 +151,10 @@ describe('parseWalkOrder', () => {
     if (result.isErr()) {
       expect(result.error.code).toBe('WALK_ORDER_DUPLICATE');
       expect(result.error.duplicates.length).toBe(2);
-      expect(result.error.duplicates.map((d) => d.id)).toEqual(['3', '4']);
+      expect(result.error.duplicates.map((d) => d.id)).toEqual([
+        expectedId('https://example.com/1'),
+        expectedId('https://example.com/1'),
+      ]);
     }
   });
 
@@ -121,26 +172,31 @@ describe('parseWalkOrder', () => {
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.length).toBe(2);
+      expect(result.value.items.length).toBe(2);
     }
   });
 
-  it('skips rows whose stripped description is empty', () => {
+  it('skips rows whose stripped description is empty AND surfaces a warning for each', () => {
     const md = ['## Walk order', '', '1. ', '2. **[X](https://x/)** real item', '3.   '].join('\n');
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.length).toBe(1);
-      expect(result.value[0]?.description).toBe('real item');
+      expect(result.value.items.length).toBe(1);
+      expect(result.value.items[0]?.description).toBe('real item');
+      expect(result.value.warnings).toEqual([
+        'line 3: numbered row had no description after stripping metadata',
+        'line 5: numbered row had no description after stripping metadata',
+      ]);
     }
   });
 
-  it('skips rows that are only an anchor with no description payload', () => {
+  it('skips rows that are only an anchor with no description payload AND warns', () => {
     const md = ['## Walk order', '', '1. **[X](https://x/)**'].join('\n');
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.length).toBe(0);
+      expect(result.value.items.length).toBe(0);
+      expect(result.value.warnings).toEqual(['line 3: numbered row had no description after stripping metadata']);
     }
   });
 
@@ -163,9 +219,9 @@ describe('parseWalkOrder', () => {
     const result = parseWalkOrder(md);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.length).toBe(1);
-      expect(result.value[0]?.anchor).toBe('شكرا 🙏');
-      expect(result.value[0]?.description).toBe('review الترجمة 🎉.');
+      expect(result.value.items.length).toBe(1);
+      expect(result.value.items[0]?.anchor).toBe('شكرا 🙏');
+      expect(result.value.items[0]?.description).toBe('review الترجمة 🎉.');
     }
   });
 });

--- a/apps/mcp-local/src/walk/parse-walk-order.ts
+++ b/apps/mcp-local/src/walk/parse-walk-order.ts
@@ -16,8 +16,10 @@
  * Anything outside the `## Walk order` section is ignored. Stops at
  * the next `##` heading.
  *
- * Items with an empty stripped description are skipped — a bare `1.`
- * with no payload is not a queue entry.
+ * Items with an empty stripped description are skipped AND surfaced
+ * as a parse warning so the upstream malformation isn't invisible
+ * (a bare `1.` or `1. **[X](https://x/)**` with no payload would
+ * otherwise vanish silently from the queue).
  *
  * Duplicate logical items (same `anchor_url`, or same `anchor` text
  * when no URL is present) cause the parser to return an `Err` with
@@ -26,6 +28,7 @@
  * reconciliation pipeline produced a malformed file.
  */
 
+import { createHash } from 'node:crypto';
 import { type Result, err, ok } from '@slopweaver/errors';
 
 export type WalkItem = {
@@ -35,6 +38,11 @@ export type WalkItem = {
   readonly priority: string | null;
   readonly description: string;
   readonly source_bucket: string | null;
+};
+
+export type WalkParseSuccess = {
+  readonly items: ReadonlyArray<WalkItem>;
+  readonly warnings: ReadonlyArray<string>;
 };
 
 export interface WalkOrderDuplicateError {
@@ -63,14 +71,24 @@ const SOURCE_BUCKET_RE = /\*\(([^)]+)\)\*\s*$/;
 /**
  * Parse a reconciliation.md body into the ranked WalkItem list.
  *
+ * Item ids are content-derived: a short sha1 hash of
+ * `anchor_url || anchor || description`. This makes ids stable across
+ * input reformats (inserting / deleting blank lines or comments above
+ * a row does not churn its id), but ids do change when the item's
+ * content changes — that's the intended semantics for a `/lock-in`
+ * state machine that wants to detect "this item is no longer the same
+ * piece of work."
+ *
  * @param markdown the raw file contents (CRLF and LF both accepted)
- * @returns the parsed queue, or an `Err` if duplicates are detected
+ * @returns the parsed queue plus any parse warnings, or an `Err` if
+ *   duplicates are detected
  */
-export function parseWalkOrder(markdown: string): Result<ReadonlyArray<WalkItem>, WalkParseError> {
+export function parseWalkOrder(markdown: string): Result<WalkParseSuccess, WalkParseError> {
   // Normalise CRLF / CR line endings so the line-by-line walk is
   // platform-independent.
   const lines = markdown.replace(/\r\n?/g, '\n').split('\n');
   const items: WalkItem[] = [];
+  const warnings: string[] = [];
   let inSection = false;
 
   for (let i = 0; i < lines.length; i++) {
@@ -97,12 +115,17 @@ export function parseWalkOrder(markdown: string): Result<ReadonlyArray<WalkItem>
       .replace(/^[\s—\-:]+|[\s—\-:]+$/g, '')
       .trim();
 
-    if (description.length === 0) continue;
+    if (description.length === 0) {
+      warnings.push(`line ${lineNumber}: numbered row had no description after stripping metadata`);
+      continue;
+    }
 
+    const anchor = anchorMatch?.[1] ?? null;
+    const anchorUrl = anchorMatch?.[2] ?? null;
     items.push({
-      id: String(lineNumber),
-      anchor: anchorMatch?.[1] ?? null,
-      anchor_url: anchorMatch?.[2] ?? null,
+      id: deriveId({ anchorUrl, anchor, description }),
+      anchor,
+      anchor_url: anchorUrl,
       priority: priorityMatch?.[1] ?? null,
       description,
       source_bucket: sourceMatch?.[1] ?? null,
@@ -114,7 +137,26 @@ export function parseWalkOrder(markdown: string): Result<ReadonlyArray<WalkItem>
     return err(WalkErrors.duplicate(duplicates));
   }
 
-  return ok(items);
+  return ok({ items, warnings });
+}
+
+/**
+ * Derive a stable 8-char id from item content. Precedence:
+ * `anchor_url` (most stable) → `anchor` text → `description`. The
+ * description fallback is always available because rows with empty
+ * descriptions are filtered upstream.
+ */
+function deriveId({
+  anchorUrl,
+  anchor,
+  description,
+}: {
+  anchorUrl: string | null;
+  anchor: string | null;
+  description: string;
+}): string {
+  const seed = anchorUrl ?? anchor ?? description;
+  return createHash('sha1').update(seed).digest('hex').slice(0, 8);
 }
 
 /**

--- a/apps/mcp-local/src/walk/parse-walk-order.ts
+++ b/apps/mcp-local/src/walk/parse-walk-order.ts
@@ -1,0 +1,73 @@
+/**
+ * Parser for the `## Walk order (priority-ranked)` section of a
+ * reconciliation.md file. Pure function — input markdown, output
+ * an ordered list of WalkItem objects.
+ *
+ * Expected line shape (per the /reconcile prompt body):
+ *
+ *   1. **[anchor](url)** — `[priority-N | rank=0-LIVE]` — <description>. *(<source-bucket>)*
+ *
+ * The parser is liberal — it accepts:
+ *   - Items numbered with `1.`, `2.` etc.
+ *   - Items with or without the bold anchor.
+ *   - Items with or without the priority bracket.
+ *   - Items with or without the source-bucket italic tail.
+ *
+ * Anything outside the `## Walk order` section is ignored. Stops at
+ * the next `##` heading.
+ */
+
+export type WalkItem = {
+  readonly index: number;
+  readonly anchor: string | null;
+  readonly anchor_url: string | null;
+  readonly priority: string | null;
+  readonly description: string;
+  readonly source_bucket: string | null;
+};
+
+const SECTION_HEADING = /^##\s+walk order/i;
+const NEXT_HEADING = /^##\s+/;
+const NUMBERED_LINE = /^\s*\d+\./;
+const ANCHOR_RE = /\*\*\[([^\]]+)\]\(([^)]+)\)\*\*/;
+const PRIORITY_RE = /`\[([^\]]+)\]`/;
+const SOURCE_BUCKET_RE = /\*\(([^)]+)\)\*\s*$/;
+
+export function parseWalkOrder(markdown: string): ReadonlyArray<WalkItem> {
+  const lines = markdown.split('\n');
+  const items: WalkItem[] = [];
+  let inSection = false;
+
+  for (const line of lines) {
+    if (SECTION_HEADING.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (!inSection) continue;
+    if (NEXT_HEADING.test(line)) break;
+    if (!NUMBERED_LINE.test(line)) continue;
+
+    const body = line.replace(/^\s*\d+\.\s*/, '').trim();
+    const anchorMatch = ANCHOR_RE.exec(body);
+    const priorityMatch = PRIORITY_RE.exec(body);
+    const sourceMatch = SOURCE_BUCKET_RE.exec(body);
+
+    const description = body
+      .replace(ANCHOR_RE, '')
+      .replace(PRIORITY_RE, '')
+      .replace(SOURCE_BUCKET_RE, '')
+      .replace(/^[\s—\-:]+|[\s—\-:]+$/g, '')
+      .trim();
+
+    items.push({
+      index: items.length + 1,
+      anchor: anchorMatch?.[1] ?? null,
+      anchor_url: anchorMatch?.[2] ?? null,
+      priority: priorityMatch?.[1] ?? null,
+      description,
+      source_bucket: sourceMatch?.[1] ?? null,
+    });
+  }
+
+  return items;
+}

--- a/apps/mcp-local/src/walk/parse-walk-order.ts
+++ b/apps/mcp-local/src/walk/parse-walk-order.ts
@@ -145,6 +145,16 @@ export function parseWalkOrder(markdown: string): Result<WalkParseSuccess, WalkP
  * `anchor_url` (most stable) → `anchor` text → `description`. The
  * description fallback is always available because rows with empty
  * descriptions are filtered upstream.
+ *
+ * Identity semantics: the id is stable as long as the highest-priority
+ * available field is unchanged. For anchored rows that means the URL is
+ * canonical identity — a description-only edit on a row that has an
+ * `anchor_url` keeps the id (the URL still wins the precedence chain).
+ * This is the right semantic for a state machine that treats the URL as
+ * the row's identity: the user is editing prose, not pointing at a
+ * different thing. For rows with no `anchor_url`, the anchor text plays
+ * that role; for rows with neither, the description does, so any edit
+ * changes the id.
  */
 function deriveId({
   anchorUrl,

--- a/apps/mcp-local/src/walk/parse-walk-order.ts
+++ b/apps/mcp-local/src/walk/parse-walk-order.ts
@@ -71,13 +71,13 @@ const SOURCE_BUCKET_RE = /\*\(([^)]+)\)\*\s*$/;
 /**
  * Parse a reconciliation.md body into the ranked WalkItem list.
  *
- * Item ids are content-derived: a short sha1 hash of
- * `anchor_url || anchor || description`. This makes ids stable across
- * input reformats (inserting / deleting blank lines or comments above
- * a row does not churn its id), but ids do change when the item's
- * content changes — that's the intended semantics for a `/lock-in`
- * state machine that wants to detect "this item is no longer the same
- * piece of work."
+ * Item ids are content-derived from the highest-priority available
+ * field: a short sha1 hash of `anchor_url || anchor || description`.
+ * That makes ids stable across input reformats (inserting or deleting
+ * blank lines or comments above a row does not churn its id). For an
+ * anchored row, the URL is the canonical identity, so a
+ * description-only edit keeps the same id. See `deriveId()` for the
+ * full per-field rules.
  *
  * @param markdown the raw file contents (CRLF and LF both accepted)
  * @returns the parsed queue plus any parse warnings, or an `Err` if

--- a/apps/mcp-local/src/walk/parse-walk-order.ts
+++ b/apps/mcp-local/src/walk/parse-walk-order.ts
@@ -15,16 +15,43 @@
  *
  * Anything outside the `## Walk order` section is ignored. Stops at
  * the next `##` heading.
+ *
+ * Items with an empty stripped description are skipped — a bare `1.`
+ * with no payload is not a queue entry.
+ *
+ * Duplicate logical items (same `anchor_url`, or same `anchor` text
+ * when no URL is present) cause the parser to return an `Err` with
+ * code `WALK_ORDER_DUPLICATE`. The walk queue is meant to be a
+ * de-duplicated ranked list; duplicates indicate the upstream
+ * reconciliation pipeline produced a malformed file.
  */
 
+import { type Result, err, ok } from '@slopweaver/errors';
+
 export type WalkItem = {
-  readonly index: number;
+  readonly id: string;
   readonly anchor: string | null;
   readonly anchor_url: string | null;
   readonly priority: string | null;
   readonly description: string;
   readonly source_bucket: string | null;
 };
+
+export interface WalkOrderDuplicateError {
+  readonly code: 'WALK_ORDER_DUPLICATE';
+  readonly message: string;
+  readonly duplicates: ReadonlyArray<WalkItem>;
+}
+
+export type WalkParseError = WalkOrderDuplicateError;
+
+const WalkErrors = {
+  duplicate: (duplicates: ReadonlyArray<WalkItem>): WalkOrderDuplicateError => ({
+    code: 'WALK_ORDER_DUPLICATE',
+    message: `Walk order contains ${duplicates.length} duplicate item(s); the reconciliation pipeline produced a malformed list.`,
+    duplicates,
+  }),
+} as const;
 
 const SECTION_HEADING = /^##\s+walk order/i;
 const NEXT_HEADING = /^##\s+/;
@@ -33,12 +60,23 @@ const ANCHOR_RE = /\*\*\[([^\]]+)\]\(([^)]+)\)\*\*/;
 const PRIORITY_RE = /`\[([^\]]+)\]`/;
 const SOURCE_BUCKET_RE = /\*\(([^)]+)\)\*\s*$/;
 
-export function parseWalkOrder(markdown: string): ReadonlyArray<WalkItem> {
-  const lines = markdown.split('\n');
+/**
+ * Parse a reconciliation.md body into the ranked WalkItem list.
+ *
+ * @param markdown the raw file contents (CRLF and LF both accepted)
+ * @returns the parsed queue, or an `Err` if duplicates are detected
+ */
+export function parseWalkOrder(markdown: string): Result<ReadonlyArray<WalkItem>, WalkParseError> {
+  // Normalise CRLF / CR line endings so the line-by-line walk is
+  // platform-independent.
+  const lines = markdown.replace(/\r\n?/g, '\n').split('\n');
   const items: WalkItem[] = [];
   let inSection = false;
 
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const lineNumber = i + 1;
+
     if (SECTION_HEADING.test(line)) {
       inSection = true;
       continue;
@@ -59,8 +97,10 @@ export function parseWalkOrder(markdown: string): ReadonlyArray<WalkItem> {
       .replace(/^[\s—\-:]+|[\s—\-:]+$/g, '')
       .trim();
 
+    if (description.length === 0) continue;
+
     items.push({
-      index: items.length + 1,
+      id: String(lineNumber),
       anchor: anchorMatch?.[1] ?? null,
       anchor_url: anchorMatch?.[2] ?? null,
       priority: priorityMatch?.[1] ?? null,
@@ -69,5 +109,43 @@ export function parseWalkOrder(markdown: string): ReadonlyArray<WalkItem> {
     });
   }
 
-  return items;
+  const duplicates = findDuplicates(items);
+  if (duplicates.length > 0) {
+    return err(WalkErrors.duplicate(duplicates));
+  }
+
+  return ok(items);
+}
+
+/**
+ * Find logically-duplicate items: same `anchor_url`, or same `anchor`
+ * text when both items have no URL. Items without an anchor (URL or
+ * text) are never duplicates of each other — they're identified only
+ * by their description, which can legitimately repeat ("follow up on
+ * the same topic in two different threads").
+ */
+function findDuplicates(items: ReadonlyArray<WalkItem>): ReadonlyArray<WalkItem> {
+  const byUrl = new Map<string, WalkItem[]>();
+  const byAnchor = new Map<string, WalkItem[]>();
+
+  for (const item of items) {
+    if (item.anchor_url != null) {
+      const bucket = byUrl.get(item.anchor_url) ?? [];
+      bucket.push(item);
+      byUrl.set(item.anchor_url, bucket);
+    } else if (item.anchor != null) {
+      const bucket = byAnchor.get(item.anchor) ?? [];
+      bucket.push(item);
+      byAnchor.set(item.anchor, bucket);
+    }
+  }
+
+  const duplicates: WalkItem[] = [];
+  for (const bucket of byUrl.values()) {
+    if (bucket.length > 1) duplicates.push(...bucket);
+  }
+  for (const bucket of byAnchor.values()) {
+    if (bucket.length > 1) duplicates.push(...bucket);
+  }
+  return duplicates;
 }

--- a/apps/mcp-local/src/walk/render-walk-queue.ts
+++ b/apps/mcp-local/src/walk/render-walk-queue.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure-function renderer for the walk queue. Takes a list of WalkItems
+ * and returns the multi-line string to print to stdout.
+ *
+ * Kept separate from the IO loop so tests can pin the exact output
+ * shape without spawning a process. The interactive loop (a v1.2
+ * follow-up using `ink` or `node:readline`) consumes the same data
+ * structure.
+ */
+
+import type { WalkItem } from './parse-walk-order.ts';
+
+export function renderWalkQueue(items: ReadonlyArray<WalkItem>): string {
+  if (items.length === 0) {
+    return [
+      'slopweaver walk',
+      '',
+      'No items in the walk queue.',
+      '',
+      'Run `/reconcile` (or `/session-start`) to populate',
+      '`.claude/personal/state/reconciliation.md` with a `## Walk order`',
+      'section, then re-run `slopweaver walk`.',
+      '',
+    ].join('\n');
+  }
+
+  const lines: string[] = [];
+  lines.push('slopweaver walk');
+  lines.push('');
+  lines.push(`Walking ${items.length} item(s). Per-item actions in /lock-in:`);
+  lines.push('  do | agent | handoff | defer | skip | note | open-question | jump N');
+  lines.push('');
+  lines.push('(Interactive loop ships in a follow-up PR — for now this is read-only.)');
+  lines.push('');
+
+  for (const item of items) {
+    const anchorBit = item.anchor != null ? `[${item.anchor}] ` : '';
+    const priorityBit = item.priority != null ? `\`${item.priority}\` ` : '';
+    const sourceBit = item.source_bucket != null ? ` (${item.source_bucket})` : '';
+    lines.push(`${pad(item.index)}. ${anchorBit}${priorityBit}${item.description}${sourceBit}`);
+    if (item.anchor_url != null) {
+      lines.push(`    ${item.anchor_url}`);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function pad(n: number): string {
+  return n < 10 ? ` ${n}` : `${n}`;
+}

--- a/apps/mcp-local/src/walk/render-walk-queue.ts
+++ b/apps/mcp-local/src/walk/render-walk-queue.ts
@@ -6,6 +6,9 @@
  * shape without spawning a process. The interactive loop (a v1.2
  * follow-up using `ink` or `node:readline`) consumes the same data
  * structure.
+ *
+ * Display numbering (1-based) is derived here from the array index —
+ * it's a presentation concern, not a property of the parsed model.
  */
 
 import type { WalkItem } from './parse-walk-order.ts';
@@ -24,6 +27,7 @@ export function renderWalkQueue(items: ReadonlyArray<WalkItem>): string {
     ].join('\n');
   }
 
+  const totalDigits = String(items.length).length;
   const lines: string[] = [];
   lines.push('slopweaver walk');
   lines.push('');
@@ -33,11 +37,14 @@ export function renderWalkQueue(items: ReadonlyArray<WalkItem>): string {
   lines.push('(Interactive loop ships in a follow-up PR — for now this is read-only.)');
   lines.push('');
 
-  for (const item of items) {
+  for (const [index, item] of items.entries()) {
+    const displayIndex = index + 1;
     const anchorBit = item.anchor != null ? `[${item.anchor}] ` : '';
     const priorityBit = item.priority != null ? `\`${item.priority}\` ` : '';
     const sourceBit = item.source_bucket != null ? ` (${item.source_bucket})` : '';
-    lines.push(`${pad(item.index)}. ${anchorBit}${priorityBit}${item.description}${sourceBit}`);
+    lines.push(
+      `${pad({ n: displayIndex, width: totalDigits })}. ${anchorBit}${priorityBit}${item.description}${sourceBit}`,
+    );
     if (item.anchor_url != null) {
       lines.push(`    ${item.anchor_url}`);
     }
@@ -46,6 +53,6 @@ export function renderWalkQueue(items: ReadonlyArray<WalkItem>): string {
   return lines.join('\n');
 }
 
-function pad(n: number): string {
-  return n < 10 ? ` ${n}` : `${n}`;
+function pad({ n, width }: { n: number; width: number }): string {
+  return String(n).padStart(width, ' ');
 }


### PR DESCRIPTION
Closes #64.

**Problem**

There was no way to actually drive the `/lock-in` walk queue from the CLI. The ranked items lived in `.claude/personal/state/reconciliation.md` as a `## Walk order` section and had to be eyeballed by hand.

**Solution**

New `slopweaver walk` subcommand reads that section, parses it into typed items, and prints a numbered queue with per-item action hints. The interactive verb-loop (do/agent/handoff/defer/skip/note/open-question/jump) is read-only for now and lands as a follow-up.

**Proof this works**

_pending local verification_

**How to test**

1. `pnpm install && pnpm compile`
2. Drop a `## Walk order` section into `.claude/personal/state/reconciliation.md` with a few numbered rows
3. Run `pnpm --filter @slopweaver/mcp-local exec slopweaver walk`
4. Confirm the queue prints with stable padding and the anchor URL under each item
5. Delete the file and re-run, confirm the empty-state helper points at `/reconcile`
6. Add a malformed row (bare `1.` or anchor-only `2. **[X](https://x/)**`), confirm stdout still prints valid items and stderr emits one warning per bad row
7. `pnpm validate`

<details>
<summary>Implementation notes</summary>

Split into three pure modules under `apps/mcp-local/src/walk/`:

- `parse-walk-order.ts` returns `Result<{ items, warnings }, ParseError>`. Malformed numbered rows do not abort the parse, they get pushed onto the `warnings` array so `runWalk` can forward them to stderr while still printing the good items. Hard errors (duplicate ids, missing `## Walk order` heading) still fail the Result.
- `render-walk-queue.ts` is the pure formatter. Numbering pads to 2 digits at 10+ items so the column stays aligned.
- `index.ts` is the runner. Every side effect (`readFile`, `stdout`, `stderr`) is injected so the tests run without touching disk.

Item ids are content-derived via a sha1 prefix of `anchor_url || anchor || description` (iter-3 fix in d7dad4f). Inserting blank lines above a row no longer renumbers everything underneath it, which is what the original position-based id scheme did.

The interactive TUI loop (ink or node:readline) is deferred. v1.1 is the read-only print path so the parse + render contracts are locked in before wiring input handling on top.

</details>
