### PR TITLE
feat(voice-rule): add-voice-rule CLI + /correct skill (upstream capture)

### DIFF
--- a/.claude/commands/correct.md
+++ b/.claude/commands/correct.md
@@ -1,0 +1,86 @@
+---
+description: Capture an in-line voice correction (e.g. "don't use delve, use check") and append it as a directive to the user's voice-rules markdown via `slopweaver add-voice-rule`. The next draft will pick up the new rule.
+argument-hint: <natural-language correction>
+---
+
+This skill is the upstream capture for the existing `apply_voice_rules` MCP tool. When the user corrects me mid-chat, I should:
+
+1. Infer the directive(s) implied by the correction.
+2. Show them to the user as a JSON-style preview.
+3. After the user confirms (or immediately, if the correction was unambiguous), run `slopweaver add-voice-rule` to append them to the rules file.
+
+The rules file lives at `$SLOPWEAVER_VOICE_RULES_PATH` if set, otherwise the user supplies `--rules-file`. A common per-user choice is `.claude/personal/rules/communication-style.md` (gitignored).
+
+## Directive grammar
+
+Three directive kinds the voice-rules parser understands:
+
+- **`forbid: <token>`** — the literal token is banned. The post-processor flags it.
+- **`replace: <from> => <to>`** — `<from>` gets rewritten to `<to>`. Whitespace either side of `=>` is trimmed.
+- **`pattern: <regex>`** — anywhere the JS regex matches, flag the draft.
+
+Pick the smallest unit that captures the correction.
+
+- "Don't use delve" → `forbid: delve`
+- "Use check instead of delve" → `replace: delve => check` (covers the forbid implicitly)
+- "Stop with the negative parallelism" → `pattern: \bit's not [^,]+, it's\b` (a pattern that catches the trope)
+- "No exclamation marks" → `replace: ! => .` (or `forbid: !` if any context counts)
+
+## Steps
+
+### 1. Parse the correction into directive(s)
+
+Read `$ARGUMENTS` (the natural-language correction the user wrote). Decide one or more directive kinds. If there's any ambiguity, ask the user before running the binary.
+
+### 2. Show the user a preview
+
+Print the inferred directives in a single block:
+
+```
+proposed:
+  - forbid: delve
+  - replace: utilize => use
+```
+
+If the user pushes back, refine. If the correction was a clear lift-and-shift ("just add forbid: X"), skip the preview and go straight to step 3.
+
+### 3. Apply
+
+Run:
+
+```bash
+slopweaver add-voice-rule \
+  [--rules-file "<path>"] \
+  [--forbid "<token>" ...] \
+  [--replace "<from> => <to>" ...] \
+  [--pattern "<regex>" ...]
+```
+
+Repeatable flags allow several directives per call. The binary:
+
+- Creates the file if missing.
+- Appends inside an existing `## Hard rules` section, or creates one.
+- Skips any directive that's already present byte-for-byte (idempotent).
+- Reports `added=N skipped=M` so the model can confirm what landed.
+
+### 4. Report
+
+After the binary returns 0, surface a one-liner:
+
+```
+✓ added 2 voice rules (1 skipped as duplicate). next draft uses them.
+```
+
+If the binary returns 2, the corrective directives were malformed. Show the stderr line, ask the user to clarify.
+
+## Why this is the upstream capture half
+
+`apply_voice_rules` (the existing MCP tool) is the downstream lint. The user runs it on a draft before sending. But the rules file has to be populated somehow. This skill is the populate side: every time the user corrects me, the correction lands as a permanent directive.
+
+Over time, the voice rules accumulate. The next draft starts cleaner. The pair is the actual feedback loop.
+
+## Notes
+
+- Don't edit `rules/communication-style.md` directly via the `Edit` tool when this skill is what the user wants. The skill is the audit trail; direct edits make duplicate detection drift.
+- A directive that's structurally valid but semantically wrong (e.g. forbid: a common preposition the user didn't mean to ban) will block legitimate drafts until removed. Bias toward `replace` over `forbid`.
+- Pattern regexes are JS-flavored. Escape backslashes when passing through the shell: `'pattern: \bnotably\b'` becomes `--pattern "\\bnotably\\b"` on the command line.

