### PR TITLE
feat(companion): Chrome extension scaffold + /api/companion/file endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ build/
 
 # Local data
 .slopweaver/
+# Per-user work-console state (companion inbox, journals, etc.). Public
+# repo: must never be committed — may contain URLs, page titles, and
+# other personal context from the user's browsing session.
+.claude/personal/
 *.db
 *.db-journal
 *.db-shm

--- a/knip.json
+++ b/knip.json
@@ -2,5 +2,6 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreExportsUsedInFile": {
     "type": true
-  }
+  },
+  "ignore": ["packages/companion-chrome/**"]
 }

--- a/packages/companion-chrome/README.md
+++ b/packages/companion-chrome/README.md
@@ -1,0 +1,62 @@
+# @slopweaver/companion-chrome
+
+Chrome extension companion for the local SlopWeaver work console.
+
+## What it does
+
+Drops a "📌 SlopWeaver" button on supported pages (GitHub PR view,
+Slack thread view in the web client). Clicking it POSTs the current
+URL + page title to the local SlopWeaver HTTP server, which routes
+the entry into the appropriate work file.
+
+Bidirectional badges on tracked anchors (so a thread you've already
+filed shows a "tracked since YYYY-MM-DD" indicator) are a v1.2
+follow-up.
+
+## Install (unpacked)
+
+1. `chrome://extensions/`
+2. Toggle **Developer mode** (top right).
+3. **Load unpacked** → select `packages/companion-chrome/`.
+4. Ensure SlopWeaver is running locally (`slopweaver` or
+   `npx -y slopweaver`). The companion talks to
+   `http://127.0.0.1:60701`.
+
+## Files
+
+```
+packages/companion-chrome/
+├── manifest.json       # Manifest v3, supported sites + permissions
+├── src/
+│   ├── background.js   # Service worker (no-op shell for v1.1)
+│   ├── content.js      # Page-side injector + click handler
+│   ├── content.css     # Pill-style button styling
+│   └── popup.html      # Default popup when the toolbar icon is clicked
+└── README.md           # You are here
+```
+
+## Local HTTP contract
+
+```
+POST http://127.0.0.1:60701/api/companion/file
+content-type: application/json
+
+{ "url": "<page url>", "title": "<page title>" }
+```
+
+Response: `200 OK` with a JSON body
+`{ "filed": true, "path": "<.claude/personal/state/companion-inbox.jsonl>" }`
+on success; non-2xx otherwise.
+
+## Status
+
+v1.1 first cut. No build step — load unpacked as-is. Future:
+- v1.2: badge for tracked anchors, hover preview.
+- v1.3: Firefox + Safari ports, Slack action manifest.
+- v1.4: mobile / native share-extension on iOS.
+
+## Permissions
+
+`activeTab`, `scripting`, plus `host_permissions` for
+`github.com`, `*.slack.com`, and `127.0.0.1:60701`. No analytics,
+no telemetry, no remote endpoints.

--- a/packages/companion-chrome/README.md
+++ b/packages/companion-chrome/README.md
@@ -45,11 +45,37 @@ DNS-rebinding protection, so a direct content-script POST is
 correctly 403'd on `Origin`.
 
 The extension's background service worker has its own privileged
-fetch context (Chrome strips or sets a `chrome-extension://<id>`
-Origin that no normal allow-list could enumerate). The local server's
-companion endpoint is therefore the **one** route that skips the
-Origin guard — justified because the server is loopback-bound and the
-endpoint is write-only into a per-user inbox file.
+fetch context: every cross-origin request it makes sets `Origin:
+chrome-extension://<id>`. The local server's companion endpoint runs
+its own authentication-by-origin guard tuned for that: it accepts
+*only* requests whose `Origin` header starts with
+`chrome-extension://`, and echoes that specific origin back in
+`Access-Control-Allow-Origin` (never `*`).
+
+## Authentication model
+
+The `/api/companion/file` endpoint is the only route on the local
+SlopWeaver server that accepts writes from outside the Diagnostics
+UI. Its trust model is:
+
+- **Allowed**: `Origin: chrome-extension://<id>` — the extension's
+  background service worker. The exact origin is echoed back in
+  `Access-Control-Allow-Origin`.
+- **Rejected (403)**: every other `Origin` value, including
+  `https://evil.example`, `https://github.com`, and
+  `http://localhost:60701` (the Diagnostics UI itself). Web pages
+  cannot forge `Origin: chrome-extension://…` — the browser stamps
+  it from the request initiator's actual origin.
+- **Rejected (403)**: requests with *no* `Origin` header. The Chrome
+  service worker always sets one for cross-origin fetches to
+  `127.0.0.1`, so a missing Origin is not the companion.
+
+The server is loopback-bound (`127.0.0.1`), so a same-machine attacker
+who can run arbitrary code is already inside the trust boundary —
+that's not the threat model here. The threat model *is* "any
+malicious website the user visits should not be able to write to the
+local inbox," and the `chrome-extension://` Origin check defends
+exactly that.
 
 ## Message contract (content → background)
 

--- a/packages/companion-chrome/README.md
+++ b/packages/companion-chrome/README.md
@@ -4,10 +4,11 @@ Chrome extension companion for the local SlopWeaver work console.
 
 ## What it does
 
-Drops a "📌 SlopWeaver" button on supported pages (GitHub PR view,
-Slack thread view in the web client). Clicking it POSTs the current
-URL + page title to the local SlopWeaver HTTP server, which routes
-the entry into the appropriate work file.
+Drops a "📌 SlopWeaver" button on supported pages (GitHub PR / issue
+view, Slack web client). Clicking it hands the current URL + page
+title to the extension's background service worker, which POSTs the
+entry to the local SlopWeaver HTTP server. The server appends a JSONL
+line to `<cwd>/.claude/personal/state/companion-inbox.jsonl`.
 
 Bidirectional badges on tracked anchors (so a thread you've already
 filed shows a "tracked since YYYY-MM-DD" indicator) are a v1.2
@@ -28,14 +29,37 @@ follow-up.
 packages/companion-chrome/
 ├── manifest.json       # Manifest v3, supported sites + permissions
 ├── src/
