### PR TITLE
feat(cli): add slopweaver demo subcommand for synthetic preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ slopweaver demo seed     # populates ~/.slopweaver/demo.db with ~22 synthetic ro
 slopweaver --demo        # runs the MCP server against demo.db instead of slopweaver.db
                          # (equivalent to SLOPWEAVER_DEMO=1)
 slopweaver demo reset    # drop + re-seed if the timestamps have drifted
-slopweaver demo exit     # remove demo.db when you're done
+slopweaver demo exit     # remove demo.db (restart the server without --demo,
+                         # or unset SLOPWEAVER_DEMO, to return to real mode)
 ```
 
 Once the server is running in demo mode, ask your MCP client to call the `start_session` tool — it serves the synthetic rows exactly the same way it would serve your real data. Only GitHub and Slack are covered (those are the integrations v1.0 actually ships); Linear / Gmail / Calendar are planned for v1.1+ and are intentionally absent from the demo so the snapshot can't claim a richer product than the binary delivers.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ Then ask your client: *"What should I work on next?"* If anything fails, [open a
 
 > **Note:** Connecting SlopWeaver to GitHub (so it can poll your PRs and mentions) uses GitHub's own OAuth or a personal access token — that's separate from the MCP transport between your client and SlopWeaver. The MCP layer itself has no auth in v1; stdio inherits the user's trust context.
 
+### Try it without connecting anything (demo mode)
+
+If you want to feel the cold-start moment before bringing your own tokens, SlopWeaver ships a demo profile that seeds a separate SQLite database with synthetic GitHub + Slack evidence:
+
+```bash
+slopweaver demo seed     # populates ~/.slopweaver/demo.db with ~22 synthetic rows
+slopweaver --demo        # runs the MCP server against demo.db instead of slopweaver.db
+                         # (equivalent to SLOPWEAVER_DEMO=1)
+slopweaver demo reset    # drop + re-seed if the timestamps have drifted
+slopweaver demo exit     # remove demo.db when you're done
+```
+
+Once the server is running in demo mode, ask your MCP client to call the `start_session` tool — it serves the synthetic rows exactly the same way it would serve your real data. Only GitHub and Slack are covered (those are the integrations v1.0 actually ships); Linear / Gmail / Calendar are planned for v1.1+ and are intentionally absent from the demo so the snapshot can't claim a richer product than the binary delivers.
+
+The bare `slopweaver demo` command (with no subcommand) prints a static markdown snapshot to stdout for screenshotting or sharing.
+
 ---
 
 ## Why local-first

--- a/apps/mcp-local/package.json
+++ b/apps/mcp-local/package.json
@@ -29,11 +29,13 @@
     "@slopweaver/db": "workspace:*",
     "@slopweaver/env": "workspace:*",
     "@slopweaver/errors": "workspace:*",
+    "@slopweaver/integrations-core": "workspace:*",
     "@slopweaver/integrations-github": "workspace:*",
     "@slopweaver/integrations-slack": "workspace:*",
     "@slopweaver/mcp-server": "workspace:*",
     "@slopweaver/ui": "workspace:*",
-    "cac": "7.0.0"
+    "cac": "7.0.0",
+    "drizzle-orm": "0.45.2"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",

--- a/apps/mcp-local/src/cli.smoke.test.ts
+++ b/apps/mcp-local/src/cli.smoke.test.ts
@@ -16,9 +16,9 @@
  */
 
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -158,6 +158,97 @@ describe('slopweaver bin (compiled CLI)', () => {
     expect(result.stderr).toContain('slopweaver:');
     expect(result.stderr).toContain('XDG_DATA_HOME must be an absolute path');
     expect(result.stderr).not.toMatch(/^\s+at /m);
+  });
+});
+
+describe('slopweaver bin demo mode (end-to-end)', () => {
+  let dataHome: string;
+
+  beforeEach(() => {
+    dataHome = mkdtempSync(resolve(tmpdir(), 'slopweaver-smoke-demo-'));
+  });
+
+  afterEach(() => {
+    rmSync(dataHome, { recursive: true, force: true });
+  });
+
+  it('demo seed populates a demo DB and start_session against it returns >0 evidence rows', async () => {
+    // Step 1: seed the demo DB via `slopweaver demo seed`. The subcommand
+    // is synchronous and exits — no transport plumbing required.
+    const seed = spawnSync(process.execPath, [cliPath, 'demo', 'seed'], {
+      env: {
+        ...process.env,
+        XDG_DATA_HOME: dataHome,
+      },
+      encoding: 'utf-8',
+    });
+    expect(seed.status).toBe(0);
+    expect(seed.stderr).toBe('');
+
+    const expectedDemoDb = join(dataHome, 'slopweaver', 'demo.db');
+    expect(existsSync(expectedDemoDb)).toBe(true);
+    // The real DB must NOT have been created by `demo seed` — the two
+    // files are siblings, not nested, and demo seeding only touches one.
+    const realDb = join(dataHome, 'slopweaver', 'slopweaver.db');
+    expect(existsSync(realDb)).toBe(false);
+
+    // Step 2: drive `start_session` against the demo DB by spawning the
+    // MCP server with --demo. The server resolves the demo DB path via
+    // the same `resolveDemoDbPath()` helper the subcommand used, so the
+    // seeded rows are visible immediately.
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [cliPath, '--demo', '--no-web-ui'],
+      env: {
+        ...process.env,
+        XDG_DATA_HOME: dataHome,
+      },
+      stderr: 'pipe',
+    });
+    const client = new Client({ name: 'slopweaver-smoke-demo', version: '0.0.0' });
+    await client.connect(transport);
+
+    try {
+      const startSession = await client.callTool({ name: 'start_session', arguments: {} });
+      expect(startSession.isError).toBeUndefined();
+      const parsed = StartSessionResult.safeParse(startSession.structuredContent);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        // PR #78 acceptance: a freshly seeded demo DB must produce a
+        // non-empty `start_session` response so a first-time user sees
+        // the real product surface, not an empty cache.
+        expect(parsed.data.items.length).toBeGreaterThan(0);
+        expect(parsed.data.evidence.length).toBeGreaterThan(0);
+        // Both shipped integrations are represented somewhere in the
+        // ranked response (start_session caps at max_items=10 by
+        // default, so we look across items + evidence to be robust to
+        // the ranking heuristic).
+        const integrations = new Set(parsed.data.evidence.map((e) => e.integration));
+        expect(integrations.has('github')).toBe(true);
+        expect(integrations.has('slack')).toBe(true);
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('demo exit removes the demo DB but leaves the real DB intact', () => {
+    // Seed first.
+    const seed = spawnSync(process.execPath, [cliPath, 'demo', 'seed'], {
+      env: { ...process.env, XDG_DATA_HOME: dataHome },
+      encoding: 'utf-8',
+    });
+    expect(seed.status).toBe(0);
+    const demoDb = join(dataHome, 'slopweaver', 'demo.db');
+    expect(existsSync(demoDb)).toBe(true);
+
+    // Then exit.
+    const exitResult = spawnSync(process.execPath, [cliPath, 'demo', 'exit'], {
+      env: { ...process.env, XDG_DATA_HOME: dataHome },
+      encoding: 'utf-8',
+    });
+    expect(exitResult.status).toBe(0);
+    expect(existsSync(demoDb)).toBe(false);
   });
 });
 

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -443,6 +443,20 @@ cli
   });
 
 cli
+  .command('demo', 'Print a synthetic /session-start snapshot (no MCP calls; zero-friction try-before-BYOK)')
+  .example('  slopweaver demo')
+  .action(async () => {
+    try {
+      const { runDemo } = await import('./demo/index.ts');
+      const code = await runDemo({ stdout });
+      exit(code);
+    } catch (error: unknown) {
+      stderr.write(`slopweaver: ${asMessage({ error })}\n`);
+      exit(1);
+    }
+  });
+
+cli
   .command('', 'Run the MCP server over stdio (default)')
   .option('--no-web-ui', 'Disable the local Diagnostics web UI on 127.0.0.1:60701')
   .action((options: { webUi: boolean }) => {

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -472,7 +472,9 @@ cli
   .example('  slopweaver demo           # print synthetic snapshot to stdout')
   .example('  slopweaver demo seed      # populate a demo DB so start_session returns synthetic evidence')
   .example('  slopweaver demo reset     # drop the demo DB and re-seed')
-  .example('  slopweaver demo exit      # remove the demo DB and switch back to the real DB')
+  .example(
+    '  slopweaver demo exit      # remove the demo DB (restart without --demo / unset SLOPWEAVER_DEMO to return to real mode)',
+  )
   .action(async (action: string | undefined) => {
     try {
       const code = await dispatchDemoAction({ action });

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -26,7 +26,7 @@ import { homedir } from 'node:os';
 import { argv, cwd as processCwd, env, exit, stderr, stdout } from 'node:process';
 import { confirm, password, select } from '@inquirer/prompts';
 import { cac } from 'cac';
-import { createDb, loadIntegrationToken, resolveDataDir, resolveDbPath } from '@slopweaver/db';
+import { createDb, loadIntegrationToken, resolveDataDir, resolveDbPath, resolveDemoDbPath } from '@slopweaver/db';
 import { loadEnv } from '@slopweaver/env';
 import {
   createGithubClient,
@@ -89,7 +89,25 @@ function resolveWebUiPort(): number {
   return parsed;
 }
 
-async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void> {
+/**
+ * Decide whether the current invocation is in demo mode. The flag is
+ * intentionally orthogonal to the rest of the CLI surface: a single
+ * `--demo` (or `SLOPWEAVER_DEMO=1`) flips the DB resolver from
+ * `slopweaver.db` to `demo.db`, and the rest of the binary runs
+ * unchanged against the alternate DB. The two files are never
+ * accidentally mixed because the resolver helpers in `@slopweaver/db`
+ * are the only callers that map an environment to a path.
+ */
+function isDemoModeEnabled({ flag }: { flag: boolean }): boolean {
+  if (flag) return true;
+  const raw = env['SLOPWEAVER_DEMO'];
+  if (raw === undefined || raw === '') return false;
+  // Accept the usual truthy strings; reject anything else so a typo
+  // doesn't silently disable the flag.
+  return raw === '1' || raw === 'true';
+}
+
+async function runMcpServer({ uiEnabled, demo }: { uiEnabled: boolean; demo: boolean }): Promise<void> {
   // Validate the environment before opening the SQLite file or starting the
   // server. The `EnvValidationError` is unwrapped at this CLI boundary so the
   // outer .catch() in the cac action prints + exits non-zero.
@@ -98,7 +116,8 @@ async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void
     throw envResult.error;
   }
 
-  const dbPathResult = resolveDbPath();
+  const demoEnabled = isDemoModeEnabled({ flag: demo });
+  const dbPathResult = demoEnabled ? resolveDemoDbPath() : resolveDbPath();
   if (dbPathResult.isErr()) {
     throw dbPathResult.error;
   }
@@ -110,6 +129,9 @@ async function runMcpServer({ uiEnabled }: { uiEnabled: boolean }): Promise<void
   const startedAtMs = Date.now();
   const dbHandle = createDb({ path: dbPathResult.value });
   const dataDir = dataDirResult.value;
+  if (demoEnabled) {
+    stderr.write(`slopweaver: demo mode — serving from ${dbPathResult.value}\n`);
+  }
 
   // Load connected integration tokens from `integration_tokens` in parallel,
   // then build a poller map keyed by integration slug to pass into the
@@ -443,12 +465,17 @@ cli
   });
 
 cli
-  .command('demo', 'Print a synthetic /session-start snapshot (no MCP calls; zero-friction try-before-BYOK)')
-  .example('  slopweaver demo')
-  .action(async () => {
+  .command(
+    'demo [action]',
+    'Demo mode (zero-friction try-before-BYOK). Actions: seed | reset | exit. With no action, prints a static snapshot.',
+  )
+  .example('  slopweaver demo           # print synthetic snapshot to stdout')
+  .example('  slopweaver demo seed      # populate a demo DB so start_session returns synthetic evidence')
+  .example('  slopweaver demo reset     # drop the demo DB and re-seed')
+  .example('  slopweaver demo exit      # remove the demo DB and switch back to the real DB')
+  .action(async (action: string | undefined) => {
     try {
-      const { runDemo } = await import('./demo/index.ts');
-      const code = await runDemo({ stdout });
+      const code = await dispatchDemoAction({ action });
       exit(code);
     } catch (error: unknown) {
       stderr.write(`slopweaver: ${asMessage({ error })}\n`);
@@ -456,11 +483,41 @@ cli
     }
   });
 
+/**
+ * Resolve `slopweaver demo [action]` to an exit code. Pulled out of
+ * the cac action callback so TypeScript's narrowing doesn't have to
+ * fight `process.exit`'s `never` return — every branch here returns a
+ * concrete `number` that the action wraps in `exit()`.
+ */
+async function dispatchDemoAction({ action }: { action: string | undefined }): Promise<number> {
+  const demo = await import('./demo/index.ts');
+  if (action === undefined) {
+    return demo.runDemo({ stdout });
+  }
+  if (action !== 'seed' && action !== 'reset' && action !== 'exit') {
+    stderr.write(`slopweaver: unknown demo action "${action}". Expected seed, reset, or exit.\n`);
+    return 1;
+  }
+  const demoDbPathResult = resolveDemoDbPath();
+  if (demoDbPathResult.isErr()) {
+    throw demoDbPathResult.error;
+  }
+  const demoDbPath = demoDbPathResult.value;
+  if (action === 'seed') {
+    return demo.runDemoSeed({ demoDbPath, stdout, stderr });
+  }
+  if (action === 'reset') {
+    return demo.runDemoReset({ demoDbPath, stdout, stderr });
+  }
+  return demo.runDemoExit({ demoDbPath, stdout, stderr });
+}
+
 cli
   .command('', 'Run the MCP server over stdio (default)')
   .option('--no-web-ui', 'Disable the local Diagnostics web UI on 127.0.0.1:60701')
-  .action((options: { webUi: boolean }) => {
-    runMcpServer({ uiEnabled: options.webUi }).catch((error: unknown) => {
+  .option('--demo', 'Use the demo DB (~/.slopweaver/demo.db) instead of slopweaver.db; equivalent to SLOPWEAVER_DEMO=1')
+  .action((options: { webUi: boolean; demo?: boolean }) => {
+    runMcpServer({ uiEnabled: options.webUi, demo: options.demo === true }).catch((error: unknown) => {
       stderr.write(`slopweaver: ${asMessage({ error })}\n`);
       exit(1);
     });

--- a/apps/mcp-local/src/demo/demo.test.ts
+++ b/apps/mcp-local/src/demo/demo.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runDemo } from './index.ts';
+import { DEMO_SNAPSHOT } from './synthetic-persona.ts';
+
+describe('runDemo', () => {
+  it('writes the synthetic snapshot to stdout and returns 0', async () => {
+    const stdout = { write: vi.fn() };
+    const code = await runDemo({ stdout });
+    expect(code).toBe(0);
+    expect(stdout.write).toHaveBeenCalledOnce();
+    expect(stdout.write.mock.calls[0]?.[0]).toBe(DEMO_SNAPSHOT);
+  });
+});
+
+describe('DEMO_SNAPSHOT', () => {
+  it('does not contain personal identifiers', () => {
+    // The synthetic persona is generic. Any real name / employer / channel
+    // would be a leak — fail the build if one ever sneaks in.
+    expect(DEMO_SNAPSHOT).not.toMatch(/Lachie|Everlab|@everlab/i);
+  });
+
+  it('ends with the canonical session-start closer', () => {
+    expect(DEMO_SNAPSHOT).toContain('What are we working on this session?');
+  });
+
+  it('mentions the BYOK try-it-yourself path', () => {
+    expect(DEMO_SNAPSHOT).toContain('claude mcp add slopweaver');
+  });
+});

--- a/apps/mcp-local/src/demo/demo.test.ts
+++ b/apps/mcp-local/src/demo/demo.test.ts
@@ -222,7 +222,7 @@ describe('runDemoExit / dropDemoDbFile', () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it('removes a seeded demo DB', async () => {
+  it('removes a seeded demo DB and prints accurate copy about returning to real mode', async () => {
     await seedDemoDb({ demoDbPath, now: 1_700_000_000_000 });
     expect(existsSync(demoDbPath)).toBe(true);
 
@@ -231,9 +231,21 @@ describe('runDemoExit / dropDemoDbFile', () => {
     const code = await runDemoExit({ demoDbPath, stdout, stderr });
     expect(code).toBe(0);
     expect(existsSync(demoDbPath)).toBe(false);
+
+    // The exit command only deletes the demo DB file. It does not modify
+    // the MCP client config or the SLOPWEAVER_DEMO env var, so the copy
+    // must tell the user how to actually return to real mode.
+    const combined = stdout.write.mock.calls.map((c) => c[0]).join('');
+    expect(combined).toContain('exit removes the demo DB');
+    expect(combined).toContain('restart the server without --demo');
+    expect(combined).toContain('unset SLOPWEAVER_DEMO');
+    // Earlier copy falsely claimed exit "switches back to the real DB" —
+    // it doesn't. Make sure that misleading phrase is gone.
+    expect(combined).not.toContain('switch back to the real DB');
+    expect(combined).not.toContain('use your real DB');
   });
 
-  it('succeeds silently when no demo DB is present', async () => {
+  it('succeeds silently when no demo DB is present and still surfaces the return-to-real-mode copy', async () => {
     const stdout = { write: vi.fn() };
     const stderr = { write: vi.fn() };
     const code = await runDemoExit({ demoDbPath, stdout, stderr });
@@ -241,6 +253,8 @@ describe('runDemoExit / dropDemoDbFile', () => {
     expect(stderr.write).not.toHaveBeenCalled();
     const combined = stdout.write.mock.calls.map((c) => c[0]).join('');
     expect(combined).toContain('no demo DB present');
+    expect(combined).toContain('restart the server without --demo');
+    expect(combined).toContain('unset SLOPWEAVER_DEMO');
   });
 
   it('dropDemoDbFile returns removed:false when nothing exists', async () => {

--- a/apps/mcp-local/src/demo/demo.test.ts
+++ b/apps/mcp-local/src/demo/demo.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it, vi } from 'vitest';
-import { runDemo } from './index.ts';
-import { DEMO_SNAPSHOT } from './synthetic-persona.ts';
+/**
+ * Unit tests for the `slopweaver demo` family of subcommands.
+ *
+ * Pure-function tests against the helpers in `./index.ts`. The demo DB
+ * is opened against an `XDG_DATA_HOME`-style tmpdir so we never touch
+ * the developer's real `~/.slopweaver/demo.db`. Smoke coverage of the
+ * end-to-end CLI flow (binary spawn + `start_session` returning >0
+ * rows against the seeded demo DB) lives in `../cli.smoke.test.ts`.
+ */
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createDb, evidenceLog, integrationState } from '@slopweaver/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dropDemoDbFile, isDemoDb, runDemo, runDemoExit, runDemoReset, runDemoSeed, seedDemoDb } from './index.ts';
+import { DEMO_EVIDENCE, DEMO_SENTINEL_INTEGRATION, DEMO_SNAPSHOT } from './synthetic-persona.ts';
 
 describe('runDemo', () => {
   it('writes the synthetic snapshot to stdout and returns 0', async () => {
@@ -25,5 +39,215 @@ describe('DEMO_SNAPSHOT', () => {
 
   it('mentions the BYOK try-it-yourself path', () => {
     expect(DEMO_SNAPSHOT).toContain('claude mcp add slopweaver');
+  });
+
+  it('points the reader at the real MCP entry point (start_session tool) — no fictional slash commands', () => {
+    // PR #78 review P2: an earlier draft told users to run `/session-start`,
+    // but this repo ships start_session as an MCP tool, not a slash command.
+    // The snapshot must not advertise a non-existent surface.
+    expect(DEMO_SNAPSHOT).not.toMatch(/\/session-start/);
+    expect(DEMO_SNAPSHOT).toContain('start_session');
+  });
+
+  it('only claims integrations that actually ship today (GitHub + Slack)', () => {
+    // PR #78 review P2: an earlier draft listed Slack / GitHub / Linear /
+    // Gmail / Calendar as "polled this run", but v1.0 only ships GitHub +
+    // Slack. The "Sources polled this run" header must reflect that.
+    const polledLine = DEMO_SNAPSHOT.match(/Sources polled this run:[^\n]+/);
+    expect(polledLine).not.toBeNull();
+    if (polledLine !== null) {
+      const line = polledLine[0];
+      expect(line).toContain('Slack');
+      expect(line).toContain('GitHub');
+      // Linear / Gmail / Calendar may still appear in the persona text
+      // *labelled as planned*, but never inside the "polled this run"
+      // checkmark line.
+      expect(line).not.toContain('Linear');
+      expect(line).not.toContain('Gmail');
+      expect(line).not.toContain('Calendar');
+    }
+  });
+});
+
+describe('DEMO_EVIDENCE', () => {
+  it('seeds at least 10 rows per shipped integration so start_session has signal to rank', () => {
+    const githubRows = DEMO_EVIDENCE.filter((r) => r.integration === 'github');
+    const slackRows = DEMO_EVIDENCE.filter((r) => r.integration === 'slack');
+    // PR #78 review P1 spec: "10-20 rows per integration covered by current build".
+    expect(githubRows.length).toBeGreaterThanOrEqual(10);
+    expect(slackRows.length).toBeGreaterThanOrEqual(10);
+    expect(githubRows.length).toBeLessThanOrEqual(20);
+    expect(slackRows.length).toBeLessThanOrEqual(20);
+  });
+
+  it('only seeds rows for integrations that ship today (no Linear / Gmail / Calendar)', () => {
+    for (const row of DEMO_EVIDENCE) {
+      expect(['github', 'slack']).toContain(row.integration);
+    }
+  });
+
+  it('every row carries a unique external_id within its integration', () => {
+    const seen = new Set<string>();
+    for (const row of DEMO_EVIDENCE) {
+      const key = `${row.integration}:${row.externalId}`;
+      expect(seen.has(key)).toBe(false);
+      seen.add(key);
+    }
+  });
+});
+
+describe('seedDemoDb / runDemoSeed', () => {
+  let tmp: string;
+  let demoDbPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'slopweaver-demo-'));
+    demoDbPath = resolve(tmp, 'demo.db');
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('creates the demo DB file and seeds every DEMO_EVIDENCE row', async () => {
+    const result = await seedDemoDb({ demoDbPath, now: 1_700_000_000_000 });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.evidenceRowsSeeded).toBe(DEMO_EVIDENCE.length);
+      expect(result.value.sentinelWritten).toBe(true);
+    }
+    expect(existsSync(demoDbPath)).toBe(true);
+
+    // Inspect the DB independently to prove the seeded rows are queryable.
+    const handle = createDb({ path: demoDbPath });
+    try {
+      const rows = handle.db.select().from(evidenceLog).all();
+      expect(rows.length).toBe(DEMO_EVIDENCE.length);
+      // Both integrations are represented.
+      const githubCount = rows.filter((r) => r.integration === 'github').length;
+      const slackCount = rows.filter((r) => r.integration === 'slack').length;
+      expect(githubCount).toBeGreaterThan(0);
+      expect(slackCount).toBeGreaterThan(0);
+
+      // Sentinel row is present.
+      expect(isDemoDb({ db: handle.db })).toBe(true);
+      const sentinel = handle.db
+        .select()
+        .from(integrationState)
+        .all()
+        .find((r) => r.integration === DEMO_SENTINEL_INTEGRATION);
+      expect(sentinel).toBeDefined();
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('is idempotent — re-seeding does not duplicate rows', async () => {
+    const first = await seedDemoDb({ demoDbPath, now: 1_700_000_000_000 });
+    expect(first.isOk()).toBe(true);
+    const second = await seedDemoDb({ demoDbPath, now: 1_700_000_100_000 });
+    expect(second.isOk()).toBe(true);
+
+    const handle = createDb({ path: demoDbPath });
+    try {
+      const rows = handle.db.select().from(evidenceLog).all();
+      expect(rows.length).toBe(DEMO_EVIDENCE.length);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('runDemoSeed exits 0 and prints the seeded path to stdout', async () => {
+    const stdout = { write: vi.fn() };
+    const stderr = { write: vi.fn() };
+    const code = await runDemoSeed({ demoDbPath, stdout, stderr, now: () => 1_700_000_000_000 });
+    expect(code).toBe(0);
+    expect(stderr.write).not.toHaveBeenCalled();
+    const combined = stdout.write.mock.calls.map((c) => c[0]).join('');
+    expect(combined).toContain(demoDbPath);
+    expect(combined).toContain('SLOPWEAVER_DEMO=1');
+  });
+});
+
+describe('runDemoReset', () => {
+  let tmp: string;
+  let demoDbPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'slopweaver-demo-reset-'));
+    demoDbPath = resolve(tmp, 'demo.db');
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('drops an existing demo DB and re-seeds it', async () => {
+    // Seed first.
+    const seed = await seedDemoDb({ demoDbPath, now: 1_700_000_000_000 });
+    expect(seed.isOk()).toBe(true);
+
+    // Reset.
+    const stdout = { write: vi.fn() };
+    const stderr = { write: vi.fn() };
+    const code = await runDemoReset({ demoDbPath, stdout, stderr, now: () => 1_700_000_500_000 });
+    expect(code).toBe(0);
+    expect(existsSync(demoDbPath)).toBe(true);
+
+    const combined = stdout.write.mock.calls.map((c) => c[0]).join('');
+    expect(combined).toContain('removed existing demo DB');
+  });
+
+  it('is a no-op-then-seed when the demo DB does not exist', async () => {
+    const stdout = { write: vi.fn() };
+    const stderr = { write: vi.fn() };
+    const code = await runDemoReset({ demoDbPath, stdout, stderr, now: () => 1_700_000_500_000 });
+    expect(code).toBe(0);
+    expect(existsSync(demoDbPath)).toBe(true);
+    const combined = stdout.write.mock.calls.map((c) => c[0]).join('');
+    expect(combined).not.toContain('removed existing demo DB');
+  });
+});
+
+describe('runDemoExit / dropDemoDbFile', () => {
+  let tmp: string;
+  let demoDbPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'slopweaver-demo-exit-'));
+    demoDbPath = resolve(tmp, 'demo.db');
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('removes a seeded demo DB', async () => {
+    await seedDemoDb({ demoDbPath, now: 1_700_000_000_000 });
+    expect(existsSync(demoDbPath)).toBe(true);
+
+    const stdout = { write: vi.fn() };
+    const stderr = { write: vi.fn() };
+    const code = await runDemoExit({ demoDbPath, stdout, stderr });
+    expect(code).toBe(0);
+    expect(existsSync(demoDbPath)).toBe(false);
+  });
+
+  it('succeeds silently when no demo DB is present', async () => {
+    const stdout = { write: vi.fn() };
+    const stderr = { write: vi.fn() };
+    const code = await runDemoExit({ demoDbPath, stdout, stderr });
+    expect(code).toBe(0);
+    expect(stderr.write).not.toHaveBeenCalled();
+    const combined = stdout.write.mock.calls.map((c) => c[0]).join('');
+    expect(combined).toContain('no demo DB present');
+  });
+
+  it('dropDemoDbFile returns removed:false when nothing exists', async () => {
+    const result = await dropDemoDbFile({ demoDbPath });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.removed).toBe(false);
+    }
   });
 });

--- a/apps/mcp-local/src/demo/index.ts
+++ b/apps/mcp-local/src/demo/index.ts
@@ -131,8 +131,11 @@ export type DemoExitDeps = {
 };
 
 /**
- * Remove the demo DB file. The real DB (`slopweaver.db`) is untouched
- * — future `slopweaver` invocations without `--demo` already use it.
+ * Remove the demo DB file. This does NOT change the MCP client config or
+ * the `SLOPWEAVER_DEMO` env var — if either of those still points the
+ * server at demo mode, the next launch will open an empty demo DB. The
+ * stdout copy reflects that: to actually return to real mode the user
+ * has to restart the server without `--demo` (and clear the env var).
  * Idempotent: succeeds silently if the demo DB doesn't exist.
  */
 export async function runDemoExit(deps: DemoExitDeps): Promise<number> {
@@ -146,7 +149,9 @@ export async function runDemoExit(deps: DemoExitDeps): Promise<number> {
   } else {
     deps.stdout.write('slopweaver: no demo DB present; nothing to remove.\n');
   }
-  deps.stdout.write('slopweaver: start the server without --demo to use your real DB.\n');
+  deps.stdout.write(
+    'slopweaver: exit removes the demo DB. To return to real mode, restart the server without --demo (or unset SLOPWEAVER_DEMO).\n',
+  );
   return 0;
 }
 

--- a/apps/mcp-local/src/demo/index.ts
+++ b/apps/mcp-local/src/demo/index.ts
@@ -1,24 +1,382 @@
 /**
- * `slopweaver demo` — print a synthetic /session-start snapshot to
- * stdout. Zero-friction try-before-BYOK: a stranger can run this
- * after `npm install -g slopweaver` and see what a populated
- * snapshot looks like without connecting Slack / GitHub / Gmail /
- * anything.
+ * `slopweaver demo` — try-before-BYOK demo mode.
  *
- * v1.1 first cut is a canned snapshot (the synthetic-persona
- * string). A v1.2 follow-up replaces this with a cassette-replay of
- * a real cold-start against a fixture workspace, so the output
- * varies a little run-to-run and feels more authentic. The CLI
- * surface stays the same — only the data source changes.
+ * Three subcommands plus a bare default:
+ *
+ * - `slopweaver demo` — print the {@link DEMO_SNAPSHOT} synthetic
+ *   `start_session` markdown to stdout. Zero side effects; pure
+ *   read-only screenshot.
+ *
+ * - `slopweaver demo seed` — open a dedicated demo SQLite DB (under
+ *   `<dataDir>/demo.db`, separate from `slopweaver.db`), seed it with
+ *   {@link DEMO_EVIDENCE} synthetic rows, and stamp an
+ *   `integration_state` sentinel row so callers can detect demo mode.
+ *
+ * - `slopweaver demo reset` — drop the demo DB and re-seed it. Useful
+ *   when the synthetic data has drifted (e.g. timestamps now look
+ *   ancient) or after a schema bump.
+ *
+ * - `slopweaver demo exit` — delete the demo DB. Future `slopweaver`
+ *   invocations without `--demo` already use the real
+ *   `slopweaver.db`; this just cleans up the demo file so disk usage
+ *   isn't left behind.
+ *
+ * The MCP server (`runMcpServer` in `cli.ts`) accepts a `--demo` flag
+ * (or `SLOPWEAVER_DEMO=1`) to point its DB resolver at `demo.db`
+ * instead of `slopweaver.db`. Once that flag is set, the *real*
+ * `start_session` tool serves the synthetic rows seeded here — the
+ * demo isn't a separate code path, it's the same product running
+ * against a separate database file.
+ *
+ * Note: this module manipulates SQLite directly and so follows the
+ * service-boundary rule (no throws). All failure modes funnel through
+ * the typed Result returned by the helpers below, which the CLI
+ * boundary unwraps in `cli.ts`.
  */
 
-import { DEMO_SNAPSHOT } from './synthetic-persona.ts';
+import { existsSync, unlinkSync } from 'node:fs';
+import { createDb, integrationState, safeQuery, type SlopweaverDatabase } from '@slopweaver/db';
+import type { BaseError, DatabaseError } from '@slopweaver/errors';
+import { okAsync, ResultAsync } from '@slopweaver/errors';
+import { upsertEvidence } from '@slopweaver/integrations-core';
+import { eq } from 'drizzle-orm';
+import { DEMO_EVIDENCE, DEMO_SENTINEL_INTEGRATION, DEMO_SNAPSHOT } from './synthetic-persona.ts';
+
+export interface DemoOperationFailedError extends BaseError {
+  readonly code: 'DEMO_OPERATION_FAILED';
+}
+
+const DemoErrors = {
+  operationFailed: (message: string): DemoOperationFailedError => ({
+    code: 'DEMO_OPERATION_FAILED',
+    message,
+  }),
+} as const;
+
+export type DemoError = DemoOperationFailedError | DatabaseError;
 
 export type RunDemoDeps = {
   stdout: { write: (s: string) => void };
 };
 
+/**
+ * Print the synthetic `start_session` snapshot to stdout. Pure read-only
+ * — no DB, no network. Returns 0 unconditionally (the CLI boundary
+ * translates that to `process.exit(0)`).
+ */
 export async function runDemo(deps: RunDemoDeps): Promise<number> {
   deps.stdout.write(DEMO_SNAPSHOT);
   return 0;
+}
+
+export type DemoSeedDeps = {
+  /**
+   * Absolute path to the demo SQLite file. Resolve via `resolveDemoDbPath()`
+   * at the CLI boundary so XDG validation happens once.
+   */
+  demoDbPath: string;
+  stdout: { write: (s: string) => void };
+  stderr: { write: (s: string) => void };
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  now?: () => number;
+};
+
+/**
+ * Seed the demo DB with {@link DEMO_EVIDENCE} synthetic rows plus a
+ * sentinel `integration_state` row identifying the DB as demo state.
+ *
+ * Idempotent: existing rows with matching `(integration, external_id)`
+ * are updated in place via `upsertEvidence`'s conflict-on-update path,
+ * so re-running `demo seed` against an already-seeded DB refreshes the
+ * timestamps without duplicating rows. The sentinel row is upserted on
+ * each call.
+ */
+export async function runDemoSeed(deps: DemoSeedDeps): Promise<number> {
+  const result = await seedDemoDb({ demoDbPath: deps.demoDbPath, now: (deps.now ?? Date.now)() });
+  if (result.isErr()) {
+    deps.stderr.write(`slopweaver: demo seed failed: ${result.error.message}\n`);
+    return 1;
+  }
+  deps.stdout.write(
+    `slopweaver: seeded ${String(result.value.evidenceRowsSeeded)} synthetic evidence rows into ${deps.demoDbPath}\n`,
+  );
+  deps.stdout.write('slopweaver: enable demo mode by passing --demo or setting SLOPWEAVER_DEMO=1 on the MCP server.\n');
+  return 0;
+}
+
+export type DemoResetDeps = DemoSeedDeps;
+
+/**
+ * Drop the demo DB file (if any) and seed a fresh one. The drop is
+ * file-level rather than `DROP TABLE` so the demo schema always
+ * matches the current Drizzle migrations — no manual migration
+ * gymnastics required.
+ */
+export async function runDemoReset(deps: DemoResetDeps): Promise<number> {
+  const dropResult = await dropDemoDbFile({ demoDbPath: deps.demoDbPath });
+  if (dropResult.isErr()) {
+    deps.stderr.write(`slopweaver: demo reset failed: ${dropResult.error.message}\n`);
+    return 1;
+  }
+  if (dropResult.value.removed) {
+    deps.stdout.write(`slopweaver: removed existing demo DB at ${deps.demoDbPath}\n`);
+  }
+  return runDemoSeed(deps);
+}
+
+export type DemoExitDeps = {
+  demoDbPath: string;
+  stdout: { write: (s: string) => void };
+  stderr: { write: (s: string) => void };
+};
+
+/**
+ * Remove the demo DB file. The real DB (`slopweaver.db`) is untouched
+ * — future `slopweaver` invocations without `--demo` already use it.
+ * Idempotent: succeeds silently if the demo DB doesn't exist.
+ */
+export async function runDemoExit(deps: DemoExitDeps): Promise<number> {
+  const dropResult = await dropDemoDbFile({ demoDbPath: deps.demoDbPath });
+  if (dropResult.isErr()) {
+    deps.stderr.write(`slopweaver: demo exit failed: ${dropResult.error.message}\n`);
+    return 1;
+  }
+  if (dropResult.value.removed) {
+    deps.stdout.write(`slopweaver: demo DB removed (${deps.demoDbPath}).\n`);
+  } else {
+    deps.stdout.write('slopweaver: no demo DB present; nothing to remove.\n');
+  }
+  deps.stdout.write('slopweaver: start the server without --demo to use your real DB.\n');
+  return 0;
+}
+
+/**
+ * Result of {@link seedDemoDb}: how many evidence rows were upserted
+ * and whether the sentinel row was newly created.
+ */
+interface DemoSeedSummary {
+  readonly evidenceRowsSeeded: number;
+  readonly sentinelWritten: boolean;
+}
+
+/**
+ * Core seed logic — open the demo DB, upsert every {@link DEMO_EVIDENCE}
+ * row, stamp the sentinel `integration_state` row, close the handle.
+ * Exported for tests; the CLI calls it via {@link runDemoSeed}.
+ */
+export function seedDemoDb({
+  demoDbPath,
+  now,
+}: {
+  demoDbPath: string;
+  now: number;
+}): ResultAsync<DemoSeedSummary, DemoError> {
+  return openDemoDb({ demoDbPath }).andThen((handle) =>
+    seedEvidenceRows({ db: handle.db, now })
+      .andThen((evidenceRowsSeeded) =>
+        // Stamp `integration_state` for each integration we just seeded.
+        // Without this, `start_session` would think the demo DB has
+        // "never polled" any integration, treat all the cached evidence
+        // as stale, and refuse to surface it (the no-poller branch
+        // skips refresh but the integration is still listed in
+        // freshness as stale). Writing a completed-poll marker per
+        // integration mirrors what a real poll cycle would do.
+        seedIntegrationStateForDemo({ db: handle.db, now }).andThen(() =>
+          upsertSentinelState({ db: handle.db, now }).map(() => ({
+            evidenceRowsSeeded,
+            sentinelWritten: true,
+          })),
+        ),
+      )
+      .map((summary) => {
+        // Close on success; the file lock is released so a subsequent
+        // `start_session --demo` invocation can open the same file.
+        handle.close();
+        return summary;
+      })
+      .mapErr((error) => {
+        // Close on failure too. The caller is free to retry or inspect
+        // the partially-seeded file; leaving the file lock held would
+        // block both.
+        handle.close();
+        return error;
+      }),
+  );
+}
+
+interface DemoSeedHandle {
+  readonly db: SlopweaverDatabase;
+  readonly close: () => void;
+}
+
+/**
+ * Open the demo DB. `createDb` runs Drizzle migrations and may throw
+ * (parent-dir creation, sqlite native init) — lift those into a Result
+ * so callers don't need a separate try/catch.
+ */
+function openDemoDb({ demoDbPath }: { demoDbPath: string }): ResultAsync<DemoSeedHandle, DemoOperationFailedError> {
+  return ResultAsync.fromPromise(
+    // `createDb` is synchronous; wrap in Promise.resolve so any
+    // synchronous throw lands in the rejection branch. Without this
+    // wrapper a throw would propagate out of `fromPromise` itself.
+    Promise.resolve().then(() => {
+      const handle = createDb({ path: demoDbPath });
+      return { db: handle.db, close: handle.close };
+    }),
+    (error): DemoOperationFailedError =>
+      DemoErrors.operationFailed(
+        `failed to open demo DB at ${demoDbPath}: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+  );
+}
+
+/**
+ * Iteratively upsert every {@link DEMO_EVIDENCE} row. Returns the
+ * count of rows seeded on success; short-circuits to the underlying
+ * `DatabaseError` if any row fails.
+ */
+function seedEvidenceRows({ db, now }: { db: SlopweaverDatabase; now: number }): ResultAsync<number, DatabaseError> {
+  const step = (index: number, count: number): ResultAsync<number, DatabaseError> => {
+    if (index >= DEMO_EVIDENCE.length) return okAsync(count);
+    const row = DEMO_EVIDENCE[index];
+    if (row === undefined) return okAsync(count);
+    const occurredAtMs = now + row.occurredAtOffsetMs;
+    return upsertEvidence({
+      db,
+      integration: row.integration,
+      externalId: row.externalId,
+      kind: row.kind,
+      title: row.title,
+      body: row.body,
+      citationUrl: row.citationUrl,
+      payloadJson: row.payloadJson,
+      occurredAtMs,
+      now,
+    }).andThen(() => step(index + 1, count + 1));
+  };
+  return step(0, 0);
+}
+
+/**
+ * Stamp an `integration_state` row for each integration represented
+ * in {@link DEMO_EVIDENCE} so `start_session` considers them
+ * "recently polled" instead of "never polled". Without this, the
+ * default `start_session` path would have `requested = []` (no
+ * pollers, no state rows for the shipped integrations) and return an
+ * empty response despite the evidence rows being present.
+ */
+function seedIntegrationStateForDemo({
+  db,
+  now,
+}: {
+  db: SlopweaverDatabase;
+  now: number;
+}): ResultAsync<void, DatabaseError> {
+  const integrations = Array.from(new Set(DEMO_EVIDENCE.map((row) => row.integration)));
+  return safeQuery({
+    execute: () => {
+      for (const integration of integrations) {
+        const existing = db
+          .select({ integration: integrationState.integration })
+          .from(integrationState)
+          .where(eq(integrationState.integration, integration))
+          .get();
+        if (existing === undefined) {
+          db.insert(integrationState)
+            .values({
+              integration,
+              cursor: 'demo',
+              lastPollStartedAtMs: now,
+              lastPollCompletedAtMs: now,
+              createdAtMs: now,
+              updatedAtMs: now,
+            })
+            .run();
+        } else {
+          db.update(integrationState)
+            .set({
+              lastPollStartedAtMs: now,
+              lastPollCompletedAtMs: now,
+              updatedAtMs: now,
+            })
+            .where(eq(integrationState.integration, integration))
+            .run();
+        }
+      }
+    },
+  });
+}
+
+/**
+ * Insert (or refresh) the sentinel row that marks this DB as demo
+ * state. Service code never reads this row to make decisions — it's
+ * purely a label for the Diagnostics UI / future `doctor` command.
+ */
+function upsertSentinelState({ db, now }: { db: SlopweaverDatabase; now: number }): ResultAsync<void, DatabaseError> {
+  return safeQuery({
+    execute: () => {
+      const existing = db
+        .select({ integration: integrationState.integration })
+        .from(integrationState)
+        .where(eq(integrationState.integration, DEMO_SENTINEL_INTEGRATION))
+        .get();
+      if (existing === undefined) {
+        db.insert(integrationState)
+          .values({
+            integration: DEMO_SENTINEL_INTEGRATION,
+            cursor: 'demo',
+            lastPollStartedAtMs: now,
+            lastPollCompletedAtMs: now,
+            createdAtMs: now,
+            updatedAtMs: now,
+          })
+          .run();
+      } else {
+        db.update(integrationState)
+          .set({
+            lastPollStartedAtMs: now,
+            lastPollCompletedAtMs: now,
+            updatedAtMs: now,
+          })
+          .where(eq(integrationState.integration, DEMO_SENTINEL_INTEGRATION))
+          .run();
+      }
+    },
+  });
+}
+
+/**
+ * Remove the demo DB file. Returns `{ removed: true }` if the file
+ * existed and was deleted, `{ removed: false }` if nothing was there.
+ * The Result wraps an `unlinkSync` failure (e.g. permission denied)
+ * into a `DEMO_OPERATION_FAILED` error so the CLI boundary can print
+ * a clean message.
+ */
+export function dropDemoDbFile({
+  demoDbPath,
+}: {
+  demoDbPath: string;
+}): ResultAsync<{ removed: boolean }, DemoOperationFailedError> {
+  if (!existsSync(demoDbPath)) return okAsync({ removed: false });
+  return safeQuery({
+    execute: () => {
+      unlinkSync(demoDbPath);
+      return { removed: true };
+    },
+  }).mapErr((error) => DemoErrors.operationFailed(`failed to remove demo DB at ${demoDbPath}: ${error.message}`));
+}
+
+/**
+ * Check whether the supplied DB is currently in demo mode (i.e. has
+ * the {@link DEMO_SENTINEL_INTEGRATION} row in `integration_state`).
+ * Exposed so the Diagnostics UI / future `doctor` command can label
+ * demo profiles without re-deriving the file path.
+ */
+export function isDemoDb({ db }: { db: SlopweaverDatabase }): boolean {
+  const row = db
+    .select({ integration: integrationState.integration })
+    .from(integrationState)
+    .where(eq(integrationState.integration, DEMO_SENTINEL_INTEGRATION))
+    .get();
+  return row !== undefined;
 }

