### PR TITLE
feat(slack-extract): xoxc token finder + Playwright-driven skill

### DIFF
--- a/.claude/commands/slack-extract-token.md
+++ b/.claude/commands/slack-extract-token.md
@@ -1,0 +1,77 @@
+---
+description: Extract the user's xoxc Slack token from a logged-in browser session via Playwright MCP, then pipe the dump through `slopweaver slack-extract-xoxc` to print the token (or an `export SLACK_XOXC=...` line). No cookie reading, no credential stores.
+argument-hint: [--format=token|export]
+---
+
+This skill resolves the `SLACK_XOXC` credential the `slack-image-draft` skill needs to send. xoxc tokens cycle on the order of 60-90 seconds on enterprise grid, so this needs to run immediately before each send. The skill never reads cookies or files; it asks the user's already-logged-in browser to read its own localStorage.
+
+## Prereqs
+
+- Playwright MCP (`mcp__playwright__*`) attached to Claude Code, with a Chrome profile that's currently logged in to Slack.
+- `slopweaver` on the PATH.
+
+## Steps
+
+### 1. Make sure a Slack tab is open and logged in
+
+If the Playwright browser doesn't already have a Slack tab open, navigate to `https://app.slack.com/client/`. SSO usually completes in the background; pause briefly if there's a login challenge.
+
+### 2. Read localStorage from the Slack tab
+
+Run `browser_evaluate` against the Slack tab with this script. It returns the full localStorage as a JSON-serialisable object so the SlopWeaver-side regex helper can do the matching, not the browser:
+
+```js
+() => {
+  const out = {};
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    if (k !== null) out[k] = localStorage.getItem(k);
+  }
+  return out;
+}
+```
+
+### 3. Pipe the dump through the extractor
+
+The extractor is a pure regex consumer. Pipe the JSON-stringified result into `slopweaver slack-extract-xoxc`:
+
+```bash
+echo '<json from step 2>' | slopweaver slack-extract-xoxc --format export
+```
+
+The `--format export` flag prints `export SLACK_XOXC=xoxc-...` so the user can `eval` it in their shell. `--format token` (default) prints the bare token, useful when piping into a downstream command.
+
+Exit codes:
+
+- `0` — token found, written to stdout.
+- `1` — no xoxc token in the input. The user is probably not logged in to Slack on the Playwright browser profile, or the workspace is using a non-standard token shape.
+- `2` — stdin read failed.
+
+### 4. Use the token
+
+For the `/slack-image-draft` flow, the cleanest sequence is:
+
+```bash
+eval "$(echo '<dump>' | slopweaver slack-extract-xoxc --format export)"
+# SLACK_XOXC is now set in this shell.
+slopweaver slack-send-image --channel "$CHANNEL" --text "$TEXT" --image "$IMG"
+```
+
+Or print the bare token and pass via `--xoxc`:
+
+```bash
+TOKEN=$(echo '<dump>' | slopweaver slack-extract-xoxc)
+slopweaver slack-send-image --xoxc "$TOKEN" --channel "$CHANNEL" --text "$TEXT" --image "$IMG"
+```
+
+## Why this shape
+
+- The browser drive lives in the skill body (Playwright MCP). The SlopWeaver binary doesn't bundle Playwright as a Node dependency, so the published package stays small.
+- The regex + parser lives in TypeScript with unit tests so the token-recognition contract is locked down.
+- The token never touches any persistent SlopWeaver state. It flows from the browser through Playwright through the extractor through the calling shell, then out to Slack. No file, no keychain, no env-export-to-disk.
+
+## Notes
+
+- Tokens cycle every ~60-90 seconds on enterprise grid. Re-extract immediately before any send.
+- A standard (non-enterprise) workspace returns the same token shape under `localConfig_v2`; the regex handles both.
+- If `slack-extract-xoxc` returns exit 1, the user may be logged in to a different Slack workspace than the one the send is targeting. Open the right workspace tab and retry.

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -484,6 +484,41 @@ cli
 
 cli
   .command(
+    'slack-extract-xoxc',
+    'Find the user xoxc token in a Slack localStorage dump read from stdin. Pairs with the slack-extract-token skill.',
+  )
+  .option(
+    '--format <fmt>',
+    'Output format: "token" (default, bare token + newline) or "export" (`export SLACK_XOXC=...` shell line).',
+    { default: 'token' },
+  )
+  .example('  cat localstorage.json | slopweaver slack-extract-xoxc')
+  .example('  eval "$(cat localstorage.json | slopweaver slack-extract-xoxc --format export)"')
+  .action(async (opts: { format?: string }) => {
+    try {
+      const format = opts.format === 'export' ? 'export' : 'token';
+      const { runSlackExtractXoxc } = await import('./slack-extract/cli-action.ts');
+      const code = await runSlackExtractXoxc({
+        flags: { format },
+        io: {
+          stdout,
+          stderr,
+          readStdin: async () => {
+            const chunks: Buffer[] = [];
+            for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+            return Buffer.concat(chunks).toString('utf-8');
+          },
+        },
+      });
+      exit(code);
+    } catch (error: unknown) {
+      stderr.write(`slopweaver: ${asMessage({ error })}\n`);
+      exit(1);
+    }
+  });
+
+cli
+  .command(
     'annotate-image',
     'Composite an annotation overlay (boxes, arrows, text) onto an image. Spec is JSON; output is PNG.',
   )

