### PR TITLE
feat(slack): slack-send-image subcommand + skill for voice-aware image sends

### DIFF
--- a/.claude/commands/slack-image-draft.md
+++ b/.claude/commands/slack-image-draft.md
@@ -1,0 +1,92 @@
+---
+description: Draft a Slack message in the user's voice with an inline image, then (after human ack) send via the same 4-call web-API sequence the Slack web client uses. Requires the user's own xoxc token. No bot token, no MCP for the upload itself.
+argument-hint: <channel-id-or-channel/thread_ts> | <message-text> | <image-path>
+---
+
+This skill exists to make "1 link + 1 image" Slack messages fast while keeping a human-review gate before send. It splits into two phases so the user reviews the text before any image lands publicly.
+
+## Why this exists
+
+Slack's API has no draft-with-attachment path. The web UI uploads first, then `files.share` sends the message + file in one shot. Bot tokens (`xoxb-`) can't run `files.getUploadURL` for personal sends. The user-scoped xoxc token from a logged-in browser tab can.
+
+This skill is the SlopWeaver-friendly version of that flow: voice-linted text via `apply_voice_rules`, draft via the Slack MCP for human ack, then a single `slopweaver slack-send-image` CLI call that runs the actual 4-call sequence.
+
+## Prereqs
+
+- The Slack MCP attached to Claude Code (provides `slack_send_message_draft`).
+- The user's xoxc token, exported as `SLACK_XOXC` (or passed via `--xoxc`).
+- The workspace API base URL, exported as `SLOPWEAVER_SLACK_WORKSPACE_URL` (`https://<workspace>.slack.com`, or `https://<workspace>.enterprise.slack.com` for enterprise grid).
+- On enterprise grid: `SLOPWEAVER_SLACK_ROUTE` set to `<enterprise_id>:<team_id>`. Standard workspaces leave this unset.
+
+Extract the xoxc token by opening Slack in a logged-in browser, then in DevTools console:
+
+```js
+for (const k of Object.keys(localStorage)) {
+  const v = localStorage.getItem(k);
+  if (v) {
+    const m = v.match(/xoxc-[0-9A-Za-z-]+/);
+    if (m) { console.log(m[0]); break; }
+  }
+}
+```
+
+These tokens cycle on the order of 60-90 seconds on enterprise grid. Re-extract immediately before sending. Do not cache them across sessions.
+
+## Inputs
+
+`$ARGUMENTS` parsed as `<channel-or-channel/thread_ts> | <message-text> | <image-path>`.
+
+- **`<channel>`**: a Slack channel id (`C…`) or DM id (`D…`). For thread replies, append `/<thread_ts>`.
+- **`<message-text>`**: the message body. Will be voice-linted before drafting.
+- **`<image-path>`**: absolute or repo-relative. PNG or JPEG.
+
+## Steps
+
+### 1. Voice-lint the text
+
+Call `apply_voice_rules` (the SlopWeaver MCP tool) with the message text and the user's `rules/communication-style.md`. Use the rewritten text for the draft.
+
+If `apply_voice_rules` is not registered in this server build, continue with the original text and surface a one-line note that voice lint was skipped.
+
+### 2. Draft for human review (Phase A)
+
+Call `slack_send_message_draft` (the Slack MCP tool) with the channel, thread_ts (if any), and the rewritten text. The draft appears in the user's Slack draft box for review. Report the draft URL plus the image path that's queued for the send call. Pause.
+
+### 3. Send when the user acks (Phase B)
+
+Once the user says "send" or otherwise acks the draft, run:
+
+```bash
+slopweaver slack-send-image \
+  --channel "<channel>" \
+  --text "<rewritten-text>" \
+  --image "<image-path>" \
+  [--thread "<thread_ts>"]
+```
+
+The binary reads `SLACK_XOXC`, `SLOPWEAVER_SLACK_WORKSPACE_URL`, and `SLOPWEAVER_SLACK_ROUTE` from the environment. Override any of them with `--xoxc`, `--workspace-url`, `--slack-route`.
+
+On success the binary prints:
+
+```
+slack-send-image: ok file=<file_id> ts=<file_msg_ts> where=<channel>[/<thread_ts>]
+```
+
+The earlier text draft becomes irrelevant once the send lands (`files.share` carries its own text). The unsent draft stays in the user's draft box until they delete it.
+
+### 4. Verify
+
+Optionally call the Slack MCP `slack_read_channel` on the target channel. The newest message should be the rewritten text plus the file.
+
+## Failure modes
+
+- `SLACK_IMAGE_INVALID_TOKEN`: the token did not start with `xoxc-`. Re-extract.
+- `SLACK_IMAGE_UPLOAD_URL_FAILED` with `slack: invalid_auth`: token expired or the workspace URL is wrong. Re-extract; verify `SLOPWEAVER_SLACK_WORKSPACE_URL` matches the workspace.
+- `SLACK_IMAGE_SHARE_FAILED` with `slack: channel_not_found`: the user is not a member of the channel (xoxc only sends as the user themselves). Pick a different channel.
+- `SLACK_IMAGE_BYTES_UPLOAD_FAILED`: the `files.slack.com` upload endpoint rejected the bytes. Often transient; retry once.
+
+## Notes
+
+- The 4-call sequence (`files.getUploadURL` -> binary POST -> `files.completeUpload` -> `files.share`) is the same path the official Slack web client uses. Nothing here exploits an undocumented API. `xoxc` tokens are workspace user tokens; the user is acting as themselves.
+- The skill never reads cookies, localStorage, or any other credential store. The user supplies the token. SlopWeaver consumes it.
+- For privacy: the inbox payloads land on the user's machine only. The send itself is observable in Slack (as any user-authored message would be).

--- a/apps/mcp-local/README.md
+++ b/apps/mcp-local/README.md
@@ -67,7 +67,29 @@ over stdio.
 
 In: stdio MCP server, `ping` tool, `--version` / `--help` / `--no-web-ui`,
 the local Diagnostics web UI on `127.0.0.1:60701`, the `init` first-run
-wizard, the `connect <integration>` subcommands, and the `walk` subcommand
+wizard, the `connect <integration>` subcommands, the `walk` subcommand
 (read-only: prints the ranked `/lock-in` queue from
 `.claude/personal/state/reconciliation.md`; the interactive TUI verb-loop
-ships in a follow-up PR). Out: `doctor`. That ships in a follow-up issue.
+ships in a follow-up PR), and the `slack-send-image` subcommand
+(human-acked Slack image send via the same 4-call web-API sequence the
+Slack web client uses; requires a user `xoxc` token and a workspace URL;
+the `.claude/commands/slack-image-draft.md` skill is the recommended
+front end). Out: `doctor`. That ships in a follow-up issue.
+
+## `slack-send-image` subcommand
+
+```bash
+slopweaver slack-send-image \
+  --channel "C0123456789" \
+  --text "deployment landed, p95 dropped from 4.9s to 667ms" \
+  --image "/tmp/dd-after.png" \
+  [--thread "1779326689.858299"]
+```
+
+Env vars:
+
+- `SLACK_XOXC` (required if `--xoxc` is omitted): the user's xoxc token. Extract from a logged-in Slack browser tab. Tokens cycle on the order of 60-90 seconds on enterprise grid; re-extract immediately before each send.
+- `SLOPWEAVER_SLACK_WORKSPACE_URL` (required if `--workspace-url` is omitted): the API base URL for the workspace, e.g. `https://acme.slack.com` or `https://acme.enterprise.slack.com`.
+- `SLOPWEAVER_SLACK_ROUTE` (enterprise grid only): the `<enterprise_id>:<team_id>` route. Standard workspaces leave this unset.
+
+The 4-call sequence runs `files.getUploadURL`, a binary POST of the image bytes, `files.completeUpload`, and `files.share`. Step 4 is the actual send (Slack has no draft-with-attachment path). The recommended flow is to draft the text via the Slack MCP for human review first, then run this command once the user acks. The `.claude/commands/slack-image-draft.md` skill drives that flow.