--- a/apps/mcp-local/src/demo/index.ts
+++ b/apps/mcp-local/src/demo/index.ts
@@ -1,0 +1,24 @@
+/**
+ * `slopweaver demo` — print a synthetic /session-start snapshot to
+ * stdout. Zero-friction try-before-BYOK: a stranger can run this
+ * after `npm install -g slopweaver` and see what a populated
+ * snapshot looks like without connecting Slack / GitHub / Gmail /
+ * anything.
+ *
+ * v1.1 first cut is a canned snapshot (the synthetic-persona
+ * string). A v1.2 follow-up replaces this with a cassette-replay of
+ * a real cold-start against a fixture workspace, so the output
+ * varies a little run-to-run and feels more authentic. The CLI
+ * surface stays the same — only the data source changes.
+ */
+
+import { DEMO_SNAPSHOT } from './synthetic-persona.ts';
+
+export type RunDemoDeps = {
+  stdout: { write: (s: string) => void };
+};
+
+export async function runDemo(deps: RunDemoDeps): Promise<number> {
+  deps.stdout.write(DEMO_SNAPSHOT);
+  return 0;
+}

--- a/apps/mcp-local/src/demo/synthetic-persona.ts
+++ b/apps/mcp-local/src/demo/synthetic-persona.ts
@@ -1,0 +1,74 @@
+/**
+ * Synthetic persona used by `slopweaver demo`. Generic enough to
+ * apply broadly — an open-source maintainer juggling a couple of
+ * PRs, a Slack inbox with a few unanswered threads, and a sprint
+ * planning meeting later in the day.
+ *
+ * No real names, no real workspaces. The point is to convey *shape*
+ * — what a populated `/session-start` snapshot looks like — without
+ * needing tokens or real platform connections.
+ */
+
+export const DEMO_SNAPSHOT = `# /session-start (demo)
+
+**Branch:** \`ai-work-console\` · **Console:** initialized · **Identity:** open-source maintainer (synthetic persona)
+
+**Sources polled this run:** Slack ✓ · GitHub ✓ · Linear ✗ (not connected) · Gmail ✓ · Calendar ✓
+
+---
+
+### Reconciliation diff
+
+**[propose-close]** — looks done, propose checking off
+- **[#412](https://example.com/repo/pull/412)** — auth middleware migration. PR merged 14 hours ago by a project co-maintainer; CI green; no outstanding review threads. Proposed: tick the matching work-file line.
+
+**[propose-update]** — state shifted but not done
+- **[ABC-83](https://example.com/issue/abc-83)** — moved to "In Review" overnight. The work file still says "drafting"; rewrite to "awaiting review".
+
+**[inbox]** — surfaced in deltas, not yet in work file
+- **[#418](https://example.com/repo/pull/418)** — review requested by another maintainer 6 hours ago. CI passing. Propose adding to Active asks owed.
+
+### Outstanding next actions (priority order)
+
+1. Reply to a question on **[#418](https://example.com/repo/pull/418)** about backwards-compat for the v2 config schema. Reviewer is waiting; no other blockers.
+2. Finish the deploy-runbook draft for the planning meeting at 17:00 local time (calendar item below).
+3. Triage 3 inbound issues filed overnight — heuristically scoped as low-priority, but the issue tracker UI shows them as new.
+
+### Slack — needs response
+
+- **#proj-channel** — _Has anyone seen the failure mode on the staging deploy?_ Posted 4 hours ago. No replies yet. You're the natural owner.
+
+### Gmail — needs reply
+
+_(none — single unread is a calendar invite already on the books)_
+
+### GitHub — needs reply / failed CI
+
+- **[#418](https://example.com/repo/pull/418)** — _Is the v2 config schema backwards-compatible?_ from another maintainer. Last comment 6h ago.
+
+### Recently done (last 7d)
+
+3 PRs merged this week (#410, #411, #412). One issue closed (ABC-79).
+
+### Calendar today
+
+- 11:00–11:30 — community-call standup (recurring, accepted)
+- 17:00–18:00 — release-cycle planning (needsAction — please respond)
+
+### Calibration trend
+
+Acceptance rate this week: **78%** (up from 64% last week). Top friction tag: \`friction:wrong-tone\` × 3 (down from 7 last week).
+
+---
+
+**What are we working on this session?**
+
+(Reasonable picks: reply to #418 → finish runbook → respond to community-call invite.)
+
+---
+
+> _This is the \`slopweaver demo\` synthetic persona. A real
+> \`/session-start\` populates this from your connected MCP servers
+> (Slack, GitHub, Linear, Gmail, Google Calendar, etc.). To try it
+> with your own data: \`claude mcp add slopweaver\` then \`/session-start\`._
+`;