--- a/apps/mcp-local/src/slack-extract/cli-action.test.ts
+++ b/apps/mcp-local/src/slack-extract/cli-action.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { runSlackExtractXoxc } from './cli-action.ts';
+
+function makeIo(stdinContents: string) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    io: {
+      stdout: { write: (s: string) => stdout.push(s) },
+      stderr: { write: (s: string) => stderr.push(s) },
+      readStdin: async () => stdinContents,
+    },
+    readStdout: () => stdout.join(''),
+    readStderr: () => stderr.join(''),
+  };
+}
+
+describe('runSlackExtractXoxc', () => {
+  it('returns 1 + stderr line when stdin is empty', async () => {
+    const { io, readStderr } = makeIo('');
+    const code = await runSlackExtractXoxc({ flags: { format: 'token' }, io });
+    expect(code).toBe(1);
+    expect(readStderr()).toContain('no xoxc token');
+  });
+
+  it('returns 1 when stdin has no token', async () => {
+    const { io } = makeIo('nothing to see');
+    const code = await runSlackExtractXoxc({ flags: { format: 'token' }, io });
+    expect(code).toBe(1);
+  });
+
+  it('prints the bare token + newline on default format', async () => {
+    const { io, readStdout } = makeIo('xoxc-aaaa-1111\n');
+    const code = await runSlackExtractXoxc({ flags: { format: 'token' }, io });
+    expect(code).toBe(0);
+    expect(readStdout()).toBe('xoxc-aaaa-1111\n');
+  });
+
+  it('prints an export line on --format export', async () => {
+    const { io, readStdout } = makeIo('xoxc-aaaa-1111');
+    const code = await runSlackExtractXoxc({ flags: { format: 'export' }, io });
+    expect(code).toBe(0);
+    expect(readStdout()).toBe('export SLACK_XOXC=xoxc-aaaa-1111\n');
+  });
+
+  it('parses a JSON dump (object) and finds the embedded token', async () => {
+    const dump = JSON.stringify({
+      localConfig_v2: JSON.stringify({ teams: { T1: { token: 'xoxc-bbbb-2222' } } }),
+    });
+    const { io, readStdout } = makeIo(dump);
+    const code = await runSlackExtractXoxc({ flags: { format: 'token' }, io });
+    expect(code).toBe(0);
+    expect(readStdout()).toBe('xoxc-bbbb-2222\n');
+  });
+
+  it('falls back to a raw text scan when stdin is not valid JSON', async () => {
+    // Looks JSON-ish (starts with `{`) but isn't valid. Should still
+    // catch the embedded token via the raw fallback.
+    const { io, readStdout } = makeIo('{not json but contains xoxc-cccc-3333');
+    const code = await runSlackExtractXoxc({ flags: { format: 'token' }, io });
+    expect(code).toBe(0);
+    expect(readStdout()).toBe('xoxc-cccc-3333\n');
+  });
+});