--- a/apps/mcp-local/src/cli.ts
+++ b/apps/mcp-local/src/cli.ts
@@ -484,6 +484,57 @@ cli
 
 cli
   .command(
+    'add-voice-rule',
+    'Append a voice-rule directive (forbid/replace/pattern) to a markdown rules file. Powers the /correct skill.',
+  )
+  .option(
+    '--rules-file <path>',
+    'Path to the voice-rules markdown file. Created if missing. Falls back to $SLOPWEAVER_VOICE_RULES_PATH.',
+  )
+  .option('--forbid <token>', 'Add a `- forbid: <token>` directive. Repeatable.', { type: [] })
+  .option('--replace <from=>to>', 'Add a `- replace: <from> => <to>` directive. Repeatable.', { type: [] })
+  .option('--pattern <regex>', 'Add a `- pattern: <regex>` directive. Repeatable.', { type: [] })
+  .example('  slopweaver add-voice-rule --rules-file ./rules/communication-style.md --forbid delve')
+  .example('  slopweaver add-voice-rule --forbid notably --replace "utilize => use"')
+  .action(
+    async (opts: {
+      rulesFile?: string;
+      forbid?: string | ReadonlyArray<string>;
+      replace?: string | ReadonlyArray<string>;
+      pattern?: string | ReadonlyArray<string>;
+    }) => {
+      try {
+        const rulesFile = opts.rulesFile ?? env['SLOPWEAVER_VOICE_RULES_PATH'];
+        if (rulesFile === undefined || rulesFile.length === 0) {
+          stderr.write(
+            'add-voice-rule: pass --rules-file or set SLOPWEAVER_VOICE_RULES_PATH so the directive has somewhere to land.\n',
+          );
+          exit(2);
+        }
+        const toArray = (v: string | ReadonlyArray<string> | undefined): ReadonlyArray<string> => {
+          if (v === undefined) return [];
+          return Array.isArray(v) ? v : [v as string];
+        };
+        const { runAddVoiceRule } = await import('./voice-rule/cli-action.ts');
+        const code = await runAddVoiceRule({
+          flags: {
+            rulesFile,
+            forbid: toArray(opts.forbid),
+            replace: toArray(opts.replace),
+            pattern: toArray(opts.pattern),
+          },
+          io: { stdout, stderr },
+        });
+        exit(code);
+      } catch (error: unknown) {
+        stderr.write(`slopweaver: ${asMessage({ error })}\n`);
+        exit(1);
+      }
+    },
+  );
+
+cli
+  .command(
     'slack-extract-xoxc',
     'Find the user xoxc token in a Slack localStorage dump read from stdin. Pairs with the slack-extract-token skill.',
   )