--- a/apps/mcp-local/src/demo/synthetic-persona.ts
+++ b/apps/mcp-local/src/demo/synthetic-persona.ts
@@ -1,59 +1,324 @@
 /**
- * Synthetic persona used by `slopweaver demo`. Generic enough to
- * apply broadly — an open-source maintainer juggling a couple of
- * PRs, a Slack inbox with a few unanswered threads, and a sprint
- * planning meeting later in the day.
+ * Synthetic persona used by `slopweaver demo`. A generic open-source
+ * maintainer juggling a couple of PRs, a Slack inbox with unanswered
+ * threads, and the usual mid-week churn. No real names, no real
+ * workspaces.
  *
- * No real names, no real workspaces. The point is to convey *shape*
- * — what a populated `/session-start` snapshot looks like — without
- * needing tokens or real platform connections.
+ * Two surfaces live here:
+ *
+ * 1. {@link DEMO_SNAPSHOT} — the human-readable summary printed by the
+ *    bare `slopweaver demo` command. It conveys *shape* — what a
+ *    populated `start_session` response looks like — without tokens or
+ *    live integrations.
+ *
+ * 2. {@link DEMO_EVIDENCE} — synthetic `evidence_log` rows seeded by
+ *    `slopweaver demo seed` into the demo DB. With these rows present,
+ *    the real `start_session` MCP tool serves the demo state instead
+ *    of empty cache, so a first-time user can drive the actual flow
+ *    against synthetic data.
+ *
+ * **Capability scope.** Only GitHub and Slack are seeded — those are the
+ * two integrations that ship in v1.0. Linear / Gmail / Calendar are
+ * intentionally omitted so the demo can't claim a richer product than
+ * the binary actually delivers. When those integrations land, add
+ * synthetic rows here and bump the snapshot to match.
  */
 