--- a/apps/mcp-local/src/slack-extract/cli-action.ts
+++ b/apps/mcp-local/src/slack-extract/cli-action.ts
@@ -1,0 +1,71 @@
+/**
+ * CLI adapter for `slopweaver slack-extract-xoxc`. Reads a JSON or
+ * plain-text dump from stdin, runs the pure `findXoxcInDump` helper,
+ * and prints either the bare token or an `export SLACK_XOXC=...` line
+ * the caller can `eval`.
+ *
+ * No browser drive happens here. The companion skill drives Playwright
+ * to produce the input stream; this subcommand is the pure consumer.
+ */
+
+import { findXoxcInDump, findXoxcInValues } from './find-token.ts';
+
+export type SlackExtractFlags = {
+  /** Output format: `token` (default, bare token) or `export` (`export SLACK_XOXC=...`). */
+  readonly format: 'token' | 'export';
+};
+
+export type SlackExtractIo = {
+  readonly stdout: { write: (s: string) => void };
+  readonly stderr: { write: (s: string) => void };
+  readonly readStdin: () => Promise<string>;
+};
+
+function findToken({ input }: { input: string }): string | null {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      const fromJson = findXoxcInDump({ dump: parsed });
+      if (fromJson !== null) return fromJson;
+    } catch {
+      // Fall through to the raw-text scan; the input may have been
+      // truncated or not actually JSON.
+    }
+  }
+  return findXoxcInValues({ values: [input] });
+}
+
+function formatOutput({ token, format }: { token: string; format: 'token' | 'export' }): string {
+  return format === 'export' ? `export SLACK_XOXC=${token}\n` : `${token}\n`;
+}
+
+/**
+ * Run the subcommand. Returns the exit code:
+ *   0 — token found, written to stdout
+ *   1 — no token in stdin
+ *   2 — stdin read failed
+ */
+export async function runSlackExtractXoxc({
+  flags,
+  io,
+}: {
+  flags: SlackExtractFlags;
+  io: SlackExtractIo;
+}): Promise<number> {
+  let input: string;
+  try {
+    input = await io.readStdin();
+  } catch (e) {
+    io.stderr.write(`slack-extract-xoxc: stdin read failed: ${e instanceof Error ? e.message : String(e)}\n`);
+    return 2;
+  }
+  const token = findToken({ input });
+  if (token === null) {
+    io.stderr.write('slack-extract-xoxc: no xoxc token found in stdin.\n');
+    return 1;
+  }
+  io.stdout.write(formatOutput({ token, format: flags.format }));
+  return 0;
+}

--- a/apps/mcp-local/src/slack-extract/find-token.test.ts
+++ b/apps/mcp-local/src/slack-extract/find-token.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { findXoxcInDump, findXoxcInValues } from './find-token.ts';
+
+describe('findXoxcInValues', () => {
+  it('returns null on an empty array', () => {
+    expect(findXoxcInValues({ values: [] })).toBeNull();
+  });
+
+  it('returns null when no value contains a token', () => {
+    expect(findXoxcInValues({ values: ['nothing here', 'still nothing', '{"x":1}'] })).toBeNull();
+  });
+
+  it('finds a bare token string', () => {
+    expect(findXoxcInValues({ values: ['xoxc-1234567890-abc'] })).toBe('xoxc-1234567890-abc');
+  });
+
+  it('finds a token embedded inside a larger JSON-encoded blob', () => {
+    const blob = JSON.stringify({ token: 'xoxc-1111-2222-3333-aaaaaaaaaa', other: 'noise' });
+    expect(findXoxcInValues({ values: ['unrelated', blob] })).toBe('xoxc-1111-2222-3333-aaaaaaaaaa');
+  });
+
+  it('returns the first match when multiple values contain tokens', () => {
+    expect(
+      findXoxcInValues({
+        values: ['xoxc-aaaaaaaa-1111', 'noise', 'xoxc-bbbbbbbb-2222'],
+      }),
+    ).toBe('xoxc-aaaaaaaa-1111');
+  });
+
+  it('does not match a bare `xoxc-` prefix with no payload', () => {
+    // Defensive: the pattern requires at least one alphanumeric/dash
+    // character after the prefix. Without that, a half-redacted log
+    // line wouldn't be confused for a real token.
+    expect(findXoxcInValues({ values: ['leaked: xoxc-'] })).toBeNull();
+  });
+
+  it('does not match xoxb/xoxp/xoxa (bot or user-app tokens)', () => {
+    expect(findXoxcInValues({ values: ['xoxb-1234', 'xoxp-1234', 'xoxa-1234'] })).toBeNull();
+  });
+
+  it('stops the match at characters outside the documented grammar', () => {
+    // The token grammar is alphanumerics + dashes. A space, quote, or
+    // `}` terminates the match.
+    expect(findXoxcInValues({ values: ['{"token":"xoxc-aaaa-1111"}'] })).toBe('xoxc-aaaa-1111');
+  });
+
+  it('handles unicode noise around a valid token', () => {
+    expect(findXoxcInValues({ values: ['💥 xoxc-aaaa-1111 💥'] })).toBe('xoxc-aaaa-1111');
+  });
+});
+
+describe('findXoxcInDump', () => {
+  it('walks nested objects to find a token in a leaf string', () => {
+    const dump = {
+      localConfig_v2: JSON.stringify({ teams: { T1: { token: 'xoxc-aaaa-1111-bbbb-cccc' } } }),
+      otherKey: 'noise',
+    };
+    expect(findXoxcInDump({ dump })).toBe('xoxc-aaaa-1111-bbbb-cccc');
+  });
+
+  it('walks arrays', () => {
+    const dump = ['unrelated', ['nested', 'xoxc-2222-aaaa']];
+    expect(findXoxcInDump({ dump })).toBe('xoxc-2222-aaaa');
+  });
+
+  it('returns null when no string in the structure matches', () => {
+    expect(findXoxcInDump({ dump: { a: 1, b: ['c', { d: 'noise' }] } })).toBeNull();
+  });
+
+  it('returns null for non-object scalars without a token', () => {
+    expect(findXoxcInDump({ dump: 42 })).toBeNull();
+    expect(findXoxcInDump({ dump: null })).toBeNull();
+    expect(findXoxcInDump({ dump: 'plain string' })).toBeNull();
+  });
+
+  it('matches a scalar string passed directly', () => {
+    expect(findXoxcInDump({ dump: 'xoxc-3333-dddd' })).toBe('xoxc-3333-dddd');
+  });
+});