--- a/apps/mcp-local/src/voice-rule/append.test.ts
+++ b/apps/mcp-local/src/voice-rule/append.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { appendDirectives } from './append.ts';
+
+describe('appendDirectives', () => {
+  it('seeds a Hard rules section in an empty file', () => {
+    const r = appendDirectives({ body: '', directives: [{ type: 'forbid', token: 'delve' }] });
+    expect(r.updated).toBe('## Hard rules\n\n- forbid: delve\n');
+    expect(r.added).toHaveLength(1);
+    expect(r.skipped).toHaveLength(0);
+  });
+
+  it('appends to an existing Hard rules section, before the next heading', () => {
+    const body = [
+      '# Voice rules',
+      '',
+      '## Hard rules',
+      '',
+      '- forbid: leverage',
+      '',
+      '## Defaults',
+      '',
+      '- forbid: utilize',
+      '',
+    ].join('\n');
+    const r = appendDirectives({
+      body,
+      directives: [{ type: 'forbid', token: 'delve' }],
+    });
+    expect(r.updated).toContain('- forbid: leverage\n- forbid: delve\n\n## Defaults');
+    expect(r.updated).toContain('- forbid: utilize');
+    expect(r.added).toHaveLength(1);
+  });
+
+  it('appends to a Hard rules section that runs to EOF', () => {
+    const body = ['## Hard rules', '', '- forbid: leverage', ''].join('\n');
+    const r = appendDirectives({
+      body,
+      directives: [{ type: 'replace', from: 'utilize', to: 'use' }],
+    });
+    expect(r.updated.endsWith('- forbid: leverage\n- replace: utilize => use\n')).toBe(true);
+  });
+
+  it('creates a Hard rules section when only other headings exist', () => {
+    const body = '## Defaults\n\n- forbid: leverage\n';
+    const r = appendDirectives({
+      body,
+      directives: [{ type: 'pattern', regex: '\\bnotably\\b' }],
+    });
+    expect(r.updated).toContain('## Defaults');
+    expect(r.updated).toContain('## Hard rules');
+    expect(r.updated).toContain('- pattern: \\bnotably\\b');
+  });
+
+  it('is idempotent when the directive already exists verbatim', () => {
+    const body = '## Hard rules\n\n- forbid: delve\n';
+    const r = appendDirectives({ body, directives: [{ type: 'forbid', token: 'delve' }] });
+    expect(r.updated).toBe(body);
+    expect(r.added).toHaveLength(0);
+    expect(r.skipped).toHaveLength(1);
+  });
+
+  it('skips duplicates but still adds new directives from the same call', () => {
+    const body = '## Hard rules\n\n- forbid: delve\n';
+    const r = appendDirectives({
+      body,
+      directives: [
+        { type: 'forbid', token: 'delve' },
+        { type: 'forbid', token: 'notably' },
+      ],
+    });
+    expect(r.added.map((d) => (d.type === 'forbid' ? d.token : ''))).toEqual(['notably']);
+    expect(r.skipped).toHaveLength(1);
+    expect(r.updated).toContain('- forbid: delve');
+    expect(r.updated).toContain('- forbid: notably');
+  });
+
+  it('appends multiple new directives in one call, preserving order', () => {
+    const r = appendDirectives({
+      body: '',
+      directives: [
+        { type: 'forbid', token: 'leverage' },
+        { type: 'replace', from: '!', to: '.' },
+        { type: 'pattern', regex: '\\bit.s not X, it.s Y\\b' },
+      ],
+    });
+    const lines = r.updated.trim().split('\n');
+    expect(lines).toContain('- forbid: leverage');
+    expect(lines).toContain('- replace: ! => .');
+    expect(lines).toContain('- pattern: \\bit.s not X, it.s Y\\b');
+    const idxF = lines.indexOf('- forbid: leverage');
+    const idxR = lines.indexOf('- replace: ! => .');
+    const idxP = lines.indexOf('- pattern: \\bit.s not X, it.s Y\\b');
+    expect(idxF).toBeLessThan(idxR);
+    expect(idxR).toBeLessThan(idxP);
+  });
+
+  it('preserves trailing newline conventions', () => {
+    const body = '## Hard rules\n\n- forbid: leverage';
+    const r = appendDirectives({ body, directives: [{ type: 'forbid', token: 'delve' }] });
+    expect(r.updated.endsWith('\n')).toBe(true);
+  });
+});