-│   ├── background.js   # Service worker (no-op shell for v1.1)
-│   ├── content.js      # Page-side injector + click handler
+│   ├── background.js   # Service worker — receives FILE_TAB and POSTs to localhost
+│   ├── content.js      # Page-side injector + click handler (sends FILE_TAB)
 │   ├── content.css     # Pill-style button styling
 │   └── popup.html      # Default popup when the toolbar icon is clicked
 └── README.md           # You are here
 ```
 
-## Local HTTP contract
+## Why the round-trip through the background worker
+
+A content script's `fetch()` inherits the host page's origin
+(`github.com`, `*.slack.com`). The local SlopWeaver server enforces a
+same-origin allow-list on its `/api/*` routes for baseline
+DNS-rebinding protection, so a direct content-script POST is
+correctly 403'd on `Origin`.
+
+The extension's background service worker has its own privileged
+fetch context (Chrome strips or sets a `chrome-extension://<id>`
+Origin that no normal allow-list could enumerate). The local server's
+companion endpoint is therefore the **one** route that skips the
+Origin guard — justified because the server is loopback-bound and the
+endpoint is write-only into a per-user inbox file.
+
+## Message contract (content → background)
+
+```js
+chrome.runtime.sendMessage({ type: 'FILE_TAB', url, title })
+  → { ok: true }
+  | { ok: false, error: string }
+```
+
+## Local HTTP contract (background → server)
 
 ```
 POST http://127.0.0.1:60701/api/companion/file
@@ -44,9 +68,17 @@ content-type: application/json
 { "url": "<page url>", "title": "<page title>" }
 ```
 
+The server validates: payload is an object, `url` is a non-empty
+`http://` or `https://` URL ≤2048 chars, `title` is a string
+≤512 chars. Other schemes (`javascript:`, `data:`, `file:`,
+`chrome:`, …) are rejected with 400.
+
 Response: `200 OK` with a JSON body
-`{ "filed": true, "path": "<.claude/personal/state/companion-inbox.jsonl>" }`
-on success; non-2xx otherwise.
+`{ "filed": true, "path": "<.claude/personal/state/companion-inbox.jsonl>", "line_number": N }`
+on success; 400 with `{ "filed": false, "error": "<reason>" }`
+otherwise.
+
+The server also handles the CORS preflight (`OPTIONS`).
 
 ## Status
 
@@ -57,6 +89,11 @@ v1.1 first cut. No build step — load unpacked as-is. Future:
 
 ## Permissions
 
-`activeTab`, `scripting`, plus `host_permissions` for
-`github.com`, `*.slack.com`, and `127.0.0.1:60701`. No analytics,
-no telemetry, no remote endpoints.
+The manifest declares only what's needed:
+
+- `host_permissions`: `http://127.0.0.1:60701/*` — the background
+  worker's fetch target. No `https://github.com/*` or
+  `https://*.slack.com/*` here; the content scripts use narrower
+  `matches` patterns instead (PR / issue / Slack archive URLs only).
+- No `activeTab`, `scripting`, `tabs`, or other broad permissions.
+- No analytics, no telemetry, no remote endpoints.

--- a/packages/companion-chrome/manifest.json
+++ b/packages/companion-chrome/manifest.json
@@ -3,14 +3,19 @@
   "name": "SlopWeaver companion",
   "version": "0.0.1",
   "description": "File-this-thread button for the local SlopWeaver work console (http://127.0.0.1:60701).",
-  "permissions": ["activeTab", "scripting"],
-  "host_permissions": ["https://github.com/*", "https://*.slack.com/*", "http://127.0.0.1:60701/*"],
+  "permissions": [],
+  "host_permissions": ["http://127.0.0.1:60701/*"],
   "background": {
     "service_worker": "src/background.js"
   },
   "content_scripts": [
     {
-      "matches": ["https://github.com/*/pull/*", "https://*.slack.com/*"],
+      "matches": [
+        "https://github.com/*/*/pull/*",
+        "https://github.com/*/*/issues/*",
+        "https://app.slack.com/client/*",
+        "https://*.slack.com/archives/*"
+      ],
       "js": ["src/content.js"],
       "css": ["src/content.css"],
       "run_at": "document_idle"

--- a/packages/companion-chrome/manifest.json
+++ b/packages/companion-chrome/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "SlopWeaver companion",
+  "version": "0.0.1",
+  "description": "File-this-thread button for the local SlopWeaver work console (http://127.0.0.1:60701).",
+  "permissions": ["activeTab", "scripting"],
+  "host_permissions": ["https://github.com/*", "https://*.slack.com/*", "http://127.0.0.1:60701/*"],
+  "background": {
+    "service_worker": "src/background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://github.com/*/pull/*", "https://*.slack.com/*"],
+      "js": ["src/content.js"],
+      "css": ["src/content.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "File in SlopWeaver",
+    "default_popup": "src/popup.html"
+  }
+}

--- a/packages/companion-chrome/src/background.js
+++ b/packages/companion-chrome/src/background.js
@@ -1,9 +1,52 @@
-// Background service worker. v1.1 first cut is a no-op shell — every
-// interaction goes through the content script's fetch to localhost.
-// The service worker exists because manifest v3 requires it for the
-// extension's lifecycle; future versions (browser-action popup,
-// badge counts, alarm-driven sync) will hook here.
+// SlopWeaver companion — background service worker.
+//
+// Receives `FILE_TAB` messages from the content script and POSTs them
+// to the local SlopWeaver HTTP server at http://127.0.0.1:60701.
+//
+// Why this lives here and not in content.js: a content script's fetch
+// inherits the page's origin (github.com / slack.com), so the local
+// server rejects it on the same-origin Origin guard. The service
+// worker runs in the extension's own privileged context — the local
+// server's companion endpoint explicitly allow-lists that and skips
+// Origin validation for it.
+
+const ENDPOINT = 'http://127.0.0.1:60701/api/companion/file';
+
 chrome.runtime.onInstalled.addListener(() => {
   // No-op for v1.1. Reserved for future install-time setup (welcome
   // page, options seeding, etc).
 });
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg == null || typeof msg !== 'object' || msg.type !== 'FILE_TAB') {
+    sendResponse({ ok: false, error: 'unknown message type' });
+    return false;
+  }
+  fileTab({ url: msg.url, title: msg.title })
+    .then((reply) => sendResponse(reply))
+    .catch((err) => sendResponse({ ok: false, error: err && err.message ? err.message : String(err) }));
+  // Return true to keep the message channel open for the async response.
+  return true;
+});
+
+async function fileTab({ url, title }) {
+  if (typeof url !== 'string' || url.length === 0) {
+    return { ok: false, error: 'url required' };
+  }
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ url, title: typeof title === 'string' ? title : '' }),
+  });
+  if (!res.ok) {
+    let detail = `${res.status}`;
+    try {
+      const body = await res.text();
+      if (body.length > 0) detail = `${res.status} ${body.slice(0, 200)}`;
+    } catch {
+      // Ignore body read failure — the status code alone is enough signal.
+    }
+    return { ok: false, error: detail };
+  }
+  return { ok: true };
+}

--- a/packages/companion-chrome/src/background.js
+++ b/packages/companion-chrome/src/background.js
@@ -1,0 +1,9 @@
+// Background service worker. v1.1 first cut is a no-op shell — every
+// interaction goes through the content script's fetch to localhost.
+// The service worker exists because manifest v3 requires it for the
+// extension's lifecycle; future versions (browser-action popup,
+// badge counts, alarm-driven sync) will hook here.
+chrome.runtime.onInstalled.addListener(() => {
+  // No-op for v1.1. Reserved for future install-time setup (welcome
+  // page, options seeding, etc).
+});

--- a/packages/companion-chrome/src/content.css
+++ b/packages/companion-chrome/src/content.css
@@ -1,0 +1,31 @@
+.slopweaver-companion-host {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2147483647;
+  pointer-events: none;
+}
+
+.slopweaver-companion-button {
+  pointer-events: auto;
+  appearance: none;
+  background: #1f2937;
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+}
+
+.slopweaver-companion-button:hover {
+  background: #111827;
+}
+
+.slopweaver-companion-button:disabled {
+  background: #6b7280;
+  cursor: progress;
+}

--- a/packages/companion-chrome/src/content.js
+++ b/packages/companion-chrome/src/content.js
@@ -1,0 +1,56 @@
+// SlopWeaver companion — content script
+//
+// Injects a small "📌 File in SlopWeaver" button on supported pages
+// (GitHub PR view + Slack thread view). Click → POSTs the current URL
+// to the local SlopWeaver HTTP server at http://127.0.0.1:60701.
+//
+// First-cut implementation. Intentionally tiny — no framework, no
+// build step. Runs as-is when loaded unpacked. Future polish (badge
+// for tracked anchors, hover preview) is a v1.2 follow-up.
+
+(() => {
+  const ENDPOINT = 'http://127.0.0.1:60701/api/companion/file';
+
+  function makeButton() {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = '📌 SlopWeaver';
+    btn.className = 'slopweaver-companion-button';
+    btn.title = 'File this thread in your SlopWeaver work console';
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      btn.textContent = '⏳ filing…';
+      try {
+        const res = await fetch(ENDPOINT, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ url: location.href, title: document.title.slice(0, 200) }),
+        });
+        btn.textContent = res.ok ? '✓ filed' : `✗ ${res.status}`;
+      } catch (err) {
+        btn.textContent = `✗ ${err.message ?? 'failed'}`;
+      } finally {
+        setTimeout(() => {
+          btn.disabled = false;
+          btn.textContent = '📌 SlopWeaver';
+        }, 3000);
+      }
+    });
+    return btn;
+  }
+
+  function ensureMounted() {
+    if (document.querySelector('.slopweaver-companion-button')) return;
+    const host = document.body;
+    if (host == null) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'slopweaver-companion-host';
+    wrapper.appendChild(makeButton());
+    host.appendChild(wrapper);
+  }
+
+  ensureMounted();
+  // GitHub + Slack are SPAs — rerun on history nav.
+  const observer = new MutationObserver(() => ensureMounted());
+  observer.observe(document.body, { childList: true, subtree: true });
+})();

--- a/packages/companion-chrome/src/content.js
+++ b/packages/companion-chrome/src/content.js
@@ -1,16 +1,23 @@
-// SlopWeaver companion — content script
+// SlopWeaver companion — content script.
 //
 // Injects a small "📌 File in SlopWeaver" button on supported pages
-// (GitHub PR view + Slack thread view). Click → POSTs the current URL
-// to the local SlopWeaver HTTP server at http://127.0.0.1:60701.
+// (GitHub PR / issue view + Slack web client). Click → asks the
+// extension service worker to POST the current URL to the local
+// SlopWeaver HTTP server at http://127.0.0.1:60701.
+//
+// Why the round-trip through the background worker: content scripts
+// run in the page's origin (github.com / slack.com), so a direct
+// `fetch('http://127.0.0.1:60701/...')` is a cross-origin request and
+// the SlopWeaver server (correctly) 403s it on Origin. Extension
+// service workers have their own privileged fetch context that the
+// local server explicitly allow-lists. See
+// `packages/companion-chrome/README.md` for the contract.
 //
 // First-cut implementation. Intentionally tiny — no framework, no
 // build step. Runs as-is when loaded unpacked. Future polish (badge
 // for tracked anchors, hover preview) is a v1.2 follow-up.
 
 (() => {
-  const ENDPOINT = 'http://127.0.0.1:60701/api/companion/file';
-
   function makeButton() {
     const btn = document.createElement('button');
     btn.type = 'button';
@@ -21,14 +28,19 @@
       btn.disabled = true;
       btn.textContent = '⏳ filing…';
       try {
-        const res = await fetch(ENDPOINT, {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ url: location.href, title: document.title.slice(0, 200) }),
+        const reply = await chrome.runtime.sendMessage({
+          type: 'FILE_TAB',
+          url: location.href,
+          title: document.title.slice(0, 200),
         });
-        btn.textContent = res.ok ? '✓ filed' : `✗ ${res.status}`;
+        if (reply && reply.ok === true) {
+          btn.textContent = '✓ filed';
+        } else {
+          const detail = reply && typeof reply.error === 'string' ? reply.error : 'failed';
+          btn.textContent = `✗ ${detail}`;
+        }
       } catch (err) {
-        btn.textContent = `✗ ${err.message ?? 'failed'}`;
+        btn.textContent = `✗ ${err && err.message ? err.message : 'failed'}`;
       } finally {
         setTimeout(() => {
           btn.disabled = false;

--- a/packages/companion-chrome/src/popup.html
+++ b/packages/companion-chrome/src/popup.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>SlopWeaver companion</title>
+    <style>
+      body {
+        font: 13px/1.4 ui-sans-serif, -apple-system, system-ui, sans-serif;
+        margin: 0;
+        padding: 12px;
+        width: 240px;
+      }
+      h1 { font-size: 14px; margin: 0 0 8px; }
+      p { margin: 0 0 8px; color: #4b5563; }
+      code { background: #f3f4f6; padding: 0 4px; border-radius: 3px; }
+    </style>
+  </head>
+  <body>
+    <h1>SlopWeaver companion</h1>
+    <p>Click the <strong>📌 SlopWeaver</strong> badge on a supported page to file the thread to your local work console.</p>
+    <p>Target: <code>http://127.0.0.1:60701/api/companion/file</code></p>
+    <p>v0.0.1 — first cut. Supported pages: GitHub PRs + Slack threads.</p>
+  </body>
+</html>

--- a/packages/ui/src/server/companion.test.ts
+++ b/packages/ui/src/server/companion.test.ts
@@ -71,4 +71,90 @@ describe('buildCompanionFileResponse', () => {
     });
     expect(result.filed).toBe(false);
   });
+
+  it('returns filed:false when payload is null', async () => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: null,
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(false);
+    if (!result.filed) expect(result.error).toContain('object');
+  });
+
+  it('returns filed:false when url is missing', async () => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: { title: 'orphan' },
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(false);
+    if (!result.filed) expect(result.error).toContain('url');
+  });
+
+  it('returns filed:false when title is missing', async () => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: { url: 'https://example.com/x' },
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(false);
+    if (!result.filed) expect(result.error).toContain('title');
+  });
+
+  it.each([
+    ['javascript:alert(1)', 'javascript'],
+    ['data:text/html,<script>alert(1)</script>', 'data'],
+    ['file:///etc/passwd', 'file'],
+    ['ftp://example.com/x', 'ftp'],
+    ['chrome://settings', 'chrome'],
+  ])('rejects non-http(s) URL scheme %s', async (url) => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: { url, title: 'evil' },
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(false);
+    if (!result.filed) expect(result.error).toContain('http');
+  });
+
+  it('rejects URLs that fail to parse', async () => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: { url: 'not a url', title: 'x' },
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(false);
+    if (!result.filed) expect(result.error.toLowerCase()).toContain('url');
+  });
+
+  it('rejects URLs exceeding the length cap', async () => {
+    const longUrl = `https://example.com/${'a'.repeat(2100)}`;
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: { url: longUrl, title: 'x' },
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(false);
+    if (!result.filed) expect(result.error).toContain('2048');
+  });
+
+  it('rejects titles exceeding the length cap', async () => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: { url: 'https://example.com/x', title: 'a'.repeat(600) },
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(false);
+    if (!result.filed) expect(result.error).toContain('512');
+  });
+
+  it('accepts http URLs (not just https)', async () => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: { url: 'http://127.0.0.1:8080/x', title: 'local' },
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(true);
+  });
 });

--- a/packages/ui/src/server/companion.test.ts
+++ b/packages/ui/src/server/companion.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the companion-file response builder. Uses a real temp dir
+ * so we exercise the actual filesystem path (the contract is "a JSONL
+ * line lands at `<cwd>/.claude/personal/state/companion-inbox.jsonl`").
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildCompanionFileResponse } from './companion.ts';
+
+const FIXED_NOW = Date.UTC(2026, 4, 21, 10, 0, 0);
+
+describe('buildCompanionFileResponse', () => {
+  let tempCwd: string;
+
+  beforeEach(() => {
+    tempCwd = mkdtempSync(join(tmpdir(), 'slop-companion-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempCwd, { recursive: true, force: true });
+  });
+
+  it('appends a valid payload as JSONL and reports line_number=1 on first call', async () => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: { url: 'https://github.com/o/r/pull/1', title: 'PR #1' },
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(true);
+    if (result.filed) {
+      expect(result.line_number).toBe(1);
+      expect(result.path).toBe(join(tempCwd, '.claude/personal/state/companion-inbox.jsonl'));
+      const onDisk = readFileSync(result.path, 'utf-8');
+      const parsed = JSON.parse(onDisk.trim()) as Record<string, unknown>;
+      expect(parsed['url']).toBe('https://github.com/o/r/pull/1');
+      expect(parsed['title']).toBe('PR #1');
+      expect(parsed['ts']).toBe(new Date(FIXED_NOW).toISOString());
+    }
+  });
+
+  it('appends subsequent entries with incrementing line numbers', async () => {
+    for (let i = 1; i <= 3; i += 1) {
+      const r = await buildCompanionFileResponse({
+        cwd: tempCwd,
+        payload: { url: `https://example.com/${i}`, title: `entry ${i}` },
+        nowMs: FIXED_NOW,
+      });
+      expect(r.filed).toBe(true);
+      if (r.filed) expect(r.line_number).toBe(i);
+    }
+  });
+
+  it('returns filed:false with an error for an invalid payload', async () => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: { url: '' },
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(false);
+    if (!result.filed) expect(result.error).toContain('url');
+  });
+
+  it('returns filed:false when payload is not an object', async () => {
+    const result = await buildCompanionFileResponse({
+      cwd: tempCwd,
+      payload: 'just a string',
+      nowMs: FIXED_NOW,
+    });
+    expect(result.filed).toBe(false);
+  });
+});

--- a/packages/ui/src/server/companion.ts
+++ b/packages/ui/src/server/companion.ts
@@ -86,6 +86,12 @@ export async function buildCompanionFileResponse(
 
 type Validated = { valid: true; url: string; title: string } | { valid: false; error: string };
 
+/** Hard caps on payload sizes. URL spec doesn't bound length, but most
+ * browsers + servers choke past ~2 KiB; titles ditto past ~512 chars.
+ * Larger values are almost always a bug or an exfiltration attempt. */
+const MAX_URL_LENGTH = 2048;
+const MAX_TITLE_LENGTH = 512;
+
 function validatePayload(payload: unknown): Validated {
   if (typeof payload !== 'object' || payload === null) {
     return { valid: false, error: 'payload must be a JSON object' };
@@ -96,8 +102,26 @@ function validatePayload(payload: unknown): Validated {
   if (typeof url !== 'string' || url.length === 0) {
     return { valid: false, error: 'url must be a non-empty string' };
   }
+  if (url.length > MAX_URL_LENGTH) {
+    return { valid: false, error: `url exceeds ${MAX_URL_LENGTH} characters` };
+  }
   if (typeof title !== 'string') {
     return { valid: false, error: 'title must be a string' };
+  }
+  if (title.length > MAX_TITLE_LENGTH) {
+    return { valid: false, error: `title exceeds ${MAX_TITLE_LENGTH} characters` };
+  }
+  // Restrict to http(s) — `javascript:`, `data:`, `file:` and friends
+  // would let an attacker land an arbitrary scheme into the inbox file
+  // that a downstream tool might later open / render.
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, error: 'url is not a valid URL' };
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { valid: false, error: `url scheme must be http(s), got "${parsed.protocol}"` };
   }
   return { valid: true, url, title };
 }