--- a/apps/mcp-local/src/slack-extract/find-token.ts
+++ b/apps/mcp-local/src/slack-extract/find-token.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure xoxc-token extraction from a dump of Slack's browser-side
+ * localStorage. The Slack web client stores a workspace user token in
+ * `localStorage[localConfig_v2]` (and a handful of other keys
+ * depending on workspace tier). The token has the shape `xoxc-<digits>-...`.
+ *
+ * This module intentionally takes the dump as a plain string array
+ * (or a JSON object whose string values get scanned) so the actual
+ * Playwright drive-loop lives in the skill body, not in compiled code.
+ * The unit suite then locks the regex behaviour without bringing the
+ * browser into the tests.
+ */
+
+/**
+ * Anchored xoxc token shape. Matches `xoxc-` followed by ASCII
+ * alphanumerics and dashes only (the documented token grammar). The
+ * `+` ensures we never return a bare `xoxc-` prefix with no payload.
+ */
+const XOXC_TOKEN_PATTERN = /xoxc-[A-Za-z0-9-]+/;
+
+/**
+ * Find the first xoxc token in a list of localStorage values. Returns
+ * `null` when nothing matches. Whitespace inside individual values is
+ * not significant; the pattern itself is anchored on the `xoxc-` prefix
+ * and only consumes the alphanumeric run that follows.
+ */
+export function findXoxcInValues({ values }: { values: ReadonlyArray<string> }): string | null {
+  for (const value of values) {
+    const match = XOXC_TOKEN_PATTERN.exec(value);
+    if (match !== null) return match[0];
+  }
+  return null;
+}
+
+/**
+ * Walk a parsed JSON-like dump (an object, array, or scalar) and
+ * collect every string-typed leaf, then run `findXoxcInValues` over
+ * the collection. Convenience for callers that have a JSON snapshot
+ * of `localStorage` keyed by key name rather than a flat values list.
+ */
+export function findXoxcInDump({ dump }: { dump: unknown }): string | null {
+  const values: string[] = [];
+  collectStrings(dump, values);
+  return findXoxcInValues({ values });
+}
+
+function collectStrings(value: unknown, sink: string[]): void {
+  if (typeof value === 'string') {
+    sink.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, sink);
+    return;
+  }
+  if (value !== null && typeof value === 'object') {
+    for (const v of Object.values(value)) collectStrings(v, sink);
+  }
+}