--- a/apps/mcp-local/src/voice-rule/append.ts
+++ b/apps/mcp-local/src/voice-rule/append.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure append of voice-rule directives to a markdown rules body.
+ *
+ * Strategy:
+ * - If the body already contains a `## Hard rules` section, append the
+ *   new directives at the end of that section (just before the next
+ *   `## ` heading, or EOF).
+ * - If the body does not contain `## Hard rules`, append a fresh
+ *   `## Hard rules` section at the end of the body.
+ * - If a given directive's formatted form is already present in the
+ *   body, skip it (idempotent for duplicate corrections).
+ *
+ * Returns the updated body plus the set of directives that were
+ * actually applied (so callers can report "0 added" when everything
+ * was a duplicate).
+ */
+
+import { formatDirective } from './format.ts';
+import type { VoiceDirective } from './types.ts';
+
+const HARD_RULES_HEADING = '## Hard rules';
+
+export type AppendResult = {
+  readonly updated: string;
+  readonly added: ReadonlyArray<VoiceDirective>;
+  readonly skipped: ReadonlyArray<VoiceDirective>;
+};
+
+export function appendDirectives({
+  body,
+  directives,
+}: {
+  body: string;
+  directives: ReadonlyArray<VoiceDirective>;
+}): AppendResult {
+  const existingLines = new Set(body.split(/\r?\n/));
+  const added: VoiceDirective[] = [];
+  const skipped: VoiceDirective[] = [];
+  const toAdd: string[] = [];
+  for (const directive of directives) {
+    const line = formatDirective({ directive });
+    if (existingLines.has(line)) {
+      skipped.push(directive);
+      continue;
+    }
+    existingLines.add(line);
+    added.push(directive);
+    toAdd.push(line);
+  }
+  if (toAdd.length === 0) {
+    return { updated: body, added, skipped };
+  }
+
+  const headingIndex = body.indexOf(HARD_RULES_HEADING);
+  if (headingIndex === -1) {
+    const trimmed = body.replace(/\s+$/, '');
+    const sep = trimmed.length === 0 ? '' : '\n\n';
+    const updated = `${trimmed}${sep}${HARD_RULES_HEADING}\n\n${toAdd.join('\n')}\n`;
+    return { updated, added, skipped };
+  }
+
+  return { updated: insertAfterHardRulesSection({ body, headingIndex, toAdd }), added, skipped };
+}
+
+function insertAfterHardRulesSection({
+  body,
+  headingIndex,
+  toAdd,
+}: {
+  body: string;
+  headingIndex: number;
+  toAdd: ReadonlyArray<string>;
+}): string {
+  // Find the next top-level (`## `) heading after the Hard rules
+  // section. Insertion goes immediately before it, separated by a
+  // single blank line. If no later heading exists, append before EOF.
+  const sectionStart = headingIndex + HARD_RULES_HEADING.length;
+  const nextHeadingMatch = /\n## /.exec(body.slice(sectionStart));
+  const sectionEnd = nextHeadingMatch === null ? body.length : sectionStart + nextHeadingMatch.index;
+  const head = body.slice(0, sectionEnd).replace(/\s+$/, '');
+  const tail = body.slice(sectionEnd);
+  const joined = toAdd.join('\n');
+  if (tail.length === 0) {
+    return `${head}\n${joined}\n`;
+  }
+  return `${head}\n${joined}\n\n${tail.replace(/^\n+/, '')}`;
+}