-export const DEMO_SNAPSHOT = `# /session-start (demo)
+/**
+ * Row shape used to seed `evidence_log`. Mirrors the columns the
+ * `@slopweaver/integrations-core` `upsertEvidence` helper accepts so the
+ * seeder can call it directly. `occurredAtOffsetMs` is a *negative* offset
+ * from "now" so the snapshot stays fresh-looking regardless of when the
+ * user runs `demo seed`.
+ */
+interface DemoEvidence {
+  readonly integration: 'github' | 'slack';
+  readonly externalId: string;
+  readonly kind: string;
+  readonly title: string;
+  readonly body: string | null;
+  readonly citationUrl: string | null;
+  readonly payloadJson: string;
+  /** Negative ms offset from "now": -3_600_000 → "1 hour ago". */
+  readonly occurredAtOffsetMs: number;
+}
+
+/**
+ * Synthetic evidence seeded into the demo DB. Sized so `start_session`
+ * (which caps at 25 items) has more rows than it shows, exercising the
+ * ranking heuristic instead of trivially returning every row. ~12
+ * GitHub and ~10 Slack rows.
+ */
+export const DEMO_EVIDENCE: readonly DemoEvidence[] = [
+  // ── GitHub ──────────────────────────────────────────────────────────
+  {
+    integration: 'github',
+    externalId: 'demo-pr-418',
+    kind: 'review_request',
+    title: 'demo/repo#418: backwards-compat shim for v2 config schema',
+    body: 'Reviewer asked: is the v2 config schema backwards-compatible? Last comment 6h ago.',
+    citationUrl: 'https://example.com/demo/repo/pull/418',
+    payloadJson: '{"demo":true,"kind":"review_request","number":418}',
+    occurredAtOffsetMs: -6 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-pr-417',
+    kind: 'pull_request',
+    title: 'demo/repo#417: drop legacy /v1 endpoint',
+    body: 'CI green; awaiting one more approval.',
+    citationUrl: 'https://example.com/demo/repo/pull/417',
+    payloadJson: '{"demo":true,"kind":"pull_request","number":417}',
+    occurredAtOffsetMs: -10 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-pr-412',
+    kind: 'pull_request',
+    title: 'demo/repo#412: auth middleware migration (merged)',
+    body: 'Merged 14h ago by a co-maintainer; CI green; no outstanding threads.',
+    citationUrl: 'https://example.com/demo/repo/pull/412',
+    payloadJson: '{"demo":true,"kind":"pull_request","number":412,"state":"merged"}',
+    occurredAtOffsetMs: -14 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-issue-204',
+    kind: 'mention',
+    title: 'demo/repo#204: @you can you confirm the failure mode?',
+    body: 'Mentioned in a triage thread for a flaky CI signal.',
+    citationUrl: 'https://example.com/demo/repo/issues/204',
+    payloadJson: '{"demo":true,"kind":"mention","number":204}',
+    occurredAtOffsetMs: -3 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-issue-201',
+    kind: 'issue',
+    title: 'demo/repo#201: typo in docs/quickstart.md',
+    body: 'Low-priority drive-by from an external contributor.',
+    citationUrl: 'https://example.com/demo/repo/issues/201',
+    payloadJson: '{"demo":true,"kind":"issue","number":201}',
+    occurredAtOffsetMs: -8 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-issue-198',
+    kind: 'issue',
+    title: 'demo/repo#198: rate-limit retry has off-by-one on the third attempt',
+    body: 'Reproducible — has a repro script attached.',
+    citationUrl: 'https://example.com/demo/repo/issues/198',
+    payloadJson: '{"demo":true,"kind":"issue","number":198}',
+    occurredAtOffsetMs: -22 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-issue-195',
+    kind: 'issue',
+    title: 'demo/repo#195: add Linear integration',
+    body: 'Feature request; no PR yet.',
+    citationUrl: 'https://example.com/demo/repo/issues/195',
+    payloadJson: '{"demo":true,"kind":"issue","number":195}',
+    occurredAtOffsetMs: -30 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-pr-411',
+    kind: 'pull_request',
+    title: 'demo/repo#411: refactor poller registry (merged)',
+    body: 'Merged 2 days ago.',
+    citationUrl: 'https://example.com/demo/repo/pull/411',
+    payloadJson: '{"demo":true,"kind":"pull_request","number":411,"state":"merged"}',
+    occurredAtOffsetMs: -2 * 24 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-pr-410',
+    kind: 'pull_request',
+    title: 'demo/repo#410: bump pnpm to 10.4 (merged)',
+    body: 'Merged 2 days ago.',
+    citationUrl: 'https://example.com/demo/repo/pull/410',
+    payloadJson: '{"demo":true,"kind":"pull_request","number":410,"state":"merged"}',
+    occurredAtOffsetMs: -2 * 24 * 60 * 60 * 1000 - 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-pr-415',
+    kind: 'pull_request',
+    title: 'demo/repo#415: extract token-refresh helper',
+    body: 'Open; CI yellow (one flake retried).',
+    citationUrl: 'https://example.com/demo/repo/pull/415',
+    payloadJson: '{"demo":true,"kind":"pull_request","number":415}',
+    occurredAtOffsetMs: -18 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-pr-419',
+    kind: 'review_request',
+    title: 'demo/repo#419: add structured logging wrapper',
+    body: 'Review requested; small diff, looks straightforward.',
+    citationUrl: 'https://example.com/demo/repo/pull/419',
+    payloadJson: '{"demo":true,"kind":"review_request","number":419}',
+    occurredAtOffsetMs: -1 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'github',
+    externalId: 'demo-issue-205',
+    kind: 'issue',
+    title: 'demo/repo#205: doctor command should print version',
+    body: 'Quick win; one-liner change.',
+    citationUrl: 'https://example.com/demo/repo/issues/205',
+    payloadJson: '{"demo":true,"kind":"issue","number":205}',
+    occurredAtOffsetMs: -45 * 60 * 1000,
+  },
+
+  // ── Slack ───────────────────────────────────────────────────────────
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700001',
+    kind: 'mention',
+    title: '#proj-channel: @you can you confirm the staging deploy failure mode?',
+    body: 'Direct mention. No replies yet; you are the natural owner.',
+    citationUrl: 'https://example.com/demo-workspace/proj-channel/p1700001',
+    payloadJson: '{"demo":true,"kind":"mention","channel":"proj-channel"}',
+    occurredAtOffsetMs: -4 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700002',
+    kind: 'dm',
+    title: 'DM from a maintainer: hey, quick question about the v2 schema',
+    body: 'Single DM. Last activity 2h ago.',
+    citationUrl: 'https://example.com/demo-workspace/dm/p1700002',
+    payloadJson: '{"demo":true,"kind":"dm"}',
+    occurredAtOffsetMs: -2 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700003',
+    kind: 'mention',
+    title: '#triage: @you triage these 3 inbound issues',
+    body: 'Triage assignment from overnight intake.',
+    citationUrl: 'https://example.com/demo-workspace/triage/p1700003',
+    payloadJson: '{"demo":true,"kind":"mention","channel":"triage"}',
+    occurredAtOffsetMs: -7 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700004',
+    kind: 'message',
+    title: '#announcements: release-cycle planning is at 17:00 today',
+    body: 'Calendar reminder posted to the team channel.',
+    citationUrl: 'https://example.com/demo-workspace/announcements/p1700004',
+    payloadJson: '{"demo":true,"kind":"message","channel":"announcements"}',
+    occurredAtOffsetMs: -5 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700005',
+    kind: 'message',
+    title: '#standup: thread from yesterday',
+    body: 'Catch-up read; no action required.',
+    citationUrl: 'https://example.com/demo-workspace/standup/p1700005',
+    payloadJson: '{"demo":true,"kind":"message","channel":"standup"}',
+    occurredAtOffsetMs: -20 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700006',
+    kind: 'mention',
+    title: '#proj-channel: @you can you review #418 today?',
+    body: 'Cross-reference to the PR review request above.',
+    citationUrl: 'https://example.com/demo-workspace/proj-channel/p1700006',
+    payloadJson: '{"demo":true,"kind":"mention","channel":"proj-channel"}',
+    occurredAtOffsetMs: -90 * 60 * 1000,
+  },
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700007',
+    kind: 'dm',
+    title: 'DM: thanks for the merge on #412!',
+    body: 'Already-resolved thanks; no reply needed.',
+    citationUrl: 'https://example.com/demo-workspace/dm/p1700007',
+    payloadJson: '{"demo":true,"kind":"dm"}',
+    occurredAtOffsetMs: -12 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700008',
+    kind: 'message',
+    title: '#proj-channel: anyone else seeing the staging deploy failure?',
+    body: 'No mention — but you are the natural owner. Posted 4h ago.',
+    citationUrl: 'https://example.com/demo-workspace/proj-channel/p1700008',
+    payloadJson: '{"demo":true,"kind":"message","channel":"proj-channel"}',
+    occurredAtOffsetMs: -4 * 60 * 60 * 1000 - 30 * 60 * 1000,
+  },
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700009',
+    kind: 'mention',
+    title: '#design: @you ping when the release-cycle deck is ready',
+    body: 'Soft mention; deadline is the 17:00 meeting.',
+    citationUrl: 'https://example.com/demo-workspace/design/p1700009',
+    payloadJson: '{"demo":true,"kind":"mention","channel":"design"}',
+    occurredAtOffsetMs: -3 * 60 * 60 * 1000,
+  },
+  {
+    integration: 'slack',
+    externalId: 'demo-msg-1700010',
+    kind: 'message',
+    title: '#community: question about the demo command',
+    body: 'A community member asked how `slopweaver demo` works. No mention.',
+    citationUrl: 'https://example.com/demo-workspace/community/p1700010',
+    payloadJson: '{"demo":true,"kind":"message","channel":"community"}',
+    occurredAtOffsetMs: -25 * 60 * 60 * 1000,
+  },
+];
+
+/**
+ * Sentinel value written into `integration_state` when the demo DB is
+ * seeded. The presence of a row with `integration = '__demo__'` is how
+ * the Diagnostics UI / future `doctor` command identifies the demo
+ * profile without re-reading the path. Service code should never check
+ * this value for branching logic — it's purely a label.
+ */
+export const DEMO_SENTINEL_INTEGRATION = '__demo__';
+
+export const DEMO_SNAPSHOT = `# start_session (demo)
 
 **Branch:** \`ai-work-console\` · **Console:** initialized · **Identity:** open-source maintainer (synthetic persona)
 
-**Sources polled this run:** Slack ✓ · GitHub ✓ · Linear ✗ (not connected) · Gmail ✓ · Calendar ✓
+**Sources polled this run:** Slack ✓ · GitHub ✓
+
+> _Linear, Gmail, and Google Calendar are planned for v1.1+. The demo
+> only covers the integrations that actually ship in v1.0._
 
 ---
 
 ### Reconciliation diff
 
 **[propose-close]** — looks done, propose checking off
-- **[#412](https://example.com/repo/pull/412)** — auth middleware migration. PR merged 14 hours ago by a project co-maintainer; CI green; no outstanding review threads. Proposed: tick the matching work-file line.
-
-**[propose-update]** — state shifted but not done
-- **[ABC-83](https://example.com/issue/abc-83)** — moved to "In Review" overnight. The work file still says "drafting"; rewrite to "awaiting review".
+- **[#412](https://example.com/demo/repo/pull/412)** — auth middleware migration. PR merged 14 hours ago by a project co-maintainer; CI green; no outstanding review threads. Proposed: tick the matching work-file line.
 
 **[inbox]** — surfaced in deltas, not yet in work file
-- **[#418](https://example.com/repo/pull/418)** — review requested by another maintainer 6 hours ago. CI passing. Propose adding to Active asks owed.
+- **[#418](https://example.com/demo/repo/pull/418)** — review requested by another maintainer 6 hours ago. CI passing. Propose adding to Active asks owed.
 
 ### Outstanding next actions (priority order)
 
-1. Reply to a question on **[#418](https://example.com/repo/pull/418)** about backwards-compat for the v2 config schema. Reviewer is waiting; no other blockers.
-2. Finish the deploy-runbook draft for the planning meeting at 17:00 local time (calendar item below).
-3. Triage 3 inbound issues filed overnight — heuristically scoped as low-priority, but the issue tracker UI shows them as new.
+1. Reply to a question on **[#418](https://example.com/demo/repo/pull/418)** about backwards-compat for the v2 config schema. Reviewer is waiting; no other blockers.
+2. Triage 3 inbound issues mentioned in #triage on Slack — scoped low-priority but worth a one-pass read.
 
 ### Slack — needs response
 
-- **#proj-channel** — _Has anyone seen the failure mode on the staging deploy?_ Posted 4 hours ago. No replies yet. You're the natural owner.
-
-### Gmail — needs reply
-
-_(none — single unread is a calendar invite already on the books)_
+- **#proj-channel** — _can you confirm the staging deploy failure mode?_ Posted 4 hours ago. Direct mention. You're the natural owner.
 
 ### GitHub — needs reply / failed CI
 
-- **[#418](https://example.com/repo/pull/418)** — _Is the v2 config schema backwards-compatible?_ from another maintainer. Last comment 6h ago.
+- **[#418](https://example.com/demo/repo/pull/418)** — _Is the v2 config schema backwards-compatible?_ from another maintainer. Last comment 6h ago.
 
 ### Recently done (last 7d)
 
-3 PRs merged this week (#410, #411, #412). One issue closed (ABC-79).
-
-### Calendar today
-
-- 11:00–11:30 — community-call standup (recurring, accepted)
-- 17:00–18:00 — release-cycle planning (needsAction — please respond)
+3 PRs merged this week (#410, #411, #412).
 
 ### Calibration trend
 
@@ -63,12 +328,19 @@ Acceptance rate this week: **78%** (up from 64% last week). Top friction tag: \`
 
 **What are we working on this session?**
 
-(Reasonable picks: reply to #418 → finish runbook → respond to community-call invite.)
+(Reasonable picks: reply to #418 → triage #triage backlog → confirm the staging deploy thread.)
 
 ---
 
 > _This is the \`slopweaver demo\` synthetic persona. A real
-> \`/session-start\` populates this from your connected MCP servers
-> (Slack, GitHub, Linear, Gmail, Google Calendar, etc.). To try it
-> with your own data: \`claude mcp add slopweaver\` then \`/session-start\`._
+> \`start_session\` populates this from your connected MCP servers
+> (currently Slack + GitHub; Linear / Gmail / Calendar planned for
+> v1.1+). To drive the actual demo state end-to-end:_
+>
+> 1. \`slopweaver demo seed\` — populate a demo DB with synthetic evidence.
+> 2. Add slopweaver to your MCP client in demo mode (or set \`SLOPWEAVER_DEMO=1\` on the slopweaver process).
+> 3. Ask your MCP client to call the \`start_session\` tool — it serves real evidence rows from the demo DB.
+> 4. \`slopweaver demo exit\` switches your client back to the real DB.
+>
+> _To leave the demo and connect your own data, run \`claude mcp add slopweaver\` then \`slopweaver init\` for the interactive setup._
 `;