--- a/apps/mcp-local/src/slack-extract/index.ts
+++ b/apps/mcp-local/src/slack-extract/index.ts
@@ -1,0 +1,2 @@
+export { findXoxcInDump, findXoxcInValues } from './find-token.ts';
+export { runSlackExtractXoxc, type SlackExtractFlags, type SlackExtractIo } from './cli-action.ts';

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
@@ -39,6 +39,7 @@ const SERVICE_BOUNDARY_DIRS: ReadonlyArray<ServiceBoundaryDir> = [
   { dir: 'apps/mcp-local/src/demo', extensions: ['.ts'] },
   { dir: 'apps/mcp-local/src/init', extensions: ['.ts'] },
   { dir: 'apps/mcp-local/src/send-image', extensions: ['.ts'] },
+  { dir: 'apps/mcp-local/src/slack-extract', extensions: ['.ts'] },
 ];
 
 const SERVICE_BOUNDARY_FILES: ReadonlyArray<string> = [


### PR DESCRIPTION
**Problem**
Every `slack-send-image` call needs the user's xoxc token, but the token cycles every 60-90 seconds on enterprise grid so a hand-pasted one is stale by next send. The flow is unusable in practice without an auto-extractor.

**Solution**
Ships a pure-TS `slopweaver slack-extract-xoxc` subcommand that consumes a Slack localStorage dump from stdin and prints the token (or an `export SLACK_XOXC=...` line). A companion `.claude/commands/slack-extract-token.md` skill drives Playwright MCP to produce the dump.

**Proof this works**
_pending live extraction run with the Playwright MCP_

**How to test**
1. `git checkout worktree/slack-extract-xoxc && pnpm install && pnpm --filter @slopweaver/mcp-local build`
2. `pnpm --filter @slopweaver/mcp-local test -- --run src/slack-extract` (20 unit tests pass)
3. `echo 'xoxc-1234-aaaa' | node apps/mcp-local/dist/cli.js slack-extract-xoxc`
4. `echo 'noise' | node apps/mcp-local/dist/cli.js slack-extract-xoxc; echo exit=$?` (should print `no xoxc token found in stdin.` to stderr and exit 1)

<details>
<summary><b>For coding agents</b>: detailed context (not in voice)</summary>

### Module layout

`apps/mcp-local/src/slack-extract/`:
- `find-token.ts` — `findXoxcInValues({ values: string[] }): string | null` and `findXoxcInDump({ dump: unknown }): string | null`. Anchored regex `xoxc-[A-Za-z0-9-]+` (requires at least one payload character after the prefix). The dump variant walks objects + arrays recursively to collect every string leaf.
- `cli-action.ts` — async stdin reader + JSON-parse-first / raw-text-fallback dispatcher. Exit 0 on found, 1 on missing token, 2 on stdin failure.
- `*.test.ts` — 20 cases total (12 find-token + 8 cli-action). Stubs stdin via injected `readStdin` so the suite doesn't rely on real stdin.

### CLI surface

`slack-extract-xoxc [--format token|export]` — reads stdin, prints token (default) or `export SLACK_XOXC=...` (with `--format export`).

### Skill flow

`.claude/commands/slack-extract-token.md`:
1. Navigate Playwright to `https://app.slack.com/client/` if no Slack tab is open.
2. `browser_evaluate` a small loop that returns localStorage as a JSON object.
3. Pipe `JSON.stringify(result)` into `slopweaver slack-extract-xoxc --format export`.
4. `eval` the line in the user's shell to set `SLACK_XOXC`. Following calls to `slack-send-image` pick it up.

### Why Playwright stays in the skill

The browser drive happens in the Claude Code session (where Playwright MCP is already available). Bundling Playwright as a runtime dep of `@slopweaver/mcp-local` would add ~100MB of native binaries to the published npm package for a feature most users won't touch. The skill/Playwright split keeps the binary lean.

### Public-repo discipline

- No cookie reads, no leveldb parsing, no Chrome profile detection. The token only flows from the user's already-logged-in browser through the skill through the extractor through stdout. Nothing persists.
- The regex is anchored — `findXoxcInValues({ values: ['leaked: xoxc-'] })` returns `null`, not `xoxc-`. Stops the function from "succeeding" on truncated log lines.
- No personal identifiers or workspace data in fixtures or tests.

### Scanner allow-list

`apps/mcp-local/src/slack-extract` added to `check-neverthrow-service-boundaries` allow-list. All exports return values or `Promise<value>`; no throws cross the boundary.
</details>