--- a/apps/mcp-local/src/cli.smoke.test.ts
+++ b/apps/mcp-local/src/cli.smoke.test.ts
@@ -112,6 +112,30 @@ describe('slopweaver bin (compiled CLI)', () => {
     }
   });
 
+  it('slack-send-image: exits 2 with a clear stderr line when --channel/--text/--image are missing', () => {
+    const result = spawnSync(process.execPath, [cliPath, 'slack-send-image'], {
+      env: { PATH: process.env['PATH'] ?? '', XDG_DATA_HOME: dataHome },
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('slack-send-image');
+    expect(result.stderr).toContain('--channel');
+    expect(result.stdout).toBe('');
+  });
+
+  it('slack-send-image: exits 2 when --xoxc / SLACK_XOXC is absent', () => {
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, 'slack-send-image', '--channel', 'C0', '--text', 'hi', '--image', '/tmp/x.png'],
+      {
+        env: { PATH: process.env['PATH'] ?? '', XDG_DATA_HOME: dataHome },
+        encoding: 'utf-8',
+      },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('xoxc');
+  });
+
   it('exits non-zero with a clean stderr message when env is invalid', () => {
     const result = spawnSync(process.execPath, [cliPath], {
       env: {

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -483,6 +483,58 @@ cli
   });
 
 cli
+  .command(
+    'slack-send-image',
+    'Share an image into a Slack channel or thread via the user web-API (4-call sequence). Requires xoxc + workspace URL.',
+  )
+  .option('--channel <id>', 'Slack channel id (C…) or DM id (D…). Required.')
+  .option('--text <body>', 'Message text. Pre-lint with apply_voice_rules. Required.')
+  .option('--image <path>', 'Absolute path to a PNG or JPEG. Required.')
+  .option('--thread <ts>', 'Optional thread root timestamp to reply into.')
+  .option('--xoxc <token>', 'xoxc user token. Falls back to SLACK_XOXC.')
+  .option(
+    '--workspace-url <url>',
+    'Workspace API base URL (e.g. https://acme.slack.com). Falls back to SLOPWEAVER_SLACK_WORKSPACE_URL.',
+  )
+  .option('--slack-route <route>', 'Enterprise grid slack_route (e.g. E…:T…). Falls back to SLOPWEAVER_SLACK_ROUTE.')
+  .example('  slopweaver slack-send-image --channel C0123 --text "hi" --image /tmp/a.png')
+  .action(
+    async (opts: {
+      channel?: string;
+      text?: string;
+      image?: string;
+      thread?: string;
+      xoxc?: string;
+      workspaceUrl?: string;
+      slackRoute?: string;
+    }) => {
+      try {
+        if (opts.channel === undefined || opts.text === undefined || opts.image === undefined) {
+          stderr.write('slack-send-image: --channel, --text, and --image are all required.\n');
+          exit(2);
+        }
+        const { runSlackSendImage } = await import('./send-image/cli-action.ts');
+        const code = await runSlackSendImage({
+          flags: {
+            channel: opts.channel,
+            text: opts.text,
+            image: opts.image,
+            ...(opts.thread !== undefined ? { thread: opts.thread } : {}),
+            ...(opts.xoxc !== undefined ? { xoxc: opts.xoxc } : {}),
+            ...(opts.workspaceUrl !== undefined ? { workspaceUrl: opts.workspaceUrl } : {}),
+            ...(opts.slackRoute !== undefined ? { slackRoute: opts.slackRoute } : {}),
+          },
+          io: { stdout, stderr, env: process.env },
+        });
+        exit(code);
+      } catch (error: unknown) {
+        stderr.write(`slopweaver: ${asMessage({ error })}\n`);
+        exit(1);
+      }
+    },
+  );
+
+cli
   .command('walk', 'Print the ranked /lock-in walk queue from the local reconciliation file')
   .example('  slopweaver walk')
   .action(async () => {

--- a/apps/mcp-local/src/send-image/cli-action.test.ts
+++ b/apps/mcp-local/src/send-image/cli-action.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { resolveConfig, runSlackSendImage } from './cli-action.ts';
+
+describe('resolveConfig', () => {
+  it('errors when neither --xoxc nor SLACK_XOXC is set', () => {
+    const r = resolveConfig({
+      flags: { channel: 'C0', text: 't', image: 'p' },
+      env: {},
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('xoxc');
+  });
+
+  it('errors when no workspace URL is set', () => {
+    const r = resolveConfig({
+      flags: { channel: 'C0', text: 't', image: 'p', xoxc: 'xoxc-fake' },
+      env: {},
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('workspace');
+  });
+
+  it('builds a standard-workspace config from env', () => {
+    const r = resolveConfig({
+      flags: { channel: 'C0', text: 't', image: 'p' },
+      env: { SLACK_XOXC: 'xoxc-fake', SLOPWEAVER_SLACK_WORKSPACE_URL: 'https://acme.slack.com' },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.config.apiBaseUrl).toBe('https://acme.slack.com');
+      expect(r.config.token).toBe('xoxc-fake');
+      expect(r.config.slackRoute).toBeUndefined();
+    }
+  });
+
+  it('includes slackRoute when env supplies it', () => {
+    const r = resolveConfig({
+      flags: { channel: 'C0', text: 't', image: 'p' },
+      env: {
+        SLACK_XOXC: 'xoxc-fake',
+        SLOPWEAVER_SLACK_WORKSPACE_URL: 'https://acme.enterprise.slack.com',
+        SLOPWEAVER_SLACK_ROUTE: 'E0:T1',
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.slackRoute).toBe('E0:T1');
+  });
+
+  it('flag overrides env', () => {
+    const r = resolveConfig({
+      flags: { channel: 'C0', text: 't', image: 'p', xoxc: 'xoxc-from-flag' },
+      env: { SLACK_XOXC: 'xoxc-from-env', SLOPWEAVER_SLACK_WORKSPACE_URL: 'https://acme.slack.com' },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.token).toBe('xoxc-from-flag');
+  });
+
+  it('treats an empty SLOPWEAVER_SLACK_ROUTE as unset', () => {
+    const r = resolveConfig({
+      flags: { channel: 'C0', text: 't', image: 'p' },
+      env: {
+        SLACK_XOXC: 'xoxc-fake',
+        SLOPWEAVER_SLACK_WORKSPACE_URL: 'https://acme.slack.com',
+        SLOPWEAVER_SLACK_ROUTE: '',
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.slackRoute).toBeUndefined();
+  });
+});
+
+describe('runSlackSendImage', () => {
+  function makeIo() {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    return {
+      io: {
+        stdout: { write: (s: string) => stdout.push(s) },
+        stderr: { write: (s: string) => stderr.push(s) },
+        env: {} as Record<string, string | undefined>,
+      },
+      readStdout: () => stdout.join(''),
+      readStderr: () => stderr.join(''),
+    };
+  }
+
+  it('returns exit code 2 + stderr when no token is configured', async () => {
+    const { io, readStderr, readStdout } = makeIo();
+    const code = await runSlackSendImage({
+      flags: { channel: 'C0', text: 't', image: 'p' },
+      io,
+    });
+    expect(code).toBe(2);
+    expect(readStderr()).toContain('xoxc');
+    expect(readStdout()).toBe('');
+  });
+
+  it('returns exit code 2 + stderr when no workspace URL is configured', async () => {
+    const { io, readStderr } = makeIo();
+    const code = await runSlackSendImage({
+      flags: { channel: 'C0', text: 't', image: 'p', xoxc: 'xoxc-fake' },
+      io,
+    });
+    expect(code).toBe(2);
+    expect(readStderr()).toContain('workspace');
+  });
+});

--- a/apps/mcp-local/src/send-image/cli-action.ts
+++ b/apps/mcp-local/src/send-image/cli-action.ts
@@ -1,0 +1,130 @@
+/**
+ * CLI adapter for the `slack-send-image` subcommand. Resolves config
+ * from env + flags, hands off to the pure `sendSlackImage` helper, and
+ * prints a one-line outcome.
+ *
+ * The xoxc token is read from `--xoxc` or the `SLACK_XOXC` env var only.
+ * No keychain fetch, no browser cookie extraction. The skill that wraps
+ * this command is responsible for getting the token to the user; the
+ * binary just consumes it.
+ */
+
+import { sendSlackImage } from './upload.ts';
+import type { SlackImageError } from './errors.ts';
+import type { SendImageResult, SlackImageUploadConfig } from './types.ts';
+
+export type SlackSendImageFlags = {
+  readonly channel: string;
+  readonly text: string;
+  readonly image: string;
+  readonly thread?: string;
+  readonly xoxc?: string;
+  readonly workspaceUrl?: string;
+  readonly slackRoute?: string;
+};
+
+export type SlackSendImageIo = {
+  readonly stdout: { write: (s: string) => void };
+  readonly stderr: { write: (s: string) => void };
+  readonly env: Readonly<Record<string, string | undefined>>;
+};
+
+/**
+ * Resolve the runtime config or report which env/flag the caller missed.
+ * Pure (no I/O); reads from `flags` and `env` only.
+ */
+export function resolveConfig({
+  flags,
+  env,
+}: {
+  flags: SlackSendImageFlags;
+  env: Readonly<Record<string, string | undefined>>;
+}): { ok: true; config: SlackImageUploadConfig } | { ok: false; error: string } {
+  const token = flags.xoxc ?? env['SLACK_XOXC'];
+  if (token === undefined || token.length === 0) {
+    return {
+      ok: false,
+      error: 'no xoxc token. Pass --xoxc or set SLACK_XOXC. Extract from a logged-in Slack browser tab.',
+    };
+  }
+  const apiBaseUrl = flags.workspaceUrl ?? env['SLOPWEAVER_SLACK_WORKSPACE_URL'];
+  if (apiBaseUrl === undefined || apiBaseUrl.length === 0) {
+    return {
+      ok: false,
+      error:
+        'no workspace URL. Pass --workspace-url https://<workspace>.slack.com or set SLOPWEAVER_SLACK_WORKSPACE_URL.',
+    };
+  }
+  const slackRoute = flags.slackRoute ?? env['SLOPWEAVER_SLACK_ROUTE'];
+  return {
+    ok: true,
+    config: {
+      apiBaseUrl,
+      token,
+      ...(slackRoute !== undefined && slackRoute.length > 0 ? { slackRoute } : {}),
+    },
+  };
+}
+
+function formatErrorLine({ error }: { error: SlackImageError }): string {
+  if (error.code === 'SLACK_IMAGE_SHARE_FAILED' && error.slackError !== undefined) {
+    return `slack-send-image: ${error.code} (slack: ${error.slackError})`;
+  }
+  if (error.code === 'SLACK_IMAGE_UPLOAD_URL_FAILED' && error.slackError !== undefined) {
+    return `slack-send-image: ${error.code} (slack: ${error.slackError})`;
+  }
+  if (error.code === 'SLACK_IMAGE_COMPLETE_FAILED' && error.slackError !== undefined) {
+    return `slack-send-image: ${error.code} (slack: ${error.slackError})`;
+  }
+  return `slack-send-image: ${error.code} ${error.message}`;
+}
+
+function formatSuccessLine({
+  result,
+  channel,
+  threadTs,
+}: {
+  result: SendImageResult;
+  channel: string;
+  threadTs?: string;
+}): string {
+  const where = threadTs === undefined ? channel : `${channel}/${threadTs}`;
+  return `slack-send-image: ok file=${result.fileId} ts=${result.fileMsgTs} where=${where}`;
+}
+
+/**
+ * Run the subcommand against the provided IO. Returns the exit code the
+ * caller should pass to `process.exit`.
+ */
+export async function runSlackSendImage({
+  flags,
+  io,
+}: {
+  flags: SlackSendImageFlags;
+  io: SlackSendImageIo;
+}): Promise<number> {
+  const resolved = resolveConfig({ flags, env: io.env });
+  if (!resolved.ok) {
+    io.stderr.write(`slack-send-image: ${resolved.error}\n`);
+    return 2;
+  }
+  const result = await sendSlackImage({
+    config: resolved.config,
+    channelId: flags.channel,
+    text: flags.text,
+    imagePath: flags.image,
+    ...(flags.thread !== undefined ? { threadTs: flags.thread } : {}),
+  });
+  if (result.isErr()) {
+    io.stderr.write(`${formatErrorLine({ error: result.error })}\n`);
+    return 1;
+  }
+  io.stdout.write(
+    `${formatSuccessLine({
+      result: result.value,
+      channel: flags.channel,
+      ...(flags.thread !== undefined ? { threadTs: flags.thread } : {}),
+    })}\n`,
+  );
+  return 0;
+}

--- a/apps/mcp-local/src/send-image/errors.ts
+++ b/apps/mcp-local/src/send-image/errors.ts
@@ -1,0 +1,70 @@
+import type { BaseError } from '@slopweaver/errors';
+
+export interface SlackImageInvalidTokenError extends BaseError {
+  readonly code: 'SLACK_IMAGE_INVALID_TOKEN';
+}
+
+export interface SlackImageImageReadError extends BaseError {
+  readonly code: 'SLACK_IMAGE_READ_FAILED';
+  readonly imagePath: string;
+}
+
+export interface SlackImageUploadUrlError extends BaseError {
+  readonly code: 'SLACK_IMAGE_UPLOAD_URL_FAILED';
+  readonly slackError?: string;
+}
+
+export interface SlackImageBytesUploadError extends BaseError {
+  readonly code: 'SLACK_IMAGE_BYTES_UPLOAD_FAILED';
+  readonly httpStatus?: number;
+}
+
+export interface SlackImageCompleteError extends BaseError {
+  readonly code: 'SLACK_IMAGE_COMPLETE_FAILED';
+  readonly slackError?: string;
+}
+
+export interface SlackImageShareError extends BaseError {
+  readonly code: 'SLACK_IMAGE_SHARE_FAILED';
+  readonly slackError?: string;
+}
+
+export type SlackImageError =
+  | SlackImageInvalidTokenError
+  | SlackImageImageReadError
+  | SlackImageUploadUrlError
+  | SlackImageBytesUploadError
+  | SlackImageCompleteError
+  | SlackImageShareError;
+
+export const SlackImageErrors = {
+  invalidToken: (): SlackImageInvalidTokenError => ({
+    code: 'SLACK_IMAGE_INVALID_TOKEN',
+    message: 'xoxc token must begin with "xoxc-".',
+  }),
+  imageReadFailed: ({ imagePath, cause }: { imagePath: string; cause: string }): SlackImageImageReadError => ({
+    code: 'SLACK_IMAGE_READ_FAILED',
+    message: `failed to read image at ${imagePath}: ${cause}`,
+    imagePath,
+  }),
+  uploadUrlFailed: ({ cause, slackError }: { cause: string; slackError?: string }): SlackImageUploadUrlError => ({
+    code: 'SLACK_IMAGE_UPLOAD_URL_FAILED',
+    message: `files.getUploadURL failed: ${cause}`,
+    ...(slackError !== undefined ? { slackError } : {}),
+  }),
+  bytesUploadFailed: ({ cause, httpStatus }: { cause: string; httpStatus?: number }): SlackImageBytesUploadError => ({
+    code: 'SLACK_IMAGE_BYTES_UPLOAD_FAILED',
+    message: `binary upload failed: ${cause}`,
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+  }),
+  completeFailed: ({ cause, slackError }: { cause: string; slackError?: string }): SlackImageCompleteError => ({
+    code: 'SLACK_IMAGE_COMPLETE_FAILED',
+    message: `files.completeUpload failed: ${cause}`,
+    ...(slackError !== undefined ? { slackError } : {}),
+  }),
+  shareFailed: ({ cause, slackError }: { cause: string; slackError?: string }): SlackImageShareError => ({
+    code: 'SLACK_IMAGE_SHARE_FAILED',
+    message: `files.share failed: ${cause}`,
+    ...(slackError !== undefined ? { slackError } : {}),
+  }),
+} as const;

--- a/apps/mcp-local/src/send-image/index.ts
+++ b/apps/mcp-local/src/send-image/index.ts
@@ -1,0 +1,3 @@
+export { sendSlackImage, type SendImageDeps } from './upload.ts';
+export { SlackImageErrors, type SlackImageError } from './errors.ts';
+export type { SendImageArgs, SendImageResult, SlackImageUploadConfig } from './types.ts';

--- a/apps/mcp-local/src/send-image/types.ts
+++ b/apps/mcp-local/src/send-image/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Public types for the slack-send-image flow. The 4-call Slack web-API
+ * sequence (files.getUploadURL -> binary PUT -> files.completeUpload ->
+ * files.share) is the same path the official Slack web client uses; this
+ * module is a thin Node port of it.
+ *
+ * The token is a user-scoped xoxc token (the kind a logged-in browser
+ * holds in `localStorage[localConfig_v2]`). Never a bot token. The
+ * caller is responsible for obtaining the token; this module never reads
+ * cookies, localStorage, or any other credential store.
+ */
+
+export type SlackImageUploadConfig = {
+  /**
+   * Workspace API base URL, e.g. `https://acme.slack.com` for a
+   * standard workspace or `https://acme.enterprise.slack.com` for an
+   * enterprise grid workspace. Required because enterprise-grid clients
+   * route through the workspace subdomain rather than `slack.com`.
+   */
+  readonly apiBaseUrl: string;
+  /**
+   * Optional `slack_route` query parameter. Required on enterprise-grid
+   * workspaces (typically `<enterprise_id>:<team_id>`); omit on
+   * standard workspaces.
+   */
+  readonly slackRoute?: string;
+  /**
+   * The xoxc token. Must begin with `xoxc-`. Tokens cycle on the order
+   * of 60-90 seconds on enterprise grid, so callers should extract
+   * fresh on every send.
+   */
+  readonly token: string;
+};
+
+export type SendImageArgs = {
+  readonly config: SlackImageUploadConfig;
+  /** Slack channel id (e.g. `C0123456789`). */
+  readonly channelId: string;
+  /** Optional thread root timestamp; omit to post at the channel root. */
+  readonly threadTs?: string;
+  /** Message text. Pass already-voice-linted text. */
+  readonly text: string;
+  /** Absolute filesystem path to the image. PNG/JPEG. */
+  readonly imagePath: string;
+};
+
+export type SendImageResult = {
+  /** Slack file id returned by `files.getUploadURL`. */
+  readonly fileId: string;
+  /** Timestamp of the channel message that carries the file. */
+  readonly fileMsgTs: string;
+};

--- a/apps/mcp-local/src/send-image/upload.test.ts
+++ b/apps/mcp-local/src/send-image/upload.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sendSlackImage } from './upload.ts';
+import type { SlackImageUploadConfig } from './types.ts';
+
+const FAKE_IMAGE = Buffer.from('PNG-bytes-go-here');
+
+const STANDARD_CONFIG: SlackImageUploadConfig = {
+  apiBaseUrl: 'https://acme.slack.com',
+  token: 'xoxc-FAKE-USER-TOKEN-FOR-TESTS',
+};
+
+const ENTERPRISE_CONFIG: SlackImageUploadConfig = {
+  apiBaseUrl: 'https://acme.enterprise.slack.com',
+  slackRoute: 'E0000000000:T1111111111',
+  token: 'xoxc-FAKE-USER-TOKEN-FOR-TESTS',
+};
+
+type CallRecord = { url: string; init: RequestInit | undefined };
+
+/**
+ * Build a `fetch` stub from a list of pre-canned responses. Each call
+ * is matched in order; the `i`th call returns the `i`th response. Any
+ * mismatch surfaces as a test-failing rejection so silent drift in
+ * call order shows up loudly.
+ */
+function makeFetchStub({
+  responses,
+}: {
+  responses: ReadonlyArray<{ status: number; json?: unknown; text?: string }>;
+}): {
+  fetchImpl: typeof fetch;
+  calls: CallRecord[];
+} {
+  const calls: CallRecord[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    calls.push({ url, init });
+    const idx = calls.length - 1;
+    const spec = responses[idx];
+    if (spec === undefined) {
+      throw new Error(`fetch stub: no response queued for call ${idx + 1} (${url})`);
+    }
+    return new Response(spec.json !== undefined ? JSON.stringify(spec.json) : (spec.text ?? ''), {
+      status: spec.status,
+      headers: { 'content-type': spec.json !== undefined ? 'application/json' : 'text/plain' },
+    });
+  };
+  return { fetchImpl, calls };
+}
+
+describe('sendSlackImage', () => {
+  it('rejects a non-xoxc token before any fetch', async () => {
+    const { fetchImpl, calls } = makeFetchStub({ responses: [] });
+    const result = await sendSlackImage(
+      {
+        config: { ...STANDARD_CONFIG, token: 'xoxb-bot-token' },
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: vi.fn() },
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('SLACK_IMAGE_INVALID_TOKEN');
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it('returns SLACK_IMAGE_READ_FAILED when reading the image throws', async () => {
+    const { fetchImpl, calls } = makeFetchStub({ responses: [] });
+    const result = await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/tmp/missing.png',
+      },
+      {
+        fetchImpl,
+        readImageBytes: async () => {
+          throw new Error('ENOENT: no such file');
+        },
+      },
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('SLACK_IMAGE_READ_FAILED');
+      if (result.error.code === 'SLACK_IMAGE_READ_FAILED') {
+        expect(result.error.imagePath).toBe('/tmp/missing.png');
+      }
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it('returns SLACK_IMAGE_UPLOAD_URL_FAILED on a non-2xx response from files.getUploadURL', async () => {
+    const { fetchImpl } = makeFetchStub({
+      responses: [{ status: 500, text: 'server fell over' }],
+    });
+    const result = await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe('SLACK_IMAGE_UPLOAD_URL_FAILED');
+    }
+  });
+
+  it('returns SLACK_IMAGE_UPLOAD_URL_FAILED with slackError when files.getUploadURL returns ok:false', async () => {
+    const { fetchImpl } = makeFetchStub({
+      responses: [{ status: 200, json: { ok: false, error: 'invalid_auth' } }],
+    });
+    const result = await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.code === 'SLACK_IMAGE_UPLOAD_URL_FAILED') {
+      expect(result.error.slackError).toBe('invalid_auth');
+    }
+  });
+
+  it('returns SLACK_IMAGE_BYTES_UPLOAD_FAILED on a non-2xx binary PUT', async () => {
+    const { fetchImpl } = makeFetchStub({
+      responses: [
+        { status: 200, json: { ok: true, upload_url: 'https://files.slack.com/upload/v1/abc', file_id: 'F0001' } },
+        { status: 502, text: 'bad gateway' },
+      ],
+    });
+    const result = await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.code === 'SLACK_IMAGE_BYTES_UPLOAD_FAILED') {
+      expect(result.error.httpStatus).toBe(502);
+    }
+  });
+
+  it('returns SLACK_IMAGE_COMPLETE_FAILED when files.completeUpload returns ok:false', async () => {
+    const { fetchImpl } = makeFetchStub({
+      responses: [
+        { status: 200, json: { ok: true, upload_url: 'https://files.slack.com/upload/v1/abc', file_id: 'F0001' } },
+        { status: 200, text: '' },
+        { status: 200, json: { ok: false, error: 'file_not_found' } },
+      ],
+    });
+    const result = await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.code === 'SLACK_IMAGE_COMPLETE_FAILED') {
+      expect(result.error.slackError).toBe('file_not_found');
+    }
+  });
+
+  it('returns SLACK_IMAGE_SHARE_FAILED when files.share returns ok:false', async () => {
+    const { fetchImpl } = makeFetchStub({
+      responses: [
+        { status: 200, json: { ok: true, upload_url: 'https://files.slack.com/upload/v1/abc', file_id: 'F0001' } },
+        { status: 200, text: '' },
+        { status: 200, json: { ok: true } },
+        { status: 200, json: { ok: false, error: 'channel_not_found' } },
+      ],
+    });
+    const result = await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C-bad',
+        text: 'hi',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.code === 'SLACK_IMAGE_SHARE_FAILED') {
+      expect(result.error.slackError).toBe('channel_not_found');
+    }
+  });
+
+  it('happy path: returns fileId + fileMsgTs and issues four sequential POSTs', async () => {
+    const { fetchImpl, calls } = makeFetchStub({
+      responses: [
+        { status: 200, json: { ok: true, upload_url: 'https://files.slack.com/upload/v1/abc', file_id: 'F0001' } },
+        { status: 200, text: '' },
+        { status: 200, json: { ok: true } },
+        { status: 200, json: { ok: true, ts: '1779999999.123456' } },
+      ],
+    });
+    const result = await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hello world',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.fileId).toBe('F0001');
+      expect(result.value.fileMsgTs).toBe('1779999999.123456');
+    }
+    expect(calls).toHaveLength(4);
+    expect(calls[0]?.url).toBe('https://acme.slack.com/api/files.getUploadURL');
+    expect(calls[1]?.url).toBe('https://files.slack.com/upload/v1/abc');
+    expect(calls[2]?.url).toBe('https://acme.slack.com/api/files.completeUpload');
+    expect(calls[3]?.url).toBe('https://acme.slack.com/api/files.share');
+  });
+
+  it('happy path: passes file_msg_ts when ts is absent (workspace tier variance)', async () => {
+    const { fetchImpl } = makeFetchStub({
+      responses: [
+        { status: 200, json: { ok: true, upload_url: 'https://files.slack.com/upload/v1/abc', file_id: 'F0001' } },
+        { status: 200, text: '' },
+        { status: 200, json: { ok: true } },
+        { status: 200, json: { ok: true, file_msg_ts: '1779999999.999999' } },
+      ],
+    });
+    const result = await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.fileMsgTs).toBe('1779999999.999999');
+    }
+  });
+
+  it('enterprise grid: appends slack_route query param to each api call', async () => {
+    const { fetchImpl, calls } = makeFetchStub({
+      responses: [
+        { status: 200, json: { ok: true, upload_url: 'https://files.slack.com/upload/v1/abc', file_id: 'F0001' } },
+        { status: 200, text: '' },
+        { status: 200, json: { ok: true } },
+        { status: 200, json: { ok: true, ts: '1.1' } },
+      ],
+    });
+    await sendSlackImage(
+      {
+        config: ENTERPRISE_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    expect(calls[0]?.url).toBe(
+      'https://acme.enterprise.slack.com/api/files.getUploadURL?slack_route=E0000000000%3AT1111111111',
+    );
+    expect(calls[2]?.url).toBe(
+      'https://acme.enterprise.slack.com/api/files.completeUpload?slack_route=E0000000000%3AT1111111111',
+    );
+    expect(calls[3]?.url).toBe(
+      'https://acme.enterprise.slack.com/api/files.share?slack_route=E0000000000%3AT1111111111',
+    );
+    // The bytes PUT goes to the upload_url verbatim. Slack returns a
+    // fully-qualified URL there; we don't add slack_route to that call.
+    expect(calls[1]?.url).toBe('https://files.slack.com/upload/v1/abc');
+  });
+
+  it('thread reply: sends thread_ts in the files.share form body', async () => {
+    const { fetchImpl, calls } = makeFetchStub({
+      responses: [
+        { status: 200, json: { ok: true, upload_url: 'https://files.slack.com/upload/v1/abc', file_id: 'F0001' } },
+        { status: 200, text: '' },
+        { status: 200, json: { ok: true } },
+        { status: 200, json: { ok: true, ts: '1.1' } },
+      ],
+    });
+    await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        threadTs: '1779326689.858299',
+        text: 'reply',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    const shareCall = calls[3];
+    expect(shareCall).toBeDefined();
+    if (shareCall === undefined) return;
+    const body = shareCall.init?.body;
+    expect(body).toBeInstanceOf(URLSearchParams);
+    if (body instanceof URLSearchParams) {
+      expect(body.get('thread_ts')).toBe('1779326689.858299');
+      expect(body.get('channel')).toBe('C0123456789');
+      expect(body.get('text')).toBe('reply');
+      expect(body.get('file')).toBe('F0001');
+    }
+  });
+
+  it('does not leak the xoxc token into URL query strings on any call', async () => {
+    const { fetchImpl, calls } = makeFetchStub({
+      responses: [
+        { status: 200, json: { ok: true, upload_url: 'https://files.slack.com/upload/v1/abc', file_id: 'F0001' } },
+        { status: 200, text: '' },
+        { status: 200, json: { ok: true } },
+        { status: 200, json: { ok: true, ts: '1.1' } },
+      ],
+    });
+    await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/tmp/example.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    for (const call of calls) {
+      expect(call.url).not.toContain('xoxc-');
+    }
+  });
+
+  it('sends the byte length in files.getUploadURL form body', async () => {
+    const { fetchImpl, calls } = makeFetchStub({
+      responses: [
+        { status: 200, json: { ok: true, upload_url: 'https://files.slack.com/upload/v1/abc', file_id: 'F0001' } },
+        { status: 200, text: '' },
+        { status: 200, json: { ok: true } },
+        { status: 200, json: { ok: true, ts: '1.1' } },
+      ],
+    });
+    await sendSlackImage(
+      {
+        config: STANDARD_CONFIG,
+        channelId: 'C0123456789',
+        text: 'hi',
+        imagePath: '/path/with spaces/photo.png',
+      },
+      { fetchImpl, readImageBytes: async () => FAKE_IMAGE },
+    );
+    const body = calls[0]?.init?.body;
+    expect(body).toBeInstanceOf(URLSearchParams);
+    if (body instanceof URLSearchParams) {
+      expect(body.get('filename')).toBe('photo.png');
+      expect(body.get('length')).toBe(String(FAKE_IMAGE.byteLength));
+    }
+  });
+});

--- a/apps/mcp-local/src/send-image/upload.ts
+++ b/apps/mcp-local/src/send-image/upload.ts
@@ -1,0 +1,318 @@
+/**
+ * Slack image-share flow. Drives the same 4-call sequence the Slack web
+ * client uses to attach an image to a channel or thread message:
+ *
+ *   1. `POST <api>/files.getUploadURL`       (user xoxc; returns upload_url + file_id)
+ *   2. `POST <upload_url>`                   (binary bytes)
+ *   3. `POST <api>/files.completeUpload`     (user xoxc; finalises the file)
+ *   4. `POST <api>/files.share`              (user xoxc; SENDS the message + attachment)
+ *
+ * Step 4 is the actual send. Slack has no draft-with-attachment path;
+ * the flow is always upload-then-share. Phase A (text draft for human
+ * review) is implemented separately via the Slack MCP, then this
+ * function runs Phase B once the human acks.
+ *
+ * The caller supplies the xoxc token. This function never reads cookies,
+ * localStorage, or any other credential store.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { errAsync, okAsync, ResultAsync } from '@slopweaver/errors';
+import { SlackImageErrors, type SlackImageError } from './errors.ts';
+import type { SendImageArgs, SendImageResult, SlackImageUploadConfig } from './types.ts';
+
+/**
+ * Dependencies injected for testability. Defaults bind to `globalThis.fetch`
+ * (Node 22+) and `fs/promises.readFile`. Tests supply mocks.
+ */
+export type SendImageDeps = {
+  readonly fetchImpl?: typeof fetch;
+  readonly readImageBytes?: (path: string) => Promise<Buffer>;
+};
+
+const XOXC_PREFIX = 'xoxc-';
+
+function isXoxcToken({ token }: { token: string }): boolean {
+  return token.startsWith(XOXC_PREFIX);
+}
+
+function buildApiUrl({ config, method }: { config: SlackImageUploadConfig; method: string }): string {
+  const base = config.apiBaseUrl.replace(/\/+$/, '');
+  const url = `${base}/api/${method}`;
+  if (config.slackRoute === undefined || config.slackRoute.length === 0) {
+    return url;
+  }
+  return `${url}?slack_route=${encodeURIComponent(config.slackRoute)}`;
+}
+
+async function readBodyAsText({ res }: { res: Response }): Promise<string> {
+  // `.text()` rejects if the response was already consumed; in this
+  // module each response is read exactly once so that case can't fire,
+  // but defend against it anyway by swallowing the read error.
+  try {
+    return await res.text();
+  } catch {
+    return '';
+  }
+}
+
+type SlackApiJson = { ok?: boolean; error?: string } & Record<string, unknown>;
+
+async function parseSlackJson({ res }: { res: Response }): Promise<SlackApiJson | null> {
+  try {
+    const body: unknown = await res.json();
+    if (body !== null && typeof body === 'object') {
+      return body as SlackApiJson;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+type GetUploadUrlResponse = {
+  readonly uploadUrl: string;
+  readonly fileId: string;
+};
+
+function getUploadUrl({
+  config,
+  fileName,
+  byteLength,
+  fetchImpl,
+}: {
+  config: SlackImageUploadConfig;
+  fileName: string;
+  byteLength: number;
+  fetchImpl: typeof fetch;
+}): ResultAsync<GetUploadUrlResponse, SlackImageError> {
+  const body = new URLSearchParams({
+    token: config.token,
+    filename: fileName,
+    length: String(byteLength),
+  });
+  return ResultAsync.fromPromise(
+    fetchImpl(buildApiUrl({ config, method: 'files.getUploadURL' }), {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded; charset=utf-8' },
+      body,
+    }),
+    (e) => SlackImageErrors.uploadUrlFailed({ cause: e instanceof Error ? e.message : String(e) }),
+  ).andThen((res) => {
+    if (!res.ok) {
+      return ResultAsync.fromPromise(readBodyAsText({ res }), () =>
+        SlackImageErrors.uploadUrlFailed({ cause: `http ${res.status}` }),
+      ).andThen((text) =>
+        errAsync<GetUploadUrlResponse, SlackImageError>(
+          SlackImageErrors.uploadUrlFailed({ cause: `http ${res.status}: ${text.slice(0, 200)}` }),
+        ),
+      );
+    }
+    return ResultAsync.fromPromise(parseSlackJson({ res }), () =>
+      SlackImageErrors.uploadUrlFailed({ cause: 'unparseable JSON' }),
+    ).andThen((json) => {
+      if (json?.ok !== true) {
+        return errAsync<GetUploadUrlResponse, SlackImageError>(
+          SlackImageErrors.uploadUrlFailed({
+            cause: 'slack reported failure',
+            ...(typeof json?.error === 'string' ? { slackError: json.error } : {}),
+          }),
+        );
+      }
+      const uploadUrl = typeof json['upload_url'] === 'string' ? json['upload_url'] : undefined;
+      const fileId = typeof json['file_id'] === 'string' ? json['file_id'] : undefined;
+      if (uploadUrl === undefined || fileId === undefined) {
+        return errAsync<GetUploadUrlResponse, SlackImageError>(
+          SlackImageErrors.uploadUrlFailed({ cause: 'response missing upload_url or file_id' }),
+        );
+      }
+      return okAsync<GetUploadUrlResponse, SlackImageError>({ uploadUrl, fileId });
+    });
+  });
+}
+
+function uploadBytes({
+  uploadUrl,
+  imageBytes,
+  fetchImpl,
+}: {
+  uploadUrl: string;
+  imageBytes: Buffer;
+  fetchImpl: typeof fetch;
+}): ResultAsync<void, SlackImageError> {
+  return ResultAsync.fromPromise(
+    fetchImpl(uploadUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/octet-stream' },
+      // Buffer is a valid request body in Node's undici-backed fetch,
+      // but the lib.dom typings only declare a subset. Cast to the
+      // structural shape `fetch` accepts.
+      body: new Uint8Array(imageBytes.buffer, imageBytes.byteOffset, imageBytes.byteLength),
+    }),
+    (e) => SlackImageErrors.bytesUploadFailed({ cause: e instanceof Error ? e.message : String(e) }),
+  ).andThen((res) => {
+    if (!res.ok) {
+      return errAsync<void, SlackImageError>(
+        SlackImageErrors.bytesUploadFailed({ cause: `http ${res.status}`, httpStatus: res.status }),
+      );
+    }
+    return okAsync<void, SlackImageError>(undefined);
+  });
+}
+
+function completeUpload({
+  config,
+  fileId,
+  fileName,
+  fetchImpl,
+}: {
+  config: SlackImageUploadConfig;
+  fileId: string;
+  fileName: string;
+  fetchImpl: typeof fetch;
+}): ResultAsync<void, SlackImageError> {
+  const body = new URLSearchParams({
+    token: config.token,
+    files: JSON.stringify([{ id: fileId, title: fileName }]),
+  });
+  return ResultAsync.fromPromise(
+    fetchImpl(buildApiUrl({ config, method: 'files.completeUpload' }), {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded; charset=utf-8' },
+      body,
+    }),
+    (e) => SlackImageErrors.completeFailed({ cause: e instanceof Error ? e.message : String(e) }),
+  ).andThen((res) => {
+    if (!res.ok) {
+      return errAsync<void, SlackImageError>(SlackImageErrors.completeFailed({ cause: `http ${res.status}` }));
+    }
+    return ResultAsync.fromPromise(parseSlackJson({ res }), () =>
+      SlackImageErrors.completeFailed({ cause: 'unparseable JSON' }),
+    ).andThen((json) => {
+      if (json?.ok !== true) {
+        return errAsync<void, SlackImageError>(
+          SlackImageErrors.completeFailed({
+            cause: 'slack reported failure',
+            ...(typeof json?.error === 'string' ? { slackError: json.error } : {}),
+          }),
+        );
+      }
+      return okAsync<void, SlackImageError>(undefined);
+    });
+  });
+}
+
+function shareFile({
+  config,
+  fileId,
+  channelId,
+  text,
+  threadTs,
+  fetchImpl,
+}: {
+  config: SlackImageUploadConfig;
+  fileId: string;
+  channelId: string;
+  text: string;
+  threadTs?: string;
+  fetchImpl: typeof fetch;
+}): ResultAsync<SendImageResult, SlackImageError> {
+  const body = new URLSearchParams({
+    token: config.token,
+    file: fileId,
+    channel: channelId,
+    text,
+    ...(threadTs !== undefined ? { thread_ts: threadTs } : {}),
+  });
+  return ResultAsync.fromPromise(
+    fetchImpl(buildApiUrl({ config, method: 'files.share' }), {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded; charset=utf-8' },
+      body,
+    }),
+    (e) => SlackImageErrors.shareFailed({ cause: e instanceof Error ? e.message : String(e) }),
+  ).andThen((res) => {
+    if (!res.ok) {
+      return errAsync<SendImageResult, SlackImageError>(SlackImageErrors.shareFailed({ cause: `http ${res.status}` }));
+    }
+    return ResultAsync.fromPromise(parseSlackJson({ res }), () =>
+      SlackImageErrors.shareFailed({ cause: 'unparseable JSON' }),
+    ).andThen((json) => {
+      if (json?.ok !== true) {
+        return errAsync<SendImageResult, SlackImageError>(
+          SlackImageErrors.shareFailed({
+            cause: 'slack reported failure',
+            ...(typeof json?.error === 'string' ? { slackError: json.error } : {}),
+          }),
+        );
+      }
+      // `files.share` returns the channel message ts as `ts` at the
+      // top level (or nested under `file_msg_ts` depending on which
+      // workspace tier the user is on). Accept either.
+      const ts =
+        typeof json['ts'] === 'string'
+          ? json['ts']
+          : typeof json['file_msg_ts'] === 'string'
+            ? json['file_msg_ts']
+            : undefined;
+      if (ts === undefined) {
+        return errAsync<SendImageResult, SlackImageError>(
+          SlackImageErrors.shareFailed({ cause: 'response missing ts / file_msg_ts' }),
+        );
+      }
+      return okAsync<SendImageResult, SlackImageError>({ fileId, fileMsgTs: ts });
+    });
+  });
+}
+
+/**
+ * Run the 4-call Slack web-API sequence to share `imagePath` into
+ * `channelId` (optionally a thread reply) with `text` as the message
+ * body. Returns the resulting file id + channel message timestamp on
+ * success, or a typed Result error at any step.
+ *
+ * The caller is responsible for:
+ *   - Providing a valid xoxc token (this function rejects non-xoxc input).
+ *   - Voice-linting the text before passing it in (use `apply_voice_rules`).
+ *   - Getting human ack on the text via the Slack MCP's draft tool
+ *     before invoking this function (which actually sends).
+ */
+export function sendSlackImage(
+  args: SendImageArgs,
+  deps: SendImageDeps = {},
+): ResultAsync<SendImageResult, SlackImageError> {
+  if (!isXoxcToken({ token: args.config.token })) {
+    return errAsync(SlackImageErrors.invalidToken());
+  }
+  const readImage = deps.readImageBytes ?? defaultReadImageBytes;
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch;
+  const fileName = basename(args.imagePath);
+  return ResultAsync.fromPromise(readImage(args.imagePath), (e) =>
+    SlackImageErrors.imageReadFailed({
+      imagePath: args.imagePath,
+      cause: e instanceof Error ? e.message : String(e),
+    }),
+  )
+    .andThen((imageBytes) =>
+      getUploadUrl({ config: args.config, fileName, byteLength: imageBytes.byteLength, fetchImpl }).map(
+        (uploadInfo) => ({ ...uploadInfo, imageBytes }),
+      ),
+    )
+    .andThen(({ uploadUrl, fileId, imageBytes }) => uploadBytes({ uploadUrl, imageBytes, fetchImpl }).map(() => fileId))
+    .andThen((fileId) => completeUpload({ config: args.config, fileId, fileName, fetchImpl }).map(() => fileId))
+    .andThen((fileId) =>
+      shareFile({
+        config: args.config,
+        fileId,
+        channelId: args.channelId,
+        text: args.text,
+        ...(args.threadTs !== undefined ? { threadTs: args.threadTs } : {}),
+        fetchImpl,
+      }),
+    );
+}
+
+async function defaultReadImageBytes(path: string): Promise<Buffer> {
+  return readFile(path);
+}

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
@@ -38,6 +38,7 @@ const SERVICE_BOUNDARY_DIRS: ReadonlyArray<ServiceBoundaryDir> = [
   { dir: 'apps/mcp-local/src/connect', extensions: ['.ts'] },
   { dir: 'apps/mcp-local/src/demo', extensions: ['.ts'] },
   { dir: 'apps/mcp-local/src/init', extensions: ['.ts'] },
+  { dir: 'apps/mcp-local/src/send-image', extensions: ['.ts'] },
 ];
 
 const SERVICE_BOUNDARY_FILES: ReadonlyArray<string> = [


### PR DESCRIPTION
**Problem**
No way today to ship "1 image + 1 line" Slack messages from inside a Claude session without leaving the chat. The existing Slack MCP can draft text but can't attach files, and bot tokens can't run the user-scoped upload endpoints.

**Solution**
Adds a `slopweaver slack-send-image` CLI subcommand plus a `.claude/commands/slack-image-draft.md` skill that orchestrates voice-lint, draft for human review, then send via the same 4-call sequence the Slack web client uses (`files.getUploadURL` -> binary POST -> `files.completeUpload` -> `files.share`).

**Proof this works**
_pending live Slack run_

**How to test**
1. `git checkout worktree/slack-send-image && pnpm install && pnpm --filter @slopweaver/mcp-local build`
2. `pnpm --filter @slopweaver/mcp-local test -- --run src/send-image` (21 unit tests pass)
3. Set `SLACK_XOXC`, `SLOPWEAVER_SLACK_WORKSPACE_URL`, optionally `SLOPWEAVER_SLACK_ROUTE`
4. `slopweaver slack-send-image --channel C... --text "hi" --image /tmp/x.png`
5. Confirm the message appears in Slack as the user (xoxc tokens send as the user themselves)

<details>
<summary><b>For coding agents</b>: detailed context (not in voice)</summary>

### Module layout

`apps/mcp-local/src/send-image/`:
- `types.ts` — `SlackImageUploadConfig`, `SendImageArgs`, `SendImageResult`. Readonly types throughout.
- `errors.ts` — `BaseError`-derived discriminated union (`SLACK_IMAGE_INVALID_TOKEN` | `_READ_FAILED` | `_UPLOAD_URL_FAILED` | `_BYTES_UPLOAD_FAILED` | `_COMPLETE_FAILED` | `_SHARE_FAILED`) plus `SlackImageErrors` factory namespace.
- `upload.ts` — pure dep-injected `sendSlackImage({ args }, { fetchImpl?, readImageBytes? }): ResultAsync<SendImageResult, SlackImageError>`. Each of the four call sites returns a typed Result; chained via `.andThen` so failure short-circuits and reports which step failed.
- `cli-action.ts` — `resolveConfig` (pure env+flag resolver) + `runSlackSendImage` (returns exit code). Separated from `cli.ts` so the CLI surface can be unit-tested without spawning a child process.
- `*.test.ts` — 21 cases (13 in `upload.test.ts`, 8 in `cli-action.test.ts`). All `fetch` calls are stubbed; the test stub records every call's URL + init for assertions on call order, query-string contents, and body shape.

### Public-repo discipline

- No captured HARs, no hardcoded workspace URLs or user / team / channel IDs.
- The xoxc token never appears in URL query strings — verified by a dedicated test (`does not leak the xoxc token into URL query strings on any call`). It's only sent in form-encoded request bodies.
- `extractToken` deliberately not shipped. The user supplies their own token; the binary consumes it. The skill markdown gives the DevTools console regex for users who want to extract their own.
- The skill body uses generic placeholder names (`acme`, `C0123456789`) only.

### Error handling

- `apps/mcp-local/src/send-image` is added to the no-throw service-boundary scanner allow-list (`packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts`). All `throw`s in this module would fail validation.
- Errors discriminated by `code`. Tests assert on `error.code`, not `error.message`, so message wording can drift without breaking tests.
- Slack-reported errors are surfaced under the `slackError` field on the appropriate error variant. The CLI's `formatErrorLine` prints `slack: <error>` so the user sees the upstream cause.

### CLI surface

`slack-send-image --channel <id> --text <body> --image <path> [--thread <ts>] [--xoxc <token>] [--workspace-url <url>] [--slack-route <route>]`

Env fallbacks: `SLACK_XOXC`, `SLOPWEAVER_SLACK_WORKSPACE_URL`, `SLOPWEAVER_SLACK_ROUTE`.

Exit codes: 0 on success (prints `slack-send-image: ok file=... ts=... where=...`), 1 on Slack/transport failure (stderr line names the error code), 2 on missing required flag or unresolved token/URL.

### Skill flow

`.claude/commands/slack-image-draft.md`:
1. `apply_voice_rules` (the SlopWeaver MCP tool from PR #68) -> rewritten text.
2. `slack_send_message_draft` (the Slack MCP) -> human-visible draft. Skill pauses.
3. On ack: invoke `slopweaver slack-send-image` with the rewritten text.

If `apply_voice_rules` is not registered in the active server build, the skill continues with the original text and surfaces a one-line note.

### Why a user xoxc token, not a bot token

`files.getUploadURL` accepts xoxc but `files.getUploadURLExternal` (the bot-token v2 endpoint) requires `xoxb-`. The user sends as themselves; bot accounts can't impersonate. Documented in the skill body.

### Token cycling

xoxc tokens cycle on the order of 60-90 seconds on enterprise grid. Skill explicitly tells users not to cache and to re-extract before every send. The CLI doesn't try to refresh; that responsibility stays with the caller of the binary.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `slopweaver slack-send-image` CLI command to upload and share images to Slack channels with optional threaded replies and two-phase approval workflow (draft review then send).

* **Documentation**
  * Updated README with `slack-send-image` capability scope and usage instructions.
  * Added comprehensive command guide documenting required credentials, input formats, and workflow details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slopweaver/slopweaver/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->