--- a/packages/ui/src/server/companion.ts
+++ b/packages/ui/src/server/companion.ts
@@ -1,0 +1,103 @@
+/**
+ * `/api/companion/file` POST endpoint backend. Accepts a JSON payload
+ * `{ url, title }` from the Chrome companion (see
+ * `packages/companion-chrome/`) and appends a JSONL line to
+ * `<cwd>/.claude/personal/state/companion-inbox.jsonl`.
+ *
+ * The endpoint is loopback-bound + Origin-validated by the existing
+ * UI server's same-origin guard. The companion's manifest declares
+ * `127.0.0.1:60701` as a host permission so the browser sends the
+ * matching Origin header.
+ *
+ * Pure-ish: parses JSON, writes a JSONL line. No fancy work-file
+ * routing in v1.1 first cut — every entry lands in a single inbox
+ * JSONL, the user (or `/session-start`) routes them to the right
+ * work file later.
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+const INBOX_REL_PATH = '.claude/personal/state/companion-inbox.jsonl';
+
+export type CompanionFileResult = {
+  filed: true;
+  path: string;
+  line_number: number;
+};
+
+export type CompanionFileError = {
+  filed: false;
+  error: string;
+};
+
+export type BuildCompanionFileArgs = {
+  cwd: string;
+  payload: unknown;
+  nowMs?: number;
+};
+
+export async function buildCompanionFileResponse(
+  args: BuildCompanionFileArgs,
+): Promise<CompanionFileResult | CompanionFileError> {
+  const validation = validatePayload(args.payload);
+  if (!validation.valid) {
+    return { filed: false, error: validation.error };
+  }
+  const nowMs = args.nowMs ?? Date.now();
+  const logPath = join(args.cwd, INBOX_REL_PATH);
+  const line = `${JSON.stringify({
+    ts: new Date(nowMs).toISOString(),
+    url: validation.url,
+    title: validation.title,
+  })}\n`;
+
+  // Count existing lines so we can report the 1-based line number.
+  let existing = 0;
+  try {
+    const content = await readFile(logPath, 'utf-8');
+    existing = content.split('\n').filter((l) => l.trim().length > 0).length;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+      return { filed: false, error: `failed to read inbox: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  }
+  try {
+    await mkdir(dirname(logPath), { recursive: true });
+  } catch (e) {
+    return { filed: false, error: `failed to mkdir: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  let next = line;
+  try {
+    const prev = await readFile(logPath, 'utf-8');
+    next = prev.endsWith('\n') || prev.length === 0 ? `${prev}${line}` : `${prev}\n${line}`;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+      return { filed: false, error: `failed to read inbox: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  }
+  try {
+    await writeFile(logPath, next, { encoding: 'utf-8', mode: 0o644 });
+  } catch (e) {
+    return { filed: false, error: `failed to write inbox: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  return { filed: true, path: logPath, line_number: existing + 1 };
+}
+
+type Validated = { valid: true; url: string; title: string } | { valid: false; error: string };
+
+function validatePayload(payload: unknown): Validated {
+  if (typeof payload !== 'object' || payload === null) {
+    return { valid: false, error: 'payload must be a JSON object' };
+  }
+  const obj = payload as Record<string, unknown>;
+  const url = obj['url'];
+  const title = obj['title'];
+  if (typeof url !== 'string' || url.length === 0) {
+    return { valid: false, error: 'url must be a non-empty string' };
+  }
+  if (typeof title !== 'string') {
+    return { valid: false, error: 'title must be a string' };
+  }
+  return { valid: true, url, title };
+}

--- a/packages/ui/src/server/start.test.ts
+++ b/packages/ui/src/server/start.test.ts
@@ -163,40 +163,101 @@ describe('startUiServer', () => {
   });
 
   describe('POST /api/companion/file', () => {
-    it('accepts a request with a cross-origin Origin (extension service worker)', async () => {
+    const EXTENSION_ORIGIN = 'chrome-extension://abcdef1234567890';
+
+    it('accepts a POST from the Chrome extension and echoes the extension Origin', async () => {
       // The Chrome extension's background worker sends Origin:
-      // `chrome-extension://<id>` (or none at all). The same-origin
-      // allow-list would reject that; the companion endpoint must
-      // bypass it. This is the P0 fix from #79.
+      // `chrome-extension://<id>`. The companion endpoint accepts
+      // *only* requests with this Origin prefix — and echoes the
+      // specific origin back, never `*`. This is the P0 fix from #79
+      // (iter-3): iter-1 wildcarded the response, letting any web
+      // page write to the local inbox.
       const h = await start();
       const res = await fetch(`${h.url}/api/companion/file`, {
         method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          origin: 'chrome-extension://abcdef1234567890',
-        },
+        headers: { 'content-type': 'application/json', origin: EXTENSION_ORIGIN },
         body: JSON.stringify({ url: 'https://github.com/o/r/pull/1', title: 'PR #1' }),
       });
       expect(res.status).toBe(200);
+      expect(res.headers.get('access-control-allow-origin')).toBe(EXTENSION_ORIGIN);
+      expect(res.headers.get('vary')).toContain('Origin');
       const body = (await res.json()) as { filed: boolean };
       expect(body.filed).toBe(true);
     });
 
-    it('responds to the CORS preflight OPTIONS request', async () => {
+    it('rejects a POST from a foreign web origin with 403', async () => {
+      // Any website the user visits could try `fetch('http://127.0.0.1:60701/api/companion/file', …)`.
+      // The endpoint must reject the request before any inbox write
+      // happens.
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', origin: 'https://evil.example' },
+        body: JSON.stringify({ url: 'https://github.com/o/r/pull/1', title: 'PR #1' }),
+      });
+      expect(res.status).toBe(403);
+      // Critically: no `Access-Control-Allow-Origin` for the foreign
+      // origin — the browser would block the response from being read
+      // anyway, but defense-in-depth.
+      expect(res.headers.get('access-control-allow-origin')).toBe(null);
+    });
+
+    it('rejects a POST from the same loopback origin with 403', async () => {
+      // A page served at `http://localhost:60701` (the Diagnostics UI
+      // itself) must NOT be able to write to the inbox. This endpoint
+      // is for the extension only.
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', origin: `http://localhost:${h.address.port}` },
+        body: JSON.stringify({ url: 'https://github.com/o/r/pull/1', title: 'PR #1' }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects a POST with no Origin header with 403', async () => {
+      // Extensions always send Origin from a service-worker fetch.
+      // A missing Origin is either a curl-style local script or a
+      // browser context that stripped the header — neither is the
+      // companion. Reject.
+      const h = await start();
+      // node-fetch sends no Origin by default. Verify by sending an
+      // explicit empty string is treated the same — easiest to do via
+      // an http.request with no origin header. The default fetch()
+      // call without `headers.origin` already omits it.
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'https://github.com/o/r/pull/1', title: 'PR #1' }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('responds to the CORS preflight OPTIONS request from the extension', async () => {
       const h = await start();
       const res = await fetch(`${h.url}/api/companion/file`, {
         method: 'OPTIONS',
-        headers: { origin: 'chrome-extension://abcdef1234567890' },
+        headers: { origin: EXTENSION_ORIGIN },
       });
       expect(res.status).toBe(204);
+      expect(res.headers.get('access-control-allow-origin')).toBe(EXTENSION_ORIGIN);
       expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+    });
+
+    it('rejects an OPTIONS preflight from a foreign web origin with 403', async () => {
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'OPTIONS',
+        headers: { origin: 'https://evil.example' },
+      });
+      expect(res.status).toBe(403);
     });
 
     it('rejects a javascript: URL with 400', async () => {
       const h = await start();
       const res = await fetch(`${h.url}/api/companion/file`, {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json', origin: EXTENSION_ORIGIN },
         body: JSON.stringify({ url: 'javascript:alert(1)', title: 'evil' }),
       });
       expect(res.status).toBe(400);
@@ -209,7 +270,7 @@ describe('startUiServer', () => {
       const h = await start();
       const res = await fetch(`${h.url}/api/companion/file`, {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json', origin: EXTENSION_ORIGIN },
         body: JSON.stringify({ url: 'data:text/html,<script>x</script>', title: 'evil' }),
       });
       expect(res.status).toBe(400);
@@ -219,7 +280,7 @@ describe('startUiServer', () => {
       const h = await start();
       const res = await fetch(`${h.url}/api/companion/file`, {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json', origin: EXTENSION_ORIGIN },
         body: JSON.stringify({ url: 'file:///etc/passwd', title: 'evil' }),
       });
       expect(res.status).toBe(400);
@@ -229,7 +290,7 @@ describe('startUiServer', () => {
       const h = await start();
       const res = await fetch(`${h.url}/api/companion/file`, {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json', origin: EXTENSION_ORIGIN },
         body: 'not json',
       });
       expect(res.status).toBe(400);
@@ -237,7 +298,9 @@ describe('startUiServer', () => {
 
     it('rejects GET with 405 and Allow: POST, OPTIONS', async () => {
       const h = await start();
-      const res = await fetch(`${h.url}/api/companion/file`);
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        headers: { origin: EXTENSION_ORIGIN },
+      });
       expect(res.status).toBe(405);
       expect(res.headers.get('allow')).toContain('POST');
     });

--- a/packages/ui/src/server/start.test.ts
+++ b/packages/ui/src/server/start.test.ts
@@ -17,10 +17,12 @@ describe('startUiServer', () => {
   let dbHandle: ReturnType<typeof createDb>;
   let handle: UiServerHandle | undefined;
   let tempAssets: string;
+  let tempCwd: string;
 
   beforeEach(() => {
     dbHandle = createDb({ path: ':memory:' });
     tempAssets = mkdtempSync(join(tmpdir(), 'ui-assets-'));
+    tempCwd = mkdtempSync(join(tmpdir(), 'ui-cwd-'));
     mkdirSync(join(tempAssets, 'assets'), { recursive: true });
     writeFileSync(join(tempAssets, 'index.html'), '<!doctype html><title>diag</title>');
     writeFileSync(join(tempAssets, 'assets', 'app.js'), 'console.log("hi")');
@@ -30,6 +32,7 @@ describe('startUiServer', () => {
     if (handle) await handle.close();
     handle = undefined;
     rmSync(tempAssets, { recursive: true, force: true });
+    rmSync(tempCwd, { recursive: true, force: true });
     dbHandle.close();
   });
 
@@ -41,6 +44,7 @@ describe('startUiServer', () => {
       port: 0,
       clientAssetsDir: tempAssets,
       staticChecks: STATIC_CHECKS,
+      companionCwd: tempCwd,
     });
     return handle;
   }
@@ -156,5 +160,86 @@ describe('startUiServer', () => {
     const res = await fetch(`${h.url}/api/diagnostics`);
     const body = (await res.json()) as DiagnosticsResponse;
     expect(body.server.port).toBe(h.address.port);
+  });
+
+  describe('POST /api/companion/file', () => {
+    it('accepts a request with a cross-origin Origin (extension service worker)', async () => {
+      // The Chrome extension's background worker sends Origin:
+      // `chrome-extension://<id>` (or none at all). The same-origin
+      // allow-list would reject that; the companion endpoint must
+      // bypass it. This is the P0 fix from #79.
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'chrome-extension://abcdef1234567890',
+        },
+        body: JSON.stringify({ url: 'https://github.com/o/r/pull/1', title: 'PR #1' }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { filed: boolean };
+      expect(body.filed).toBe(true);
+    });
+
+    it('responds to the CORS preflight OPTIONS request', async () => {
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'OPTIONS',
+        headers: { origin: 'chrome-extension://abcdef1234567890' },
+      });
+      expect(res.status).toBe(204);
+      expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+    });
+
+    it('rejects a javascript: URL with 400', async () => {
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'javascript:alert(1)', title: 'evil' }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { filed: boolean; error: string };
+      expect(body.filed).toBe(false);
+      expect(body.error).toContain('http');
+    });
+
+    it('rejects a data: URL with 400', async () => {
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'data:text/html,<script>x</script>', title: 'evil' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a file: URL with 400', async () => {
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'file:///etc/passwd', title: 'evil' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid JSON with 400', async () => {
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: 'not json',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects GET with 405 and Allow: POST, OPTIONS', async () => {
+      const h = await start();
+      const res = await fetch(`${h.url}/api/companion/file`);
+      expect(res.status).toBe(405);
+      expect(res.headers.get('allow')).toContain('POST');
+    });
   });
 });

--- a/packages/ui/src/server/start.ts
+++ b/packages/ui/src/server/start.ts
@@ -192,17 +192,31 @@ function handleApi({
   companionCwd: string;
 }): void {
   // The companion endpoint is reached from the Chrome extension's
-  // background service worker. That request's Origin is either
-  // `chrome-extension://<id>` or absent (some extension fetches strip
-  // it), neither of which the same-origin allow-list accepts. The
-  // server is loopback-bound (127.0.0.1) so the only attack surface
-  // is malicious code on the same machine — and that's already inside
-  // the trust boundary. Skip the Origin guard for this endpoint and
-  // handle the CORS preflight explicitly.
+  // background service worker. The same-origin allow-list (which
+  // protects `/api/diagnostics`) would reject the extension's
+  // `chrome-extension://<id>` Origin, so this endpoint runs its own
+  // authentication-by-origin guard: it accepts requests *only* when
+  // the `Origin` header starts with `chrome-extension://`, and echoes
+  // that specific origin back (never `*`). A missing Origin header is
+  // rejected — the extension's service worker fetch always sends one.
+  //
+  // This is the authentication boundary for the companion: the
+  // server is loopback-bound, so a same-machine attacker is already
+  // inside the trust boundary, but *any web origin in the user's
+  // browser* must NOT be able to forge writes to the local inbox.
+  // That includes both same-origin (`http://localhost:60701`) and
+  // foreign (`https://evil.example`) browser pages — only the
+  // extension context is allowed.
   if (pathname === '/api/companion/file') {
+    if (!isCompanionOriginAllowed({ req })) {
+      writeText({ res, status: 403, body: 'forbidden origin\n' });
+      return;
+    }
+    const allowedOrigin = req.headers.origin as string;
     if (method === 'OPTIONS') {
       res.writeHead(204, {
-        'access-control-allow-origin': '*',
+        'access-control-allow-origin': allowedOrigin,
+        vary: 'Origin',
         'access-control-allow-methods': 'POST, OPTIONS',
         'access-control-allow-headers': 'content-type',
         'access-control-max-age': '600',
@@ -215,7 +229,7 @@ function handleApi({
       res.end('method not allowed\n');
       return;
     }
-    handleCompanionFile({ req, res, companionCwd }).catch((e: unknown) => {
+    handleCompanionFile({ req, res, companionCwd, allowedOrigin }).catch((e: unknown) => {
       writeText({ res, status: 500, body: `internal error: ${e instanceof Error ? e.message : String(e)}\n` });
     });
     return;
@@ -245,10 +259,12 @@ async function handleCompanionFile({
   req,
   res,
   companionCwd,
+  allowedOrigin,
 }: {
   req: IncomingMessage;
   res: ServerResponse;
   companionCwd: string;
+  allowedOrigin: string;
 }): Promise<void> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) chunks.push(chunk as Buffer);
@@ -257,22 +273,55 @@ async function handleCompanionFile({
   try {
     payload = JSON.parse(raw);
   } catch {
-    writeJson({ res, status: 400, body: { filed: false, error: 'invalid JSON' } });
+    writeJson({ res, status: 400, body: { filed: false, error: 'invalid JSON' }, allowedOrigin });
     return;
   }
   const result = await buildCompanionFileResponse({ cwd: companionCwd, payload });
-  writeJson({ res, status: result.filed ? 200 : 400, body: result });
+  writeJson({ res, status: result.filed ? 200 : 400, body: result, allowedOrigin });
 }
 
-function writeJson({ res, status, body }: { res: ServerResponse; status: number; body: unknown }): void {
+function writeJson({
+  res,
+  status,
+  body,
+  allowedOrigin,
+}: {
+  res: ServerResponse;
+  status: number;
+  body: unknown;
+  allowedOrigin: string;
+}): void {
   res.writeHead(status, {
     'content-type': 'application/json; charset=utf-8',
-    // Same rationale as the OPTIONS preflight above: the companion's
-    // background worker calls this from the extension origin, which
-    // is not the bound localhost origin.
-    'access-control-allow-origin': '*',
+    // Echo the specific verified extension origin — never `*`. This
+    // is what makes `chrome-extension://` the authentication boundary:
+    // only the request that passed `isCompanionOriginAllowed` reaches
+    // this response, and the same origin is echoed back. Web pages
+    // calling this URL are rejected with 403 long before they reach
+    // here.
+    'access-control-allow-origin': allowedOrigin,
+    vary: 'Origin',
   });
   res.end(JSON.stringify(body));
+}
+
+/**
+ * The companion endpoint accepts requests *only* from the Chrome
+ * extension's background service worker, identified by an `Origin`
+ * header beginning with `chrome-extension://`. Missing Origin and any
+ * other scheme (`http://`, `https://`, `file://`, etc.) are rejected.
+ *
+ * The Chromium service worker `fetch()` always sets `Origin:
+ * chrome-extension://<id>` when issuing a cross-origin request to
+ * `http://127.0.0.1:60701`, so this check is reliable. A web page that
+ * tries to call this URL will send its own origin (e.g.
+ * `https://evil.example` or `http://localhost:60701`), which fails the
+ * prefix check.
+ */
+function isCompanionOriginAllowed({ req }: { req: IncomingMessage }): boolean {
+  const origin = req.headers.origin;
+  if (typeof origin !== 'string') return false;
+  return origin.startsWith('chrome-extension://');
 }
 
 function isOriginAllowed({

--- a/packages/ui/src/server/start.ts
+++ b/packages/ui/src/server/start.ts
@@ -17,6 +17,8 @@ export type StartUiServerOptions = {
   clientAssetsDir?: string;
   /** Override env checks (tests). */
   staticChecks?: StaticEnvChecks;
+  /** Override cwd used by the companion endpoint (tests). Defaults to `process.cwd()`. */
+  companionCwd?: string;
 };
 
 export type UiServerHandle = {
@@ -90,7 +92,8 @@ export async function startUiServer(opts: StartUiServerOptions): Promise<UiServe
   // when callers pass `port: 0` (tests).
   const bindAddress = { host: requestedHost, port: requestedPort };
 
-  const server = createServer(createHandler({ db: opts.db, staticChecks, clientAssetsDir, bindAddress }));
+  const companionCwd = opts.companionCwd ?? process.cwd();
+  const server = createServer(createHandler({ db: opts.db, staticChecks, clientAssetsDir, bindAddress, companionCwd }));
 
   await listen({ server, port: requestedPort, host: requestedHost });
 
@@ -134,6 +137,7 @@ type HandlerArgs = {
   staticChecks: StaticEnvChecks;
   clientAssetsDir: string;
   bindAddress: { host: string; port: number };
+  companionCwd: string;
 };
 
 function createHandler({
@@ -141,6 +145,7 @@ function createHandler({
   staticChecks,
   clientAssetsDir,
   bindAddress,
+  companionCwd,
 }: HandlerArgs): (req: IncomingMessage, res: ServerResponse) => void {
   return (req, res) => {
     const method = req.method ?? 'GET';
@@ -154,7 +159,7 @@ function createHandler({
     }
 
     if (pathname.startsWith('/api/')) {
-      handleApi({ req, res, method, pathname, db, staticChecks, bindAddress });
+      handleApi({ req, res, method, pathname, db, staticChecks, bindAddress, companionCwd });
       return;
     }
 
@@ -175,6 +180,7 @@ function handleApi({
   db,
   staticChecks,
   bindAddress,
+  companionCwd,
 }: {
   req: IncomingMessage;
   res: ServerResponse;
@@ -183,20 +189,39 @@ function handleApi({
   db: SlopweaverDatabase;
   staticChecks: StaticEnvChecks;
   bindAddress: { host: string; port: number };
+  companionCwd: string;
 }): void {
-  if (!isOriginAllowed({ req, bindAddress })) {
-    writeText({ res, status: 403, body: 'forbidden origin\n' });
-    return;
-  }
+  // The companion endpoint is reached from the Chrome extension's
+  // background service worker. That request's Origin is either
+  // `chrome-extension://<id>` or absent (some extension fetches strip
+  // it), neither of which the same-origin allow-list accepts. The
+  // server is loopback-bound (127.0.0.1) so the only attack surface
+  // is malicious code on the same machine — and that's already inside
+  // the trust boundary. Skip the Origin guard for this endpoint and
+  // handle the CORS preflight explicitly.
   if (pathname === '/api/companion/file') {
+    if (method === 'OPTIONS') {
+      res.writeHead(204, {
+        'access-control-allow-origin': '*',
+        'access-control-allow-methods': 'POST, OPTIONS',
+        'access-control-allow-headers': 'content-type',
+        'access-control-max-age': '600',
+      });
+      res.end();
+      return;
+    }
     if (method !== 'POST') {
-      res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST' });
+      res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST, OPTIONS' });
       res.end('method not allowed\n');
       return;
     }
-    handleCompanionFile({ req, res }).catch((e: unknown) => {
+    handleCompanionFile({ req, res, companionCwd }).catch((e: unknown) => {
       writeText({ res, status: 500, body: `internal error: ${e instanceof Error ? e.message : String(e)}\n` });
     });
+    return;
+  }
+  if (!isOriginAllowed({ req, bindAddress })) {
+    writeText({ res, status: 403, body: 'forbidden origin\n' });
     return;
   }
   if (method !== 'GET' && method !== 'HEAD') {
@@ -216,7 +241,15 @@ function handleApi({
   writeText({ res, status: 404, body: 'not found\n' });
 }
 
-async function handleCompanionFile({ req, res }: { req: IncomingMessage; res: ServerResponse }): Promise<void> {
+async function handleCompanionFile({
+  req,
+  res,
+  companionCwd,
+}: {
+  req: IncomingMessage;
+  res: ServerResponse;
+  companionCwd: string;
+}): Promise<void> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) chunks.push(chunk as Buffer);
   const raw = Buffer.concat(chunks).toString('utf-8');
@@ -224,17 +257,22 @@ async function handleCompanionFile({ req, res }: { req: IncomingMessage; res: Se
   try {
     payload = JSON.parse(raw);
   } catch {
-    writeText({ res, status: 400, body: 'invalid JSON\n' });
+    writeJson({ res, status: 400, body: { filed: false, error: 'invalid JSON' } });
     return;
   }
-  const result = await buildCompanionFileResponse({ cwd: process.cwd(), payload });
-  if (!result.filed) {
-    res.writeHead(400, { 'content-type': 'application/json; charset=utf-8' });
-    res.end(JSON.stringify(result));
-    return;
-  }
-  res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
-  res.end(JSON.stringify(result));
+  const result = await buildCompanionFileResponse({ cwd: companionCwd, payload });
+  writeJson({ res, status: result.filed ? 200 : 400, body: result });
+}
+
+function writeJson({ res, status, body }: { res: ServerResponse; status: number; body: unknown }): void {
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    // Same rationale as the OPTIONS preflight above: the companion's
+    // background worker calls this from the extension origin, which
+    // is not the bound localhost origin.
+    'access-control-allow-origin': '*',
+  });
+  res.end(JSON.stringify(body));
 }
 
 function isOriginAllowed({

--- a/packages/ui/src/server/start.ts
+++ b/packages/ui/src/server/start.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { extname, isAbsolute, join, relative, resolve } from 'node:path';
 import type { SlopweaverDatabase } from '@slopweaver/db';
 import { runStaticEnvChecks, type StaticEnvChecks } from './checks.ts';
+import { buildCompanionFileResponse } from './companion.ts';
 import { buildDiagnosticsResponse } from './diagnostics.ts';
 import { CLIENT_ASSETS_DIR } from './static-dir.ts';
 
@@ -183,13 +184,24 @@ function handleApi({
   staticChecks: StaticEnvChecks;
   bindAddress: { host: string; port: number };
 }): void {
+  if (!isOriginAllowed({ req, bindAddress })) {
+    writeText({ res, status: 403, body: 'forbidden origin\n' });
+    return;
+  }
+  if (pathname === '/api/companion/file') {
+    if (method !== 'POST') {
+      res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST' });
+      res.end('method not allowed\n');
+      return;
+    }
+    handleCompanionFile({ req, res }).catch((e: unknown) => {
+      writeText({ res, status: 500, body: `internal error: ${e instanceof Error ? e.message : String(e)}\n` });
+    });
+    return;
+  }
   if (method !== 'GET' && method !== 'HEAD') {
     res.writeHead(405, { 'content-type': 'text/plain', allow: 'GET, HEAD' });
     res.end('method not allowed\n');
-    return;
-  }
-  if (!isOriginAllowed({ req, bindAddress })) {
-    writeText({ res, status: 403, body: 'forbidden origin\n' });
     return;
   }
   if (pathname === '/api/diagnostics') {
@@ -202,6 +214,27 @@ function handleApi({
     return;
   }
   writeText({ res, status: 404, body: 'not found\n' });
+}
+
+async function handleCompanionFile({ req, res }: { req: IncomingMessage; res: ServerResponse }): Promise<void> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString('utf-8');
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    writeText({ res, status: 400, body: 'invalid JSON\n' });
+    return;
+  }
+  const result = await buildCompanionFileResponse({ cwd: process.cwd(), payload });
+  if (!result.filed) {
+    res.writeHead(400, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify(result));
+    return;
+  }
+  res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(result));
 }
 
 function isOriginAllowed({


### PR DESCRIPTION
**Problem**

There was no one-click way to file a GitHub PR or Slack thread into the local SlopWeaver work console. Iter-1 of this PR shipped the round-trip but regressed to wildcard CORS, which would let any visited web page write to `.claude/personal/state/companion-inbox.jsonl`.

**Solution**

Added a manifest v3 Chrome extension (`packages/companion-chrome/`) plus a `POST /api/companion/file` endpoint on the local UI server. The endpoint now gates writes on `Origin: chrome-extension://<id>` only, echoes that exact origin back in `Access-Control-Allow-Origin`, and 403s everything else including missing Origin and the Diagnostics UI itself.

**Proof this works**

_pending local verification_

**How to test**

1. `pnpm install && pnpm build` at the repo root.
2. Run `slopweaver` (or `npx -y slopweaver`) so the UI server is listening on `127.0.0.1:60701`.
3. Open `chrome://extensions/`, toggle Developer mode, click Load unpacked, select `packages/companion-chrome/`.
4. Visit a GitHub PR or Slack archive thread, click the pinned SlopWeaver pill.
5. Confirm a new JSONL line lands in `.claude/personal/state/companion-inbox.jsonl` with the URL and page title.
6. From DevTools on `https://github.com`, run `fetch('http://127.0.0.1:60701/api/companion/file', {method:'POST', headers:{'content-type':'application/json'}, body:'{}'})` and confirm 403.

<details>
<summary>Implementation notes</summary>

Closes #66 and closes the v1.1 epic #55.

- Content script (`src/content.js`) injects the pill on PR / issue / Slack archive URLs and posts a `FILE_TAB` message to the background service worker. Direct `fetch` from the content script would inherit the host page origin and hit the 403 guard.
- Background service worker (`src/background.js`) owns the cross-origin fetch. Its Origin is `chrome-extension://<id>`, set by the browser from the request initiator and unforgeable from web content.
- Server endpoint (`/api/companion/file`) validates `url` as `http://` or `https://` only (`javascript:`, `data:`, `file:`, `chrome:` rejected), caps `url` at 2048 chars and `title` at 512, then appends a JSONL line. OPTIONS preflight from any other origin is rejected too.
- Iter-3 fix commit: 68693c1. Replaces the wildcard with explicit authentication-by-origin and adds the full test matrix (extension accepted and echoed, foreign web rejected, loopback rejected, missing Origin rejected, foreign preflight rejected).
- Manifest permissions are trimmed: `permissions: []`, `host_permissions: ['http://127.0.0.1:60701/*']` only. No `activeTab`, `scripting`, `tabs`, or remote endpoints.
- `.claude/personal/` is gitignored so inbox content never leaves the user's machine.

</details>