--- a/apps/mcp-local/src/demo/synthetic-persona.ts
+++ b/apps/mcp-local/src/demo/synthetic-persona.ts
@@ -340,7 +340,7 @@ Acceptance rate this week: **78%** (up from 64% last week). Top friction tag: \`
 > 1. \`slopweaver demo seed\` — populate a demo DB with synthetic evidence.
 > 2. Add slopweaver to your MCP client in demo mode (or set \`SLOPWEAVER_DEMO=1\` on the slopweaver process).
 > 3. Ask your MCP client to call the \`start_session\` tool — it serves real evidence rows from the demo DB.
-> 4. \`slopweaver demo exit\` switches your client back to the real DB.
+> 4. \`slopweaver demo exit\` removes the demo DB. To return to real mode, restart the server without \`--demo\` (or unset \`SLOPWEAVER_DEMO\`).
 >
 > _To leave the demo and connect your own data, run \`claude mcp add slopweaver\` then \`slopweaver init\` for the interactive setup._
 `;

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
@@ -36,6 +36,7 @@ const SERVICE_BOUNDARY_DIRS: ReadonlyArray<ServiceBoundaryDir> = [
   { dir: 'packages/integrations/slack/src', extensions: ['.ts'] },
   { dir: 'packages/mcp-server/src/tools', extensions: ['.ts'] },
   { dir: 'apps/mcp-local/src/connect', extensions: ['.ts'] },
+  { dir: 'apps/mcp-local/src/demo', extensions: ['.ts'] },
   { dir: 'apps/mcp-local/src/init', extensions: ['.ts'] },
 ];
 