--- a/apps/mcp-local/src/voice-rule/cli-action.test.ts
+++ b/apps/mcp-local/src/voice-rule/cli-action.test.ts
@@ -1,0 +1,131 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parseFlagsToDirectives, runAddVoiceRule } from './cli-action.ts';
+
+function makeIo() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    io: {
+      stdout: { write: (s: string) => stdout.push(s) },
+      stderr: { write: (s: string) => stderr.push(s) },
+    },
+    readStdout: () => stdout.join(''),
+    readStderr: () => stderr.join(''),
+  };
+}
+
+describe('parseFlagsToDirectives', () => {
+  it('rejects an empty forbid value', () => {
+    const r = parseFlagsToDirectives({ flags: { rulesFile: 'x', forbid: [''], replace: [], pattern: [] } });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('forbid');
+  });
+
+  it('rejects a replace without =>', () => {
+    const r = parseFlagsToDirectives({ flags: { rulesFile: 'x', forbid: [], replace: ['foo bar'], pattern: [] } });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('=>');
+  });
+
+  it('rejects a replace with empty left side', () => {
+    const r = parseFlagsToDirectives({
+      flags: { rulesFile: 'x', forbid: [], replace: [' => something'], pattern: [] },
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('parses one of each kind in stable order', () => {
+    const r = parseFlagsToDirectives({
+      flags: { rulesFile: 'x', forbid: ['delve'], replace: ['utilize => use'], pattern: ['\\bnotably\\b'] },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.directives.map((d) => d.type)).toEqual(['forbid', 'replace', 'pattern']);
+      const replace = r.directives[1];
+      if (replace?.type === 'replace') {
+        expect(replace.from).toBe('utilize');
+        expect(replace.to).toBe('use');
+      }
+    }
+  });
+
+  it('trims whitespace around the => separator', () => {
+    const r = parseFlagsToDirectives({
+      flags: { rulesFile: 'x', forbid: [], replace: ['  utilize   =>   use  '], pattern: [] },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const replace = r.directives[0];
+      if (replace?.type === 'replace') {
+        expect(replace.from).toBe('utilize');
+        expect(replace.to).toBe('use');
+      }
+    }
+  });
+});
+
+describe('runAddVoiceRule', () => {
+  let tempDir: string;
+  let rulesFile: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'slopweaver-voice-rule-'));
+    rulesFile = join(tempDir, 'communication-style.md');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('exits 2 when no directive flags are given', async () => {
+    const { io, readStderr } = makeIo();
+    const code = await runAddVoiceRule({
+      flags: { rulesFile, forbid: [], replace: [], pattern: [] },
+      io,
+    });
+    expect(code).toBe(2);
+    expect(readStderr()).toContain('at least one');
+  });
+
+  it('creates the file when missing and writes the first directive', async () => {
+    const { io, readStdout } = makeIo();
+    const code = await runAddVoiceRule({
+      flags: { rulesFile, forbid: ['delve'], replace: [], pattern: [] },
+      io,
+    });
+    expect(code).toBe(0);
+    const written = readFileSync(rulesFile, 'utf-8');
+    expect(written).toContain('## Hard rules');
+    expect(written).toContain('- forbid: delve');
+    expect(readStdout()).toContain('ok');
+    expect(readStdout()).toContain('added=1');
+  });
+
+  it('appends to an existing rules file and reports added/skipped counts', async () => {
+    writeFileSync(rulesFile, '## Hard rules\n\n- forbid: delve\n', 'utf-8');
+    const { io, readStdout } = makeIo();
+    const code = await runAddVoiceRule({
+      flags: { rulesFile, forbid: ['delve', 'notably'], replace: [], pattern: [] },
+      io,
+    });
+    expect(code).toBe(0);
+    expect(readStdout()).toContain('added=1');
+    expect(readStdout()).toContain('skipped=1');
+    expect(readFileSync(rulesFile, 'utf-8')).toContain('- forbid: notably');
+  });
+
+  it('returns 0 with stderr note when every directive is a duplicate', async () => {
+    writeFileSync(rulesFile, '## Hard rules\n\n- forbid: delve\n', 'utf-8');
+    const { io, readStderr, readStdout } = makeIo();
+    const code = await runAddVoiceRule({
+      flags: { rulesFile, forbid: ['delve'], replace: [], pattern: [] },
+      io,
+    });
+    expect(code).toBe(0);
+    expect(readStderr()).toContain('already present');
+    expect(readStdout()).toBe('');
+  });
+});

--- a/apps/mcp-local/src/voice-rule/cli-action.ts
+++ b/apps/mcp-local/src/voice-rule/cli-action.ts
@@ -1,0 +1,113 @@
+/**
+ * CLI adapter for `slopweaver add-voice-rule`. Reads the existing
+ * rules file (creating an empty one if missing), runs the pure
+ * `appendDirectives` helper, and writes the updated body back.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { appendDirectives } from './append.ts';
+import { formatDirective } from './format.ts';
+import type { VoiceDirective } from './types.ts';
+
+export type AddVoiceRuleFlags = {
+  readonly rulesFile: string;
+  readonly forbid: ReadonlyArray<string>;
+  readonly replace: ReadonlyArray<string>;
+  readonly pattern: ReadonlyArray<string>;
+};
+
+export type AddVoiceRuleIo = {
+  readonly stdout: { write: (s: string) => void };
+  readonly stderr: { write: (s: string) => void };
+};
+
+export function parseFlagsToDirectives({
+  flags,
+}: {
+  flags: AddVoiceRuleFlags;
+}): { ok: true; directives: ReadonlyArray<VoiceDirective> } | { ok: false; error: string } {
+  const directives: VoiceDirective[] = [];
+  for (const token of flags.forbid) {
+    if (token.length === 0) return { ok: false, error: '--forbid value must not be empty' };
+    directives.push({ type: 'forbid', token });
+  }
+  for (const raw of flags.replace) {
+    const idx = raw.indexOf('=>');
+    if (idx === -1) {
+      return { ok: false, error: `--replace value must be "<from> => <to>"; got "${raw}"` };
+    }
+    const from = raw.slice(0, idx).trim();
+    const to = raw.slice(idx + 2).trim();
+    if (from.length === 0) {
+      return { ok: false, error: `--replace value must have a non-empty left side; got "${raw}"` };
+    }
+    directives.push({ type: 'replace', from, to });
+  }
+  for (const regex of flags.pattern) {
+    if (regex.length === 0) return { ok: false, error: '--pattern value must not be empty' };
+    directives.push({ type: 'pattern', regex });
+  }
+  return { ok: true, directives };
+}
+
+type ReadRulesResult = { kind: 'ok'; body: string } | { kind: 'error'; message: string };
+
+async function readRulesFile({ path }: { path: string }): Promise<ReadRulesResult> {
+  try {
+    const body = await readFile(path, 'utf-8');
+    return { kind: 'ok', body };
+  } catch (e) {
+    if (typeof e === 'object' && e !== null && 'code' in e && e.code === 'ENOENT') {
+      return { kind: 'ok', body: '' };
+    }
+    return { kind: 'error', message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+export async function runAddVoiceRule({
+  flags,
+  io,
+}: {
+  flags: AddVoiceRuleFlags;
+  io: AddVoiceRuleIo;
+}): Promise<number> {
+  const parsed = parseFlagsToDirectives({ flags });
+  if (!parsed.ok) {
+    io.stderr.write(`add-voice-rule: ${parsed.error}\n`);
+    return 2;
+  }
+  if (parsed.directives.length === 0) {
+    io.stderr.write('add-voice-rule: at least one --forbid, --replace, or --pattern is required.\n');
+    return 2;
+  }
+
+  const readResult = await readRulesFile({ path: flags.rulesFile });
+  if (readResult.kind === 'error') {
+    io.stderr.write(`add-voice-rule: failed to read ${flags.rulesFile}: ${readResult.message}\n`);
+    return 1;
+  }
+
+  const result = appendDirectives({ body: readResult.body, directives: parsed.directives });
+
+  if (result.added.length === 0) {
+    io.stderr.write(
+      `add-voice-rule: all ${result.skipped.length} directive(s) already present in ${flags.rulesFile}; nothing to do.\n`,
+    );
+    return 0;
+  }
+
+  try {
+    await writeFile(flags.rulesFile, result.updated, 'utf-8');
+  } catch (e) {
+    io.stderr.write(
+      `add-voice-rule: failed to write ${flags.rulesFile}: ${e instanceof Error ? e.message : String(e)}\n`,
+    );
+    return 1;
+  }
+
+  const summary = result.added.map((d) => formatDirective({ directive: d })).join(', ');
+  io.stdout.write(
+    `add-voice-rule: ok added=${result.added.length} skipped=${result.skipped.length} path=${flags.rulesFile} new=${JSON.stringify(summary)}\n`,
+  );
+  return 0;
+}

--- a/apps/mcp-local/src/voice-rule/format.ts
+++ b/apps/mcp-local/src/voice-rule/format.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure formatter for voice-rule directives. Always emits exactly the
+ * shape `@slopweaver/voice-rules` parses: a single bullet per line,
+ * the directive keyword + colon, then the body.
+ */
+
+import type { VoiceDirective } from './types.ts';
+
+export function formatDirective({ directive }: { directive: VoiceDirective }): string {
+  switch (directive.type) {
+    case 'forbid':
+      return `- forbid: ${directive.token}`;
+    case 'replace':
+      return `- replace: ${directive.from} => ${directive.to}`;
+    case 'pattern':
+      return `- pattern: ${directive.regex}`;
+  }
+}

--- a/apps/mcp-local/src/voice-rule/index.ts
+++ b/apps/mcp-local/src/voice-rule/index.ts
@@ -1,0 +1,9 @@
+export { appendDirectives, type AppendResult } from './append.ts';
+export { formatDirective } from './format.ts';
+export {
+  parseFlagsToDirectives,
+  runAddVoiceRule,
+  type AddVoiceRuleFlags,
+  type AddVoiceRuleIo,
+} from './cli-action.ts';
+export type { ForbidDirective, PatternDirective, ReplaceDirective, VoiceDirective } from './types.ts';

--- a/apps/mcp-local/src/voice-rule/types.ts
+++ b/apps/mcp-local/src/voice-rule/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Voice-rule directive shapes. Mirror the grammar parsed by the
+ * `@slopweaver/voice-rules` package; this CLI is the upstream capture
+ * surface that appends new directives to a markdown rules file.
+ */
+
+export type ForbidDirective = {
+  readonly type: 'forbid';
+  /** Bare token (e.g. `delve`). Stored verbatim. */
+  readonly token: string;
+};
+
+export type ReplaceDirective = {
+  readonly type: 'replace';
+  readonly from: string;
+  readonly to: string;
+};
+
+export type PatternDirective = {
+  readonly type: 'pattern';
+  /** Regex source (without surrounding slashes). */
+  readonly regex: string;
+};
+
+export type VoiceDirective = ForbidDirective | ReplaceDirective | PatternDirective;

--- a/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
+++ b/packages/cli-tools/src/check-neverthrow-service-boundaries/core.ts
@@ -40,6 +40,7 @@ const SERVICE_BOUNDARY_DIRS: ReadonlyArray<ServiceBoundaryDir> = [
   { dir: 'apps/mcp-local/src/init', extensions: ['.ts'] },
   { dir: 'apps/mcp-local/src/send-image', extensions: ['.ts'] },
   { dir: 'apps/mcp-local/src/slack-extract', extensions: ['.ts'] },
+  { dir: 'apps/mcp-local/src/voice-rule', extensions: ['.ts'] },
 ];
 
 const SERVICE_BOUNDARY_FILES: ReadonlyArray<string> = [


### PR DESCRIPTION
**Problem**
`apply_voice_rules` (PR #68) lints drafts against a rules file, but the rules file has to be populated by hand. There's no way to capture an inline correction ("don't use delve, use check") and turn it into a permanent directive.

**Solution**
Adds `slopweaver add-voice-rule` (a TS subcommand that appends typed directives to a markdown rules file with duplicate detection) and a `.claude/commands/correct.md` skill that captures the correction, infers the directive(s), and drives the binary.

**Proof this works**
_pending live capture run_

**How to test**
1. `git checkout worktree/add-voice-rule && pnpm install && pnpm --filter @slopweaver/mcp-local build`
2. `pnpm --filter @slopweaver/mcp-local test -- --run src/voice-rule` (17 unit tests pass)
3. `node apps/mcp-local/dist/cli.js add-voice-rule --rules-file /tmp/rules.md --forbid delve --replace "utilize => use"`
4. `cat /tmp/rules.md` — should show a `## Hard rules` section with both bullets
5. Re-run the same command — should print `already present; nothing to do.` and leave the file untouched

<details>
<summary><b>For coding agents</b>: detailed context (not in voice)</summary>

### Module layout

`apps/mcp-local/src/voice-rule/`:
- `types.ts` — `VoiceDirective` discriminated union: `{ type: 'forbid', token }`, `{ type: 'replace', from, to }`, `{ type: 'pattern', regex }`. Matches the grammar that `@slopweaver/voice-rules` parses (PR #68).
- `format.ts` — pure directive-to-bullet formatter. Single switch; emits exactly `- forbid: X` / `- replace: X => Y` / `- pattern: X`.
- `append.ts` — pure markdown manipulator. Locates `## Hard rules`, inserts new directives before the next heading or EOF, skips byte-identical duplicates. Returns `{ updated, added, skipped }` so the caller can report counts.
- `cli-action.ts` — flag parser + filesystem I/O. Handles `=>` parsing in `--replace` values with whitespace trimming. ENOENT treated as empty body (file gets created). No throws cross the service boundary.
- `*.test.ts` — 17 unit cases (8 append-helper, 9 cli-action). Real tmpdir fixtures for the I/O paths.

### CLI surface

`add-voice-rule --rules-file <path> [--forbid X]... [--replace "X => Y"]... [--pattern X]...`

Repeatable flags. Falls back to `$SLOPWEAVER_VOICE_RULES_PATH` when `--rules-file` is omitted. Exit codes: 0 on success (file written or all duplicates), 1 on filesystem failure, 2 on missing rules path or malformed flags.

### Service boundary

`apps/mcp-local/src/voice-rule` added to `check-neverthrow-service-boundaries`. The internal `readRulesFile` originally rethrew on non-ENOENT errors; the scanner caught it, refactored to return `{ kind: 'ok' | 'error' }` instead.

### Skill flow

`.claude/commands/correct.md`:
1. Read `$ARGUMENTS` (the user's correction).
2. Infer one or more directives. Bias toward `replace` over `forbid` when the user names a substitution.
3. Show the model's inference as a preview if ambiguous.
4. Run `slopweaver add-voice-rule` with the corresponding flags.
5. Report `added=N skipped=M`.

### Idempotency

Duplicate detection is byte-exact match on the formatted bullet line. `- forbid: delve` and `- forbid:  delve` (extra space) would both register, which is a minor wart; if it matters later we can normalise on read.
</details>