--- a/packages/db/src/path.test.ts
+++ b/packages/db/src/path.test.ts
@@ -9,7 +9,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { resolveDataDir, resolveDbPath } from './path.ts';
+import { resolveDataDir, resolveDbPath, resolveDemoDbPath } from './path.ts';
 
 describe('resolveDataDir', () => {
   it('uses XDG_DATA_HOME when supplied', () => {
@@ -58,6 +58,46 @@ describe('resolveDbPath', () => {
 
   it('propagates DATA_PATH_INVALID from resolveDataDir', () => {
     const result = resolveDbPath({ xdgDataHome: 'tmp/relative' });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('DATA_PATH_INVALID');
+    }
+  });
+});
+
+describe('resolveDemoDbPath', () => {
+  it('appends demo.db (not slopweaver.db) to the XDG-aware data dir', () => {
+    const result = resolveDemoDbPath({ xdgDataHome: '/tmp/xdg' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('/tmp/xdg/slopweaver/demo.db');
+    }
+  });
+
+  it('sits beside slopweaver.db under the same data dir (sibling, not nested)', () => {
+    const real = resolveDbPath({ xdgDataHome: '/tmp/xdg' });
+    const demo = resolveDemoDbPath({ xdgDataHome: '/tmp/xdg' });
+    expect(real.isOk()).toBe(true);
+    expect(demo.isOk()).toBe(true);
+    if (real.isOk() && demo.isOk()) {
+      // Same parent directory; different filename. This is what makes
+      // `slopweaver doctor` / Diagnostics UI work transparently against
+      // either file without a directory remount.
+      expect(real.value.replace(/[^/]+$/, '')).toBe(demo.value.replace(/[^/]+$/, ''));
+      expect(real.value).not.toBe(demo.value);
+    }
+  });
+
+  it('defaults to os.homedir() when no home is supplied and XDG_DATA_HOME is unset', () => {
+    const result = resolveDemoDbPath({ xdgDataHome: '' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(join(homedir(), '.slopweaver', 'demo.db'));
+    }
+  });
+
+  it('propagates DATA_PATH_INVALID from resolveDataDir', () => {
+    const result = resolveDemoDbPath({ xdgDataHome: 'tmp/relative' });
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.code).toBe('DATA_PATH_INVALID');

--- a/packages/db/src/path.ts
+++ b/packages/db/src/path.ts
@@ -57,3 +57,18 @@ export function resolveDataDir({ home, xdgDataHome }: ResolvePathOptions = {}): 
 export function resolveDbPath(options: ResolvePathOptions = {}): Result<string, DataPathInvalidError> {
   return resolveDataDir(options).map((dir) => join(dir, 'slopweaver.db'));
 }
+
+/**
+ * Resolve the absolute path to the SlopWeaver **demo** SQLite database file.
+ *
+ * The demo DB is a sibling of the real `slopweaver.db` under the same
+ * XDG-resolved data directory, named `demo.db`. Keeping it side-by-side
+ * (rather than in a separate tmp dir) means the same `slopweaver doctor` /
+ * Diagnostics UI surfaces work against demo state, and the user can flip
+ * between demo and real without re-copying anything. The two files never
+ * mix because the resolver here is the single source of truth and is only
+ * consulted when the caller asks for demo mode.
+ */
+export function resolveDemoDbPath(options: ResolvePathOptions = {}): Result<string, DataPathInvalidError> {
+  return resolveDataDir(options).map((dir) => join(dir, 'demo.db'));
+}

--- a/packages/mcp-server/src/tools/builtin/get-freshness.test.ts
+++ b/packages/mcp-server/src/tools/builtin/get-freshness.test.ts
@@ -113,6 +113,21 @@ describe('createGetFreshnessTool', () => {
     expect(parsed.freshness[0]?.stale).toBe(true);
   });
 
+  it('filters out `__`-prefixed sentinel rows (e.g. `__demo__`) so they never appear in the wire response', async () => {
+    // The demo seeder writes an `integration_state` row with
+    // integration = '__demo__' as a label for the demo DB profile. That row
+    // must not pollute the freshness output — it's not a real integration.
+    seedIntegrationState({ integration: '__demo__', lastPollCompletedAtMs: FIXED_NOW - FIVE_MIN });
+    seedIntegrationState({ integration: 'github', lastPollCompletedAtMs: FIXED_NOW - FIVE_MIN });
+
+    const tool = createGetFreshnessTool({ now: () => FIXED_NOW });
+    const raw = await callHandler(tool, {});
+    const parsed = GetFreshnessResult.parse(raw);
+
+    expect(parsed.freshness).toHaveLength(1);
+    expect(parsed.freshness[0]?.integration).toBe('github');
+  });
+
   it('returns entries sorted alphabetically by integration (deterministic across SQLite plans)', async () => {
     // Seed in reverse-alphabetical insertion order so a missing ORDER BY would
     // produce `['slack', 'github']` and fail this assertion.

--- a/packages/mcp-server/src/tools/builtin/get-freshness.ts
+++ b/packages/mcp-server/src/tools/builtin/get-freshness.ts
@@ -52,14 +52,21 @@ export function createGetFreshnessTool(args: CreateGetFreshnessToolArgs = {}): T
         .orderBy(asc(integrationState.integration))
         .all();
 
-      const freshness: Freshness[] = rows.map((row) => {
-        const last = row.lastPollCompletedAtMs;
-        return {
-          integration: row.integration,
-          last_polled_at: last != null ? new Date(last).toISOString() : null,
-          stale: last == null || nowMs - last > staleThresholdMs,
-        };
-      });
+      // `__`-prefixed integration slugs are reserved sentinels (e.g. the
+      // `__demo__` label written by `slopweaver demo seed`) — they live in
+      // `integration_state` to mark the DB profile but are not real
+      // integrations, so they must not appear in the freshness wire
+      // response.
+      const freshness: Freshness[] = rows
+        .filter((row) => !row.integration.startsWith('__'))
+        .map((row) => {
+          const last = row.lastPollCompletedAtMs;
+          return {
+            integration: row.integration,
+            last_polled_at: last != null ? new Date(last).toISOString() : null,
+            stale: last == null || nowMs - last > staleThresholdMs,
+          };
+        });
 
       return ok({
         freshness,

--- a/packages/mcp-server/src/tools/composite/start-session.test.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.test.ts
@@ -488,6 +488,38 @@ describe('createStartSessionTool', () => {
     expect(parsed.items.map((i) => i.title)).toEqual(['Newer', 'Older']);
   });
 
+  it('filters out `__`-prefixed sentinel integrations from both default-resolved and explicit lists', async () => {
+    // The demo seeder writes an `integration_state` row with
+    // integration = '__demo__' as a profile label. start_session must not
+    // treat it as a real integration in the freshness output, regardless of
+    // whether the caller supplies an explicit integrations list.
+    dbHandle.db
+      .insert(integrationState)
+      .values({
+        integration: '__demo__',
+        cursor: 'demo',
+        lastPollStartedAtMs: FIXED_NOW - FIVE_MIN,
+        lastPollCompletedAtMs: FIXED_NOW - FIVE_MIN,
+        createdAtMs: FIXED_NOW - FIVE_MIN,
+        updatedAtMs: FIXED_NOW - FIVE_MIN,
+      })
+      .run();
+    seedFreshIntegrationState('github');
+    seedEvidence({ integration: 'github', externalId: 'pr-1', title: 'A real PR' });
+
+    const tool = createStartSessionTool({ now: () => FIXED_NOW });
+
+    // Default-resolved path: union of pollers + integration_state rows.
+    const defaultResult = await callHandler(tool, {});
+    const defaultParsed = StartSessionResult.parse(defaultResult);
+    expect(defaultParsed.freshness.map((f) => f.integration)).toEqual(['github']);
+
+    // Explicit list path: caller-supplied integrations are still filtered.
+    const explicitResult = await callHandler(tool, { integrations: ['github', '__demo__'] });
+    const explicitParsed = StartSessionResult.parse(explicitResult);
+    expect(explicitParsed.freshness.map((f) => f.integration)).toEqual(['github']);
+  });
+
   it('breaks remaining ties by id asc — earlier insert first when score and occurredAtMs are equal', async () => {
     const idA = seedEvidence({
       integration: 'github',

--- a/packages/mcp-server/src/tools/composite/start-session.ts
+++ b/packages/mcp-server/src/tools/composite/start-session.ts
@@ -160,6 +160,12 @@ export function createStartSessionTool(args: CreateStartSessionToolArgs = {}): T
  * the union of registered pollers and existing `integration_state` rows so a
  * first-run `force_refresh` actually has something to poll. First-seen order
  * is preserved.
+ *
+ * Sentinel/internal rows whose `integration` begins with `__` (currently only
+ * the `__demo__` label written by `slopweaver demo seed`) are filtered out so
+ * they never appear in the wire response. The `__`-prefix convention is the
+ * one rule service code uses to distinguish labels-on-DB-state from real
+ * integration slugs.
  */
 function resolveRequested(
   db: SlopweaverDatabase,
@@ -167,14 +173,23 @@ function resolveRequested(
   pollers: Record<string, StartSessionPoller>,
 ): string[] {
   if (inputIntegrations !== undefined) {
-    return dedupeOrdered(inputIntegrations);
+    return dedupeOrdered(inputIntegrations).filter(isRealIntegration);
   }
   const stateRows = db
     .select({ integration: integrationState.integration })
     .from(integrationState)
     .all()
     .map((r) => r.integration);
-  return dedupeOrdered([...Object.keys(pollers), ...stateRows]);
+  return dedupeOrdered([...Object.keys(pollers), ...stateRows]).filter(isRealIntegration);
+}
+
+/**
+ * `__`-prefixed integration slugs are reserved sentinels (e.g. `__demo__`)
+ * that label DB state without representing a real integration. Service code
+ * must not iterate over them.
+ */
+function isRealIntegration(integration: string): boolean {
+  return !integration.startsWith('__');
 }
 
 function dedupeOrdered(values: readonly string[]): string[] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@slopweaver/errors':
         specifier: workspace:*
         version: link:../../packages/errors
+      '@slopweaver/integrations-core':
+        specifier: workspace:*
+        version: link:../../packages/integrations/core
       '@slopweaver/integrations-github':
         specifier: workspace:*
         version: link:../../packages/integrations/github
@@ -85,6 +88,9 @@ importers:
       cac:
         specifier: 7.0.0
         version: 7.0.0
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0


### PR DESCRIPTION
**Problem**

First-time users had to bring their own GitHub or Slack tokens before they could see what `start_session` actually returns. No way to feel the product cold without OAuth round-trips.

**Solution**

Added a `slopweaver demo` subcommand family that seeds a dedicated `demo.db` with synthetic GitHub and Slack evidence, plus a `--demo` server flag that points the MCP server at that DB instead of the real one. Closes #62.

**Proof this works**

_pending local verification_

**How to test**

1. `pnpm validate` (smoke suite covers seed, start_session against demo.db, and exit cleanup).
2. `slopweaver demo seed`, then confirm `~/.local/share/slopweaver/demo.db` exists and the real `slopweaver.db` does not.
3. `slopweaver --demo --no-web-ui`, call `start_session` via MCP, confirm items come back covering both `github` and `slack` integrations.
4. `slopweaver demo reset` while in demo mode, confirm timestamps refresh without duplicating rows.
5. `slopweaver demo exit`, confirm `demo.db` is gone and the real DB is untouched.
6. Bare `slopweaver demo` with no subcommand prints the static markdown snapshot to stdout.

<details>
<summary>Implementation notes</summary>

Three commits:

1. `4cf9404` adds the CLI surface and the static markdown snapshot.
2. `c8dde54` wires the seeder to a real `demo.db` so `start_session` serves synthetic evidence through the same code path as real data.
3. `5beb70e` is the iter-3 review fix: filters `__`-prefixed `integration_state` rows out of both `start_session` and `get_freshness` so the `__demo__` profile sentinel does not leak onto the wire, and rewrites `demo exit` copy. Removing `demo.db` does not flip the MCP client config or `SLOPWEAVER_DEMO`, so the new copy reads "exit removes the demo DB. To return to real mode, restart the server without --demo (or unset SLOPWEAVER_DEMO)."

Synthetic persona covers GitHub and Slack only. Linear / Gmail / Calendar are v1.1+ and intentionally absent so the demo cannot claim a richer product than the binary ships.

</